### PR TITLE
Clarify test/example cmake settings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,11 +133,17 @@ SET(SimTKSIMBODY_STATIC_LIBRARY_VN ${SimTKSIMBODY_LIBRARY_NAME_VN}_static)
 # Caution: this variable is automatically created by the CMake
 # ENABLE_TESTING() command, but we'll take it over here for
 # our own purposes too.
-SET( BUILD_TESTING ON CACHE BOOL
-	"Control building of Simbody test programs." )
+SET(BUILD_TESTING ON CACHE BOOL
+    "Control building of Simbody test programs.
+    To actually build tests, one
+    or both of BUILD_TESTS_AND_EXAMPLES_STATIC and
+    BUILD_TESTS_AND_EXAMPLES_SHARED must be ON.")
 
-SET( BUILD_EXAMPLES ON CACHE BOOL
-	"Control building of Simbody example programs.")
+SET(BUILD_EXAMPLES ON CACHE BOOL
+	"Control building of Simbody example programs.
+    To actually build examples, one
+    or both of BUILD_TESTS_AND_EXAMPLES_STATIC and
+    BUILD_TESTS_AND_EXAMPLES_SHARED must be ON.")
 
 # Set whether to build the Visualizer code.
 SET(BUILD_VISUALIZER ON CACHE BOOL 
@@ -145,12 +151,32 @@ SET(BUILD_VISUALIZER ON CACHE BOOL
 
 # Turning this off reduces the build time (and space) substantially,
 # but you may miss the occasional odd bug. Also currently on Windows it
-# is easier to debug the static tests than the DLL-liked ones.
-SET( BUILD_TESTING_STATIC ON CACHE BOOL
-    "If building static libraries, build static test and example programs too?" )
+# is easier to debug the static tests than the DLL-linked ones.
+SET(BUILD_TESTS_AND_EXAMPLES_STATIC ON CACHE BOOL
+    "If BUILDING_STATIC_LIBRARIES and BUILD_TESTING or BUILD_EXAMPLES, build
+    statically-linked test and example programs too? On Windows,
+    statically-linked tests may be easier to debug than DLL-linked tests.
+    Statically-linked examples are never installed.")
+MARK_AS_ADVANCED(BUILD_TESTS_AND_EXAMPLES_STATIC)
 
-SET( BUILD_TESTING_SHARED ON CACHE BOOL
-    "If building test or example programs, include dynamically-linked ones?" )
+SET(BUILD_TESTS_AND_EXAMPLES_SHARED ON CACHE BOOL
+    "If BUILD_TESTING or BUILD_EXAMPLES, build dynamically-linked ones?")
+MARK_AS_ADVANCED(BUILD_TESTS_AND_EXAMPLES_SHARED)
+
+IF(BUILD_TESTING AND NOT (BUILD_TESTS_AND_EXAMPLES_STATIC OR
+        BUILD_TESTS_AND_EXAMPLES_SHARED))
+    MESSAGE(SEND_ERROR "No tests would be built, despite BUILD_EXAMPLES"
+        "being on, because BUILD_TESTS_AND_EXAMPLES_STATIC and "
+        "BUILD_TESTS_AND_EXAMPLES_SHARED are both off.")
+ENDIF()
+
+IF(BUILD_EXAMPLES AND NOT (BUILD_TESTS_AND_EXAMPLES_STATIC OR
+        BUILD_TESTS_AND_EXAMPLES_SHARED))
+    MESSAGE(SEND_ERROR
+        "No examples would be built, despite BUILD_EXAMPLES being on, "
+        "because BUILD_TESTS_AND_EXAMPLES_STATIC and "
+        "BUILD_TESTS_AND_EXAMPLES_SHARED are both off.")
+ENDIF()
 
 #
 # Create a platform name useful for finding things in the Platform

--- a/SimTKcommon/tests/CMakeLists.txt
+++ b/SimTKcommon/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ ADD_SUBDIRECTORY(adhoc)
 # executables will be labeled "Regr - TheTestName" if a file
 # TheTestName.cpp is found in this directory.
 #
-# We check the BUILD_TESTING_{SHARED,STATIC} variables to determine
+# We check the BUILD_TESTS_AND_EXAMPLES_{SHARED,STATIC} variables to determine
 # whether to build dynamically linked, statically linked, or both
 # versions of the executable.
 
@@ -25,7 +25,7 @@ FILE(GLOB REGR_TESTS "*.cpp")
 FOREACH(TEST_PROG ${REGR_TESTS})
     GET_FILENAME_COMPONENT(TEST_ROOT ${TEST_PROG} NAME_WE)
 
-    IF (BUILD_TESTING_SHARED)
+    IF (BUILD_TESTS_AND_EXAMPLES_SHARED)
         # Link with shared library
         ADD_EXECUTABLE(${TEST_ROOT} ${TEST_PROG})
         SET_TARGET_PROPERTIES(${TEST_ROOT}
@@ -34,9 +34,9 @@ FOREACH(TEST_PROG ${REGR_TESTS})
         TARGET_LINK_LIBRARIES(${TEST_ROOT} 
 					${TEST_SHARED_TARGET})
         ADD_TEST(${TEST_ROOT} ${EXECUTABLE_OUTPUT_PATH}/${TEST_ROOT})
-    ENDIF (BUILD_TESTING_SHARED)
+    ENDIF (BUILD_TESTS_AND_EXAMPLES_SHARED)
 
-    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTING_STATIC)
+    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTS_AND_EXAMPLES_STATIC)
         # Link with static library
         SET(TEST_STATIC ${TEST_ROOT}Static)
         ADD_EXECUTABLE(${TEST_STATIC} ${TEST_PROG})

--- a/SimTKcommon/tests/adhoc/CMakeLists.txt
+++ b/SimTKcommon/tests/adhoc/CMakeLists.txt
@@ -12,7 +12,7 @@
 # executables will be labeled "Adhoc - TheTestName" if a file
 # TheTestName.cpp is found in this directory.
 #
-# We check the BUILD_TESTING_{SHARED,STATIC} variables to determine
+# We check the BUILD_TESTS_AND_EXAMPLES_{SHARED,STATIC} variables to determine
 # whether to build dynamically linked, statically linked, or both
 # versions of the executable.
 
@@ -21,7 +21,7 @@ FILE(GLOB ADHOC_TESTS "*.cpp")
 FOREACH(TEST_PROG ${ADHOC_TESTS})
     GET_FILENAME_COMPONENT(TEST_ROOT ${TEST_PROG} NAME_WE)
 
-    IF (BUILD_TESTING_SHARED)
+    IF (BUILD_TESTS_AND_EXAMPLES_SHARED)
         # Link with shared library
         ADD_EXECUTABLE(${TEST_ROOT} ${TEST_PROG})
         SET_TARGET_PROPERTIES(${TEST_ROOT}
@@ -29,9 +29,9 @@ FOREACH(TEST_PROG ${ADHOC_TESTS})
 	      PROJECT_LABEL "Test_Adhoc - ${TEST_ROOT}")
         TARGET_LINK_LIBRARIES(${TEST_ROOT} 
 					${TEST_SHARED_TARGET})
-    ENDIF (BUILD_TESTING_SHARED)
+    ENDIF (BUILD_TESTS_AND_EXAMPLES_SHARED)
 
-    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTING_STATIC)
+    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTS_AND_EXAMPLES_STATIC)
         # Link with static library
         SET(TEST_STATIC ${TEST_ROOT}Static)
         ADD_EXECUTABLE(${TEST_STATIC} ${TEST_PROG})

--- a/SimTKmath/Integrators/src/CPodes/sundials/tests/CMakeLists.txt
+++ b/SimTKmath/Integrators/src/CPodes/sundials/tests/CMakeLists.txt
@@ -27,7 +27,7 @@ include_directories(
 # executables will be labeled "Regr - TheTestName" if a file
 # TheTestName.cpp is found in this directory.
 #
-# We check the BUILD_TESTING_{SHARED,STATIC} variables to determine
+# We check the BUILD_TESTS_AND_EXAMPLES_{SHARED,STATIC} variables to determine
 # whether to build dynamically linked, statically linked, or both
 # versions of the executable.
 
@@ -35,7 +35,7 @@ FILE(GLOB REGR_TESTS "*.c")
 FOREACH(TEST_PROG ${REGR_TESTS})
     GET_FILENAME_COMPONENT(TEST_ROOT ${TEST_PROG} NAME_WE)
 
-    IF (BUILD_TESTING_SHARED)
+    IF (BUILD_TESTS_AND_EXAMPLES_SHARED)
         # Link with shared library
         ADD_EXECUTABLE(${TEST_ROOT} ${TEST_PROG})
         SET_TARGET_PROPERTIES(${TEST_ROOT}
@@ -44,9 +44,9 @@ FOREACH(TEST_PROG ${REGR_TESTS})
         TARGET_LINK_LIBRARIES(${TEST_ROOT} 
 					${TEST_SHARED_TARGET})
         ADD_TEST(${TEST_ROOT} ${EXECUTABLE_OUTPUT_PATH}/${TEST_ROOT})
-    ENDIF (BUILD_TESTING_SHARED)
+    ENDIF (BUILD_TESTS_AND_EXAMPLES_SHARED)
 
-    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTING_STATIC)
+    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTS_AND_EXAMPLES_STATIC)
         # Link with static library
         SET(TEST_STATIC ${TEST_ROOT}Static)
         ADD_EXECUTABLE(${TEST_STATIC} ${TEST_PROG})

--- a/SimTKmath/Integrators/src/CPodes/tests/CMakeLists.txt
+++ b/SimTKmath/Integrators/src/CPodes/tests/CMakeLists.txt
@@ -19,7 +19,7 @@ INCLUDE_DIRECTORIES(${SimTK_SDK}/include)
 # executables will be labeled "Regr - TheTestName" if a file
 # TheTestName.cpp is found in this directory.
 #
-# We check the BUILD_TESTING_{SHARED,STATIC} variables to determine
+# We check the BUILD_TESTS_AND_EXAMPLES_{SHARED,STATIC} variables to determine
 # whether to build dynamically linked, statically linked, or both
 # versions of the executable.
 
@@ -27,7 +27,7 @@ FILE(GLOB REGR_TESTS "*.cpp")
 FOREACH(TEST_PROG ${REGR_TESTS})
     GET_FILENAME_COMPONENT(TEST_ROOT ${TEST_PROG} NAME_WE)
 
-    IF (BUILD_TESTING_SHARED)
+    IF (BUILD_TESTS_AND_EXAMPLES_SHARED)
         # Link with shared library
         ADD_EXECUTABLE(${TEST_ROOT} ${TEST_PROG})
         SET_TARGET_PROPERTIES(${TEST_ROOT}
@@ -36,9 +36,9 @@ FOREACH(TEST_PROG ${REGR_TESTS})
         TARGET_LINK_LIBRARIES(${TEST_ROOT} 
 					${TEST_SHARED_TARGET})
         ADD_TEST(${TEST_ROOT} ${EXECUTABLE_OUTPUT_PATH}/${TEST_ROOT})
-    ENDIF (BUILD_TESTING_SHARED)
+    ENDIF (BUILD_TESTS_AND_EXAMPLES_SHARED)
 
-    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTING_STATIC)
+    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTS_AND_EXAMPLES_STATIC)
         # Link with static library
         SET(TEST_STATIC ${TEST_ROOT}Static)
         ADD_EXECUTABLE(${TEST_STATIC} ${TEST_PROG})

--- a/SimTKmath/examples/CMakeLists.txt
+++ b/SimTKmath/examples/CMakeLists.txt
@@ -24,7 +24,7 @@
 # executables will be labeled "Example - TheExampleName" if a file
 # TheExampleName.cpp is found in this directory.
 #
-# We check the BUILD_TESTING_{SHARED,STATIC} variables to determine
+# We check the BUILD_TESTS_AND_EXAMPLES_{SHARED,STATIC} variables to determine
 # whether to build dynamically linked, statically linked, or both
 # versions of the executable.
 
@@ -34,16 +34,16 @@ FOREACH(EX_PROG ${EXAMPLES})
     GET_FILENAME_COMPONENT(EX_SRC  ${EX_PROG} NAME)
     GET_FILENAME_COMPONENT(EX_ROOT ${EX_PROG} NAME_WE)
 
-    IF (BUILD_TESTING_SHARED)
+    IF (BUILD_TESTS_AND_EXAMPLES_SHARED)
         # Link with shared library
         ADD_EXECUTABLE(${EX_ROOT} ${EX_PROG})
         SET_TARGET_PROPERTIES(${EX_ROOT}
 		PROPERTIES
 	      PROJECT_LABEL "Example - ${EX_ROOT}")
         TARGET_LINK_LIBRARIES(${EX_ROOT} ${TEST_SHARED_TARGET})
-    ENDIF (BUILD_TESTING_SHARED)
+    ENDIF (BUILD_TESTS_AND_EXAMPLES_SHARED)
 
-    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTING_STATIC)
+    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTS_AND_EXAMPLES_STATIC)
         # Link with static library
         SET(EX_STATIC ${EX_ROOT}Static)
         ADD_EXECUTABLE(${EX_STATIC} ${EX_PROG})

