### PR TITLE
Fixes #139.

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -237,15 +237,16 @@ extern "C" {
 #include <algorithm>
 
 /* Transition macros for C++11 support. VC10 and VC11 have partial support for
-C++11, early VC's do not. Currently we're assuming no support from gcc. */
+C++11, early VC's do not. If using gcc or Clang, we check for C++11 support. */
 #ifndef SWIG
-    #if _MSC_VER>=1700 /* VC11 or higher */
+    #if _MSC_VER>=1700 || (defined(__GNUG__) && __cplusplus>=201103L)
+        /* VC11 or higher, OR using gcc or Clang and using C++11 */
         #define OVERRIDE_11  override
         #define FINAL_11     final
     #elif _MSC_VER==1600 /* VC10 */
         #define OVERRIDE_11  override
         #define FINAL_11     sealed
-    #else /* gcc or earlier VC */
+    #else /* gcc or Clang without C++11, or earlier VC */
         #define OVERRIDE_11
         #define FINAL_11
     #endif


### PR DESCRIPTION
If using gcc or Clang and using C++11, then we fill in the OVERRIDE_11
and FINAL_11 macros with `override`, and `final`.

Note that the way I check if we're using C++11 is not completely
legitimate, but it's the best we can do for a simple solution. The internet suggests doing feature-by-feature checks, since most compiliers who say they are C++11 compliant are not necessarily
fully C++11 compliant. For the current C++11 features we use, there is no issue.
