### PR TITLE
prevent NaN generation when gravity is (0, 0, 0) and we switch from body...

### DIFF
--- a/Simbody/src/Force_Gravity.cpp
+++ b/Simbody/src/Force_Gravity.cpp
@@ -330,7 +330,10 @@ setBodyIsExcluded(State& state, MobilizedBodyIndex mobod,
         impl.setMobodIsImmune(state, mobod, isExcluded);
         // The zero must be precalculated if the body is immune to gravity.
         SpatialVec& F = impl.updForceCache(state).F_GB[mobod];
-        if (isExcluded) F.setToZero(); else F.setToNaN();
+        if (isExcluded || getMagnitude(state) == 0)
+          F.setToZero();
+        else
+          F.setToNaN();
     }
     return *this;
 }


### PR DESCRIPTION
... is excluded to body is not excluded in gravity force appliction.  This is necessary as the rest of the code skips updates when gravity is special cased to zero.