--- a/SimTKmath/tests/CMakeLists.txt
+++ b/SimTKmath/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ ADD_SUBDIRECTORY(adhoc)
 # executables will be labeled "Regr - TheTestName" if a file
 # TheTestName.cpp is found in this directory.
 #
-# We check the BUILD_TESTING_{SHARED,STATIC} variables to determine
+# We check the BUILD_TESTS_AND_EXAMPLES_{SHARED,STATIC} variables to determine
 # whether to build dynamically linked, statically linked, or both
 # versions of the executable.
 
@@ -25,7 +25,7 @@ FILE(GLOB REGR_TESTS "*.cpp")
 FOREACH(TEST_PROG ${REGR_TESTS})
     GET_FILENAME_COMPONENT(TEST_ROOT ${TEST_PROG} NAME_WE)
 
-    IF (BUILD_TESTING_SHARED)
+    IF (BUILD_TESTS_AND_EXAMPLES_SHARED)
         # Link with shared library
         ADD_EXECUTABLE(${TEST_ROOT} ${TEST_PROG})
         SET_TARGET_PROPERTIES(${TEST_ROOT}
@@ -34,9 +34,9 @@ FOREACH(TEST_PROG ${REGR_TESTS})
         TARGET_LINK_LIBRARIES(${TEST_ROOT} 
 					${TEST_SHARED_TARGET})
         ADD_TEST(${TEST_ROOT} ${EXECUTABLE_OUTPUT_PATH}/${TEST_ROOT})
-    ENDIF (BUILD_TESTING_SHARED)
+    ENDIF (BUILD_TESTS_AND_EXAMPLES_SHARED)
 
-    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTING_STATIC)
+    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTS_AND_EXAMPLES_STATIC)
         # Link with static library
         SET(TEST_STATIC ${TEST_ROOT}Static)
         ADD_EXECUTABLE(${TEST_STATIC} ${TEST_PROG})

