### PR TITLE
Use RelWithDebInfo to build simbody debian binaries

### DIFF
--- a/doc/debian/rules
+++ b/doc/debian/rules
@@ -10,7 +10,8 @@
 override_dh_auto_configure:
 	dh_auto_configure --  \
 	    -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-	    -DBUILD_EXAMPLES:BOOL=False
+	    -DBUILD_EXAMPLES:BOOL=False \
+	    -DMAKE_BUILD_TYPE:STRING=RelWithDebInfo
 
 override_dh_auto_build-indep:
 	dh_auto_build -- doxygen


### PR DESCRIPTION
As per discussion on issue #157, modify the debian build to call RelWithDebInfo
