### PR TITLE
Fix SimbodyConfig.cmake for math libs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -607,10 +607,10 @@ add_custom_target(uninstall
 # Make the cmake config files
 set(PKG_NAME ${PROJECT_NAME})
 set(PKG_LIBRARIES
-  SimTKsimbody
-  SimTKmath
-  SimTKcommon
-)
+    ${SimTKSIMBODY_LIBRARY_NAME}
+    ${SimTKMATH_LIBRARY_NAME}
+    ${SimTKCOMMON_LIBRARY_NAME}
+    )
 
 if (WIN32)
   set(SIMBODY_CMAKE_DIR cmake)

--- a/cmake/SimbodyConfig.cmake.in
+++ b/cmake/SimbodyConfig.cmake.in
@@ -68,38 +68,21 @@ if (NOT "@SIMBODY_DOXYGEN_TAGFILE_NAME@" STREQUAL "")
     unset(temp_tagfile_path)
 endif()
 
-# Set extra libraries to link against
-if (WIN32)
-  set(Simbody_LAPACK_LIBRARY_LIST liblapack;libblas)
-else()
-  set(Simbody_LAPACK_LIBRARY_LIST lapack;blas)
-endif()
-if (WIN32)
-  if( ${CMAKE_SIZEOF_VOID_P} EQUAL 8 )
-    set(Simbody_EXTRA_LIBRARY_LIST pthreadVC2_x64)
-  else()
-    set(Simbody_EXTRA_LIBRARY_LIST pthreadVC2)
-  endif()
-elseif (APPLE)
-  set(Simbody_EXTRA_LIBRARY_LIST pthread;dl)
-else()
-  set(Simbody_EXTRA_LIBRARY_LIST pthread;rt;dl;m)
-endif()
 
 # Find out which of the libraries are available.
-find_library(Simbody_LIBRARY NAMES SimTKsimbody
+find_library(Simbody_LIBRARY NAMES @NS@SimTKsimbody
     PATHS ${Simbody_LIB_DIR}
     DOC "This is the main Simbody library."
     NO_DEFAULT_PATH)
-find_library(Simbody_STATIC_LIBRARY NAMES SimTKsimbody_static
+find_library(Simbody_STATIC_LIBRARY NAMES @NS@SimTKsimbody_static
     PATHS ${Simbody_LIB_DIR}
     DOC "This is the main Simbody static library."
     NO_DEFAULT_PATH)
-find_library(Simbody_DEBUG_LIBRARY NAMES SimTKsimbody@CMAKE_DEBUG_POSTFIX@
+find_library(Simbody_DEBUG_LIBRARY NAMES @NS@SimTKsimbody@CMAKE_DEBUG_POSTFIX@
     PATHS ${Simbody_LIB_DIR}
     DOC "This is the main Simbody debug library."
     NO_DEFAULT_PATH)
-find_library(Simbody_STATIC_DEBUG_LIBRARY NAMES SimTKsimbody_static@CMAKE_DEBUG_POSTFIX@
+find_library(Simbody_STATIC_DEBUG_LIBRARY NAMES @NS@SimTKsimbody_static@CMAKE_DEBUG_POSTFIX@
     PATHS ${Simbody_LIB_DIR}
     DOC "This is the main Simbody static debug library."
     NO_DEFAULT_PATH)
@@ -152,12 +135,7 @@ elseif(Simbody_DEBUG_LIBRARY)
 endif()
 
 if (LIBS)
-    foreach(lapack_lib IN LISTS Simbody_LAPACK_LIBRARY_LIST)
-        set(LIBS ${LIBS} "${lapack_lib}")
-    endforeach()
-    foreach(extra_lib IN LISTS Simbody_EXTRA_LIBRARY_LIST)
-        set(LIBS ${LIBS} "${extra_lib}")
-    endforeach()
+    set(LIBS ${LIBS} "@MATH_LIBS_TO_USE@")
     set(Simbody_LIBRARIES ${LIBS} CACHE STRING 
         "Simbody dynamic libraries" FORCE)
 else()
@@ -216,12 +194,7 @@ endif()
 
 if (LIBS)
     # these aren't available in static
-    foreach(lapack_lib IN LISTS Simbody_LAPACK_LIBRARY_LIST)
-        set(LIBS ${LIBS} "${lapack_lib}")
-    endforeach()
-    foreach(extra_lib IN LISTS Simbody_EXTRA_LIBRARY_LIST)
-        set(LIBS ${LIBS} "${extra_lib}")
-    endforeach()
+    set(LIBS ${LIBS} "@MATH_LIBS_TO_USE@")
     set(Simbody_STATIC_LIBRARIES "${LIBS}" CACHE STRING 
         "Simbody static libraries" FORCE)
 else()


### PR DESCRIPTION
The SimbodyConfig.cmake used to ignore some settings from the Simbody project regarding library dependencies. Now, SimbodyConfig.cmake pays attention BUILD_USING_NAMESPACE and BUILD_USING_OTHER_LAPACK.

Fixes #255.