--- a/SimTKmath/tests/adhoc/CMakeLists.txt
+++ b/SimTKmath/tests/adhoc/CMakeLists.txt
@@ -12,7 +12,7 @@
 # executables will be labeled "Adhoc - TheTestName" if a file
 # TheTestName.cpp is found in this directory.
 #
-# We check the BUILD_TESTING_{SHARED,STATIC} variables to determine
+# We check the BUILD_TESTS_AND_EXAMPLES_{SHARED,STATIC} variables to determine
 # whether to build dynamically linked, statically linked, or both
 # versions of the executable.
 
@@ -21,7 +21,7 @@ FILE(GLOB ADHOC_TESTS "*.cpp")
 FOREACH(TEST_PROG ${ADHOC_TESTS})
     GET_FILENAME_COMPONENT(TEST_ROOT ${TEST_PROG} NAME_WE)
 
-    IF (BUILD_TESTING_SHARED)
+    IF (BUILD_TESTS_AND_EXAMPLES_SHARED)
         # Link with shared library
         ADD_EXECUTABLE(${TEST_ROOT} ${TEST_PROG})
         SET_TARGET_PROPERTIES(${TEST_ROOT}
@@ -29,9 +29,9 @@ FOREACH(TEST_PROG ${ADHOC_TESTS})
 	      PROJECT_LABEL "Test_Adhoc - ${TEST_ROOT}")
         TARGET_LINK_LIBRARIES(${TEST_ROOT} 
 					${TEST_SHARED_TARGET})
