### PR TITLE
Make use of Chris Dembia's new NiceTypeName::namestr() method

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -413,7 +413,7 @@ template<class T> inline static
 bool tryConvertStringTo(const String& value, T*& out) {
     SimTK_ERRCHK1_ALWAYS(false, "SimTK::convertStringTo(value,T*)",
         "Can't interpret a string as a pointer (%s*).",
-        NiceTypeName<T>::name());
+        NiceTypeName<T>::namestr().c_str());
     return false; 
 }
 
@@ -433,7 +433,7 @@ String::convertTo(T& out) const {
     if (shorter.size() < this->size()) shorter += " ...";
     SimTK_ERRCHK2_ALWAYS(convertOK, "String::convertTo()",
         "Couldn't interpret string '%s' as type T=%s.",
-        shorter.c_str(), NiceTypeName<T>::name());
+        shorter.c_str(), NiceTypeName<T>::namestr().c_str());
 }
 
 /** This method converts its String argument to type T and returns it into

--- a/SimTKcommon/include/SimTKcommon/internal/Value.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Value.h
@@ -89,7 +89,7 @@ public:
         if (!isA(v)) SimTK_THROW2(Exception::IncompatibleValues,v.getTypeName(),getTypeName());
         *this = downcast(v);
     }
-    String getTypeName() const { return NiceTypeName<T>::name(); }
+    String getTypeName() const { return NiceTypeName<T>::namestr(); }
     // TODO: should have some general way to serialize these.
     String getValueAsString() const 
     { return "Value<" + getTypeName() + ">"; }

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -9,9 +9,9 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-14 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
- * Contributors:                                                              *
+ * Contributors: Chris Dembia                                                 *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -733,17 +733,22 @@ static const bool Is64BitPlatform = sizeof(size_t) > sizeof(int);
 typedef Is64BitHelper<Is64BitPlatform>::Result Is64BitPlatformType;
 
 
-/** Attempts to demangle a type name. Platform-dependent. */
+/** Attempt to demangle a type name as returned by typeid.name(), with the
+result hopefully suitable for meaningful display to a human. Behavior is 
+compiler-dependent. **/
 SimTK_SimTKCOMMON_EXPORT std::string demangle(const char* name);
 
 /** In case you don't like the name you get from typeid(), you can specialize
-this class to provide a nicer name. This is typically used for error messages 
-and testing. **/
+this class to provide a nicer name. This class is typically used for error 
+messages and testing. **/
 template <class T> struct NiceTypeName {
-    /** With GCC and Clang, this gives a mangled type name. */
+    /** The default implementation of name() here returns the raw result from
+    typeid(T).name() which will be fast but may be a mangled name in some 
+    compilers (gcc and clang included). **/
     static const char* name() {return typeid(T).name();}
-    /** This attempts to give a demangled type name in a
-     * platform-dependent way. */
+    /** The default implementation of namestr() attempts to return a nicely
+    demangled type name on all platforms, using the SimTK::demangle() method
+    defined above. Don't expect this to be fast. **/
     static std::string namestr() {return demangle(name());}
 };
 

--- a/SimTKcommon/src/NiceTypeName.cpp
+++ b/SimTKcommon/src/NiceTypeName.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2010-14 Stanford University and the Authors.        *
+ * Portions copyright (c) 2014 Stanford University and the Authors.           *
  * Authors: Chris Dembia, Michael Sherman                                     *
  * Contributors:                                                              *
  *                                                                            *
@@ -34,7 +34,7 @@ namespace SimTK {
 
 std::string demangle(const char* name) {
     #if defined(__GNUG__)
-        int status;
+        int status=-100; // just in case it doesn't get set
         char* ret = abi::__cxa_demangle(name, NULL, NULL, &status);
         const char* const demangled_name = (status == 0) ? ret : name;
         std::string demangled_string(demangled_name);

--- a/SimTKcommon/tests/TestArray.cpp
+++ b/SimTKcommon/tests/TestArray.cpp
@@ -110,6 +110,7 @@ private:
 namespace SimTK {
 template <> struct NiceTypeName<SmallIx> {
     static const char* name() {return "SmallIx";}
+    static std::string namestr() {return "SmallIx";}
 };
 }
 
@@ -755,9 +756,11 @@ void testNiceTypeName() {
         << NiceTypeName<ArrayIndexPackType<long>::packed_size_type>::name() << endl;
     cout << "packed_size_type<unsigned long long>=" 
         << NiceTypeName<ArrayIndexPackType<unsigned long long>::packed_size_type>::name() << endl;
-    cout << NiceTypeName< Array_<String,char> >::name() << endl;
+    cout << "Array_<String,char> using name(): " 
+         << NiceTypeName< Array_<String,char> >::name() << endl;
     // Check demangling on GCC/Clang.
-    cout << NiceTypeName< Array_<String,char> >::namestr() << endl;
+    cout << "Array_<String,char> using namestr(): " 
+         << NiceTypeName< Array_<String,char> >::namestr() << endl;
 }
 
 // The Array_ class is supposed to make better use of memory than does


### PR DESCRIPTION
Simbody used `SimTK::NiceTypeName::name()` for some error messages, but those type names come out mangled on some compilers. @chrisdembia added a `namestr()` method in PR #223 that returns demangled names on all platforms.

This PR makes some minor Simbody changes to exploit the availability of the new method. I also expanded some comments and made one probably-unnecessary code safety change to `demangle()`.
