### PR TITLE
SIMBODY_SONAME_VERSION not updated after rerunning CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,13 +49,15 @@ ENDIF()
 SET(SIMBODY_VERSION 
     "${SIMBODY_MAJOR_VERSION}.${SIMBODY_MINOR_VERSION}${PATCH_VERSION_STRING}" 
     CACHE STRING 
-    "This is the version that will be built (can't be changed here)." 
+    "This is the version that will be built (can't be changed in GUI)." 
     FORCE)
 
 SET(SIMBODY_SONAME_VERSION
     "${SIMBODY_MAJOR_VERSION}.${SIMBODY_MINOR_VERSION}"
     CACHE STRING
-    "Soname version to use when generating shared libs")
+    "Soname version; appended to names of shared libs
+    (can't be changed in GUI)."
+    FORCE)
 
 # This is the suffix if we're building and depending on versioned libraries.
 SET(VN "_${SIMBODY_VERSION}")


### PR DESCRIPTION
I don't think this needs to be cached. If it is cached, if I check out a different branch of Simbody, using the same CMake build directory, then this variable is not updated. Would a user ever need to modify this themselves?

```
SET(SIMBODY_SONAME_VERSION "${SIMBODY_MAJOR_VERSION}.${SIMBODY_MINOR_VERSION}"
    CACHE STRING
    "Soname version to use when generating shared libs")
```