-    ENDIF (BUILD_TESTING_SHARED)
+    ENDIF (BUILD_TESTS_AND_EXAMPLES_SHARED)
 
-    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTING_STATIC)
+    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTS_AND_EXAMPLES_STATIC)
         # Link with static library
         SET(TEST_STATIC ${TEST_ROOT}Static)
         ADD_EXECUTABLE(${TEST_STATIC} ${TEST_PROG})

--- a/Simbody/examples/CMakeLists.txt
+++ b/Simbody/examples/CMakeLists.txt
@@ -13,7 +13,7 @@
 # executables will be labeled "Example - TheExampleName" if a file
 # TheExampleName.cpp is found in this directory.
 #
-# We check the BUILD_TESTING_{SHARED,STATIC} variables to determine
+# We check the BUILD_TESTS_AND_EXAMPLES_{SHARED,STATIC} variables to determine
 # whether to build dynamically linked, statically linked, or both
 # versions of the executable.
 
@@ -23,7 +23,7 @@ FOREACH(EX_PROG ${EXAMPLES})
     GET_FILENAME_COMPONENT(EX_SRC  ${EX_PROG} NAME)
     GET_FILENAME_COMPONENT(EX_ROOT ${EX_PROG} NAME_WE)
 
-    IF (BUILD_TESTING_SHARED)
+    IF (BUILD_TESTS_AND_EXAMPLES_SHARED)
         # Link with shared library
         ADD_EXECUTABLE(${EX_ROOT} ${EX_PROG})
 	IF(GUI_NAME)
