### PR TITLE
Create .gitignore, and ignore debian output.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,9 @@ debian/libsimbody-doc
 debian/libsimbody3.3
 debian/libsimbody3.3-dbg
 debian/tmp
-files
+debian/files
 debian/*log
 debian/*debhelper
 debian/*substvars
+# The build for debian ends up in a directory like obj-x86_64-linux-gnu.
 obj-*


### PR DESCRIPTION
Ideally, I think the debian output would not be built in the source tree. But since it IS built in the source tree, it would be nice if it didn't clutter the output of `git status`, or present the risk of accidentally getting tracked.
