### PR TITLE
Fix bug in mesh triangulation reported by Alexandra Zobova. 

### DIFF
--- a/SimTKmath/Geometry/src/ContactGeometry_TriangleMesh.cpp
+++ b/SimTKmath/Geometry/src/ContactGeometry_TriangleMesh.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2008-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2008-14 Stanford University and the Authors.        *
  * Authors: Peter Eastman                                                     *
  * Contributors: Michael Sherman                                              *
  *                                                                            *
@@ -348,6 +348,10 @@ ContactGeometry::TriangleMesh::Impl::Impl
                 faceIndices.push_back(mesh.getFaceVertex(i, j+1));
                 faceIndices.push_back(newIndex);
             }
+            // Close the face (thanks, Alexandra Zobova).
+            faceIndices.push_back(mesh.getFaceVertex(i, numVert-1));
+            faceIndices.push_back(mesh.getFaceVertex(i, 0));
+            faceIndices.push_back(newIndex);
         }
     }
     init(vertexPositions, faceIndices);

--- a/Simbody/Visualizer/src/VisualizerProtocol.cpp
+++ b/Simbody/Visualizer/src/VisualizerProtocol.cpp
@@ -443,6 +443,10 @@ void VisualizerProtocol::drawPolygonalMesh(const PolygonalMesh& mesh, const Tran
                 faces.push_back((unsigned short) mesh.getFaceVertex(i, j+1));
                 faces.push_back((unsigned short) newIndex);
             }
+            // Close the face (thanks, Alexandra Zobova).
+            faces.push_back((unsigned short) mesh.getFaceVertex(i, numVert-1));
+            faces.push_back((unsigned short) mesh.getFaceVertex(i, 0));
+            faces.push_back((unsigned short) newIndex);
         }
     }
     SimTK_ERRCHK1_ALWAYS(vertices.size() <= 65535*3, 


### PR DESCRIPTION
This applies to meshes containing a face that has 5 or more edges. There were identical bugs in TriangleMesh for contact and in the code that prepares a mesh to be passed to the visualizer.

Fixes #198.