@@ -35,9 +35,9 @@ FOREACH(EX_PROG ${EXAMPLES})
         TARGET_LINK_LIBRARIES(${EX_ROOT} ${TEST_SHARED_TARGET})
 
 	INSTALL(TARGETS ${EX_ROOT} DESTINATION examples/bin)
-    ENDIF (BUILD_TESTING_SHARED)
+    ENDIF (BUILD_TESTS_AND_EXAMPLES_SHARED)
 
-    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTING_STATIC)
+    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTS_AND_EXAMPLES_STATIC)
         # Link with static library
         SET(EX_STATIC ${EX_ROOT}Static)
         ADD_EXECUTABLE(${EX_STATIC} ${EX_PROG})

--- a/Simbody/examples/InstalledCMakeLists.txt
+++ b/Simbody/examples/InstalledCMakeLists.txt
@@ -13,7 +13,7 @@
 # executables will be labeled "Example - TheExampleName" if a file
 # TheExampleName.cpp is found in this directory.
 #
-# We check the BUILD_TESTING_{SHARED,STATIC} variables to determine
+# We check the BUILD_TESTS_AND_EXAMPLES_{SHARED,STATIC} variables to determine
 # whether to build dynamically linked, statically linked, or both
 # versions of the executable.
 
@@ -21,9 +21,9 @@ CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
 
 PROJECT(SimTKExamples)
 
