### PR TITLE
Fix #85: reduce scope of Doxyfile EXCLUDE_PATTERN

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -787,7 +787,9 @@ EXCLUDE_SYMLINKS       = NO
 EXCLUDE_PATTERNS       = */Platform/* \
                          */tests/* \
                          */examples/* \
-                         */src/* \
+                         */SimTKcommon/*src/* \
+                         */SimTKmath/*src/* \
+                         */Simbody/*src/* \
                          */SimTKlapack.h \
                          */internal/ResultType.h \
                          */simbody-visualizer/* \


### PR DESCRIPTION
The _/src/_ pattern was a little broad, so I changed it be scoped
a little more towards simbody-specific folders.
