### PR TITLE
Add ability to maintain back reference to user object in DecorativeGeometry

### DIFF
--- a/SimTKcommon/Geometry/src/DecorativeGeometry.cpp
+++ b/SimTKcommon/Geometry/src/DecorativeGeometry.cpp
@@ -84,6 +84,10 @@ DecorativeGeometry& DecorativeGeometry::operator=(const DecorativeGeometry& src)
 
 DecorativeGeometry& DecorativeGeometry::setBodyId(int b) {updRep().setBodyId(b);return *this;}
 int DecorativeGeometry::getBodyId() const {return getRep().getBodyId();}
+DecorativeGeometry& DecorativeGeometry::setIndexOnBody(int x) {updRep().setIndexOnBody(x);return *this;}
+int DecorativeGeometry::getIndexOnBody() const {return getRep().getIndexOnBody();}
+DecorativeGeometry& DecorativeGeometry::setUserRef(void* p) {updRep().setUserRef(p);return *this;}
+void* DecorativeGeometry::getUserRef() const {return getRep().getUserRef();}
 
 DecorativeGeometry& DecorativeGeometry::setTransform(const Transform& X_BD) {updRep().setTransform(X_BD);return *this;}
 const Transform& DecorativeGeometry::getTransform() const    {return getRep().getTransform();}

--- a/SimTKcommon/Geometry/src/DecorativeGeometryRep.h
+++ b/SimTKcommon/Geometry/src/DecorativeGeometryRep.h
@@ -9,9 +9,9 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-13 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
- * Contributors: Jack Middleton, Peter Eastman                                *
+ * Contributors: Jack Middleton, Peter Eastman, Ayman Habib                   *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -34,7 +34,8 @@ namespace SimTK {
 class DecorativeGeometryRep {
 public:
     DecorativeGeometryRep() 
-    :   myHandle(0), body(0), placement(), resolution(-1), 
+    :   myHandle(0), body(0), indexOnBody(-1), userRef(0), 
+        placement(), resolution(-1), 
         scaleFactors(-1,-1,-1), colorRGB(-1,-1,-1), opacity(-1), 
         lineThickness(-1), faceCamera(-1), 
         representation(DecorativeGeometry::DrawDefault)
@@ -47,12 +48,12 @@ public:
     virtual DecorativeGeometryRep* cloneDecorativeGeometryRep() const = 0;
     virtual void implementGeometry(DecorativeGeometryImplementation&) const = 0;
 
-
-
-    void setBodyId(int b) {
-        body = b;
-    }
+    void setBodyId(int b) {body = b;}
     int getBodyId() const {return body;}
+    void setIndexOnBody(int x) {indexOnBody = x;}
+    int getIndexOnBody() const {return indexOnBody;}
+    void setUserRef(void* p) {userRef = p;}
+    void* getUserRef() const {return userRef;}
 
     void setTransform(const Transform& X_BD) {placement = X_BD;}
     const Transform& getTransform() const    {return placement;}
@@ -113,20 +114,20 @@ public:
         return dup;
     }
 
-    void setMyHandle(DecorativeGeometry& h) {
-        myHandle = &h;
-    }
-    void clearMyHandle() {
-        myHandle=0;
-    }
+    void setMyHandle(DecorativeGeometry& h) {myHandle = &h;}
+    void clearMyHandle() {myHandle=0;}
 
+    // Used by the composite Decorations object:
     // Set any properties that still have their default values to the ones
-    // from src. Source body is transferred unconditionally; source
-    // placement is composed with this one unconditionally. Scale factors,
-    // resolution, opacity, and line thickness are composed, with a default
-    // (-1) value treated as 1.
+    // from src. Source body, index, and userRef are transferred 
+    // unconditionally; source placement is composed with this one 
+    // unconditionally. Scale factors, resolution, opacity, and line thickness 
+    // are composed, with a default (-1) value treated as 1.
     void inheritPropertiesFrom(const DecorativeGeometryRep& srep) {
-        body = srep.body;
+        body        = srep.body;
+        indexOnBody = srep.indexOnBody;
+        userRef     = srep.userRef;
+
         placement = srep.placement * placement;
 
         // These are multiplied together if both are valid, otherwise we
@@ -159,6 +160,9 @@ protected:
     friend class DecorativeGeometry;
 
     int         body;
+    int         indexOnBody;
+    void*       userRef;
+
     Transform   placement;          // default is identity
     Vec3        scaleFactors;       // -1 means use default in that direction
 

--- a/Simbody/tests/adhoc/GeometryPlayground.cpp
+++ b/Simbody/tests/adhoc/GeometryPlayground.cpp
@@ -324,11 +324,24 @@ int main() {
         Rotation(BodyRotationSequence, Pi/4, XAxis, Pi/8, YAxis, -Pi/4, ZAxis),
         Vec3(1.5, -5, 5.25)));
     matter.Ground().addBodyDecoration(Vec3(0),
-        DecorativeBrick(box.getHalfLengths()).setOpacity(.1).setColor(Blue));
+        DecorativeBrick(box.getHalfLengths()).setOpacity(.1).setColor(Blue)
+        .setIndexOnBody(14).setUserRef(&matter.Ground()));
     matter.Ground().addBodyDecoration(obox.getTransform(),
-        DecorativeBrick(obox.getHalfLengths()).setOpacity(.1).setColor(Green));
+        DecorativeBrick(obox.getHalfLengths()).setOpacity(.1).setColor(Green)
+                .setIndexOnBody(22).setUserRef(&matter.Ground()));
     cout << "May intersect=" << box.mayIntersectOrientedBox(obox) << "\n";
     cout << "Intersects=" << box.intersectsOrientedBox(obox) << "\n";
+    
+    const Body& groundBody = matter.Ground().getBody();
+    const int nDecGeoms = groundBody.getNumDecorations();
+    printf("%d Ground body decorations (&Ground=0x%x). Last two:\n", nDecGeoms,
+        &matter.Ground());
+    for (int i=nDecGeoms-2; i < nDecGeoms; ++i) {
+        printf("%d: bodyId=%d, index=%d, userRef=0x%x\n", i,
+            groundBody.getDecoration(i).getBodyId(),
+            groundBody.getDecoration(i).getIndexOnBody(),
+            groundBody.getDecoration(i).getUserRef());
+    }
 
     Geo::Sphere curveSphere = curve.calcBoundingSphere();
     Geo::AlignedBox curveAABB = curve.calcAxisAlignedBoundingBox();


### PR DESCRIPTION
Fixes issue #34.
- After discussion with @aymanhab, added to `DecorativeGeometry` the ability to store and recall a user pointer for use in selection operations for mapping the selected piece of geometry back to the object to which it refers.
- There was already a body id stored with `DecorativeGeometry`; I added an arbitrary index also that would allow differentiation of several pieces of geometry that might refer to the same object.
- Added missing concrete class overrides for the generic `set()` methods that return concrete type references for easier chaining.
- Added some missing doxygen.
- Lightly tested.
