### PR TITLE
Fix Windows build (broken by PR #241).

### DIFF
--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -13,10 +13,7 @@
 #-----------------------------------------------------------
 ADD_CUSTOM_TARGET(PlatformFiles ALL DEPENDS ${COPIED_LIB_FILES})
 
-if(NOT CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
-  # only provide for native builds
-  return()
-endif ()
+SET(PLATFORM_ROOT ${CMAKE_SOURCE_DIR}/Platform/${CMAKE_HOST_SYSTEM_NAME})
 
 SET(LIB_ABI_DIR "${PLATFORM_ROOT}/lib_${PLATFORM_ABI}")
 FILE(GLOB LIB_FILES 


### PR DESCRIPTION
- Restored now-missing PLATFORM_ROOT variable which was still in use
- Removed early return() in case of non-Windows. I want to keep this working for auxiliary files in case we need some later. Since there is no MingW directory, this should do nothing if that is the host system name.
