### PR TITLE
SimbodyConfig.cmake says where SimbodyDoxygenTagfile is.

### DIFF
--- a/ApiDoxygen.cmake
+++ b/ApiDoxygen.cmake
@@ -4,6 +4,9 @@ IF(DOXYGEN_EXECUTABLE-NOTFOUND)
 ELSE(DOXYGEN_EXECUTABLE-NOTFOUND)
     SET(DOXY_CONFIG "${CMAKE_CURRENT_BINARY_DIR}/Doxyfile")
 
+    # This is used in Doxyfile.in and SimbodyConfig.cmake.in.
+    SET(SIMBODY_DOXYGEN_TAGFILE_RELPATH "html/SimbodyDoxygenTagfile")
+
     CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in 
           ${DOXY_CONFIG}
           @ONLY )

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -2024,7 +2024,7 @@ TAGFILES               =
 # tag file that is based on the input files it reads. See section "Linking to
 # external documentation" for more information about the usage of tag files.
 
-GENERATE_TAGFILE       = "html/@PROJECT_NAME@DoxygenTagfile"
+GENERATE_TAGFILE       = "@SIMBODY_DOXYGEN_TAGFILE_RELPATH@"
 
 # If the ALLEXTERNALS tag is set to YES all external class will be listed in the
 # class index. If set to NO only the inherited external classes will be listed.

--- a/cmake/SimbodyConfig.cmake.in
+++ b/cmake/SimbodyConfig.cmake.in
@@ -16,6 +16,11 @@
 #   Simbody_STATIC_LIBRARIES - suitable for target_link_libraries(); includes
 #                              both optimized and debug static libraries if
 #                              both are available
+#   Simbody_DOXYGEN_TAGFILE - Path to SimbodyDoxygenTagFile, which
+#                             which can be used to include Simbody
+#                             Doxygen documentation directly in your project.
+#                             Only defined if Doxygen documentation is
+#                             installed.
 if (@PKG_NAME@_CONFIG_INCLUDED)
   return()
 endif()
@@ -39,6 +44,14 @@ list(APPEND @PKG_NAME@_CFLAGS
 
 list(APPEND @PKG_NAME@_LDFLAGS 
             -L"@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@")
+
+if (NOT "@SIMBODY_DOXYGEN_TAGFILE_RELPATH@" STREQUAL "")
+    set(temp_tagfile_path
+        "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_DOCDIR@/api/@PROJECT_NAME@/@SIMBODY_DOXYGEN_TAGFILE_RELPATH@")
+    if (EXISTS "${temp_tagfile_path}")
+        set(@PKG_NAME@_DOXYGEN_TAGFILE "${temp_tagfile_path}")
+    endif()
+endif()
 
 # Set extra libraries to link against
 if (WIN32)


### PR DESCRIPTION
This will be useful for resolving
https://github.com/opensim-org/opensim-core/issues#122 in a cross-platform way.
