### PR TITLE
Clean up dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,8 +9,7 @@ Build-Depends: debhelper (>= 9),
                freeglut3-dev,
                libxi-dev,
                libxmu-dev,
-               liblapack-dev,
-               libblas-dev
+               liblapack-dev
 Vcs-Browser: https://github.com/simbody/simbody
 Vcs-Git: git://github.com/simbody/simbody.git
 Homepage: https://simtk.org/home/simbody
@@ -36,7 +35,6 @@ Depends: freeglut3-dev,
          libxi-dev,
          libxmu-dev,
          liblapack-dev,
-         libblas-dev,
 	 libsimbody3.3 (= ${binary:Version}),
 	 ${misc:Depends}
 Multi-Arch: same


### PR DESCRIPTION
Some of them were plain wrong, and some others are not needed (indirect dependencies).

We should propagate these changes to master branch.
