### PR TITLE
Correct typos in IpOpt header guards.

### DIFF
--- a/SimTKmath/Optimizers/src/IpOpt/IpGradientScaling.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpGradientScaling.hpp
@@ -6,7 +6,7 @@
 //
 // Authors:  Carl Laird, Andreas Waechter     IBM    2005-07-13
 
-#ifndef __IPGRADIENTCALING_HPP__
+#ifndef __IPGRADIENTSCALING_HPP__
 #define __IPGRADIENTSCALING_HPP__
 
 #include "IpNLPScaling.hpp"

--- a/SimTKmath/Optimizers/src/IpOpt/IpLapackSolverInterface.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLapackSolverInterface.hpp
@@ -1,7 +1,6 @@
 
 #ifndef __IPLAPACKSOLVERINTERFACE_HPP__
-
-#define __IPLAPACKSSOLVERINTERFACE_HPP__
+#define __IPLAPACKSOLVERINTERFACE_HPP__
 
 #include "IpSparseSymLinearSolverInterface.hpp"
 

--- a/SimTKmath/Optimizers/src/IpOpt/IpTSymLinearSolver.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTSymLinearSolver.hpp
@@ -7,7 +7,7 @@
 // Authors:  Carl Laird, Andreas Waechter     IBM    2004-03-17
 
 #ifndef __IPTSYMLINEARSOLVER_HPP__
-#define __IPTSYMLINEATSOLVER_HPP__
+#define __IPTSYMLINEARSOLVER_HPP__
 
 #include "IpSymLinearSolver.hpp"
 #include "IpSparseSymLinearSolverInterface.hpp"


### PR DESCRIPTION
Clang picked up these 3 things and gave me warnings.
