### PR TITLE
Fix #66: add += operator to VectorIterator class

### DIFF
--- a/SimTKcommon/BigMatrix/include/SimTKcommon/internal/BigMatrix.h
+++ b/SimTKcommon/BigMatrix/include/SimTKcommon/internal/BigMatrix.h
@@ -3633,8 +3633,13 @@ public:
         return current;
     }
     VectorIterator operator+=(ptrdiff_t n) {
-        assert (index+n-1 < vector.size());
+        assert (0 <= index+n && index+n <= vector.size());
         index += n;
+        return *this;
+    }
+    VectorIterator operator-=(ptrdiff_t n) {
+        assert (0 <= index-n && index-n <= vector.size());
+        index -= n;
         return *this;
     }
     bool operator<(VectorIterator iter) const {


### PR DESCRIPTION
The build is broken on Mac OS X 10.9. One big change is the move to libc++ by default, which has caused some problems for other people.

I'm not sure if this is related to libc++ or not, but it seems that the templated std::sort with clang on OS X 10.9 requires iterators to have a += operator defined. Adding the operator fixes the broken build.

@sherm1 can you check the assert math? I tried to extend the logic used in the increment operators, but I'm not sure if it's off by 1.