-SET(BUILD_TESTING_SHARED TRUE CACHE BOOL 
+SET(BUILD_TESTS_AND_EXAMPLES_SHARED TRUE CACHE BOOL 
 		"Build examples using dynamic SimTK libraries.")
-SET(BUILD_TESTING_STATIC FALSE CACHE BOOL
+SET(BUILD_TESTS_AND_EXAMPLES_STATIC FALSE CACHE BOOL
 		"Build examples using static SimTK libraries.")
 
 SET(SimTK_SHARED_LIBS 
@@ -73,7 +73,7 @@ FILE(GLOB EXAMPLES "*.cpp")
 FOREACH(EX_PROG ${EXAMPLES})
     GET_FILENAME_COMPONENT(EX_ROOT ${EX_PROG} NAME_WE)
 
-    IF (BUILD_TESTING_SHARED)
+    IF (BUILD_TESTS_AND_EXAMPLES_SHARED)
         # Link with shared library
         ADD_EXECUTABLE(${EX_ROOT} ${EX_PROG})
         SET_TARGET_PROPERTIES(${EX_ROOT}
@@ -83,9 +83,9 @@ FOREACH(EX_PROG ${EXAMPLES})
 				${SimTK_SHARED_LIBS_D}
 				${SimTK_SHARED_LIBS}
 				${SimTK_GENERAL_LIBS})
-    ENDIF (BUILD_TESTING_SHARED)
+    ENDIF (BUILD_TESTS_AND_EXAMPLES_SHARED)
 
-    IF (BUILD_TESTING_STATIC)
+    IF (BUILD_TESTS_AND_EXAMPLES_STATIC)
         # Link with static library
         SET(EX_STATIC ${EX_ROOT}Static)
         ADD_EXECUTABLE(${EX_STATIC} ${EX_PROG})
@@ -97,7 +97,7 @@ FOREACH(EX_PROG ${EXAMPLES})
 				${SimTK_STATIC_LIBS_D}
 				${SimTK_STATIC_LIBS}
 				${SimTK_GENERAL_LIBS})
-    ENDIF (BUILD_TESTING_STATIC)
+    ENDIF (BUILD_TESTS_AND_EXAMPLES_STATIC)
 
 ENDFOREACH(EX_PROG ${EXAMPLES})
 

--- a/Simbody/tests/CMakeLists.txt
+++ b/Simbody/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ ADD_SUBDIRECTORY(adhoc)
 # executables will be labeled "Regr - TheTestName" if a file
 # TheTestName.cpp is found in this directory.
 #
-# We check the BUILD_TESTING_{SHARED,STATIC} variables to determine
+# We check the BUILD_TESTS_AND_EXAMPLES_{SHARED,STATIC} variables to determine
 # whether to build dynamically linked, statically linked, or both
 # versions of the executable.
 
@@ -25,7 +25,7 @@ FILE(GLOB REGR_TESTS "*.cpp")
 FOREACH(TEST_PROG ${REGR_TESTS})
     GET_FILENAME_COMPONENT(TEST_ROOT ${TEST_PROG} NAME_WE)
 
-    IF (BUILD_TESTING_SHARED)
+    IF (BUILD_TESTS_AND_EXAMPLES_SHARED)
         # Link with shared library
         ADD_EXECUTABLE(${TEST_ROOT} ${TEST_PROG})
         SET_TARGET_PROPERTIES(${TEST_ROOT}
@@ -34,9 +34,9 @@ FOREACH(TEST_PROG ${REGR_TESTS})
         TARGET_LINK_LIBRARIES(${TEST_ROOT} 
 					${TEST_SHARED_TARGET})
         ADD_TEST(${TEST_ROOT} ${EXECUTABLE_OUTPUT_PATH}/${TEST_ROOT})
-    ENDIF (BUILD_TESTING_SHARED)
+    ENDIF (BUILD_TESTS_AND_EXAMPLES_SHARED)
 
-    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTING_STATIC)
+    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTS_AND_EXAMPLES_STATIC)
         # Link with static library
         SET(TEST_STATIC ${TEST_ROOT}Static)
         ADD_EXECUTABLE(${TEST_STATIC} ${TEST_PROG})

--- a/Simbody/tests/adhoc/CMakeLists.txt
+++ b/Simbody/tests/adhoc/CMakeLists.txt
@@ -12,7 +12,7 @@
 # executables will be labeled "Adhoc - TheTestName" if a file
 # TheTestName.cpp is found in this directory.
 #
-# We check the BUILD_TESTING_{SHARED,STATIC} variables to determine
+# We check the BUILD_TESTS_AND_EXAMPLES_{SHARED,STATIC} variables to determine
 # whether to build dynamically linked, statically linked, or both
 # versions of the executable.
 
@@ -21,7 +21,7 @@ FILE(GLOB ADHOC_TESTS "*.cpp")
 FOREACH(TEST_PROG ${ADHOC_TESTS})
     GET_FILENAME_COMPONENT(TEST_ROOT ${TEST_PROG} NAME_WE)
 
-    IF (BUILD_TESTING_SHARED)
+    IF (BUILD_TESTS_AND_EXAMPLES_SHARED)
         # Link with shared library
         ADD_EXECUTABLE(${TEST_ROOT} ${TEST_PROG})
 	IF(GUI_NAME)
@@ -32,9 +32,9 @@ FOREACH(TEST_PROG ${ADHOC_TESTS})
 	      PROJECT_LABEL "Test_Adhoc - ${TEST_ROOT}")
         TARGET_LINK_LIBRARIES(${TEST_ROOT} 
 		              ${TEST_SHARED_TARGET})
-    ENDIF (BUILD_TESTING_SHARED)
+    ENDIF (BUILD_TESTS_AND_EXAMPLES_SHARED)
 
-    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTING_STATIC)
+    IF (BUILD_STATIC_LIBRARIES AND BUILD_TESTS_AND_EXAMPLES_STATIC)
         # Link with static library
         SET(TEST_STATIC ${TEST_ROOT}Static)
         ADD_EXECUTABLE(${TEST_STATIC} ${TEST_PROG})


### PR DESCRIPTION
This commit attempts to fix issue #92 via the following changes:
- Rename BUILD_TESTING_{STATIC,SHARED} to
  BUILD_TESTS_AND_EXAMPLES_{STATIC,SHARED}, everywhere.
- In the comments for BUILD_TESTING and BUILD_EXAMPLES, mention the
  importance of BUILD_TESTS_AND_EXAMPLES_{STATIC,SHARED}.
- Edit comment for BUILD_TESTS_AND_EXAMPLES{STATIC,SHARED}.
- Add CMake errors if the user wants tests or examples but sets both
  BUILD_TESTS_AND_EXAMPLES_{STATIC,SHARED} off.
