### PR TITLE
Switch test and subtest timing to use high precision real time and cpu timers

### DIFF
--- a/SimTKcommon/include/SimTKcommon/Testing.h
+++ b/SimTKcommon/include/SimTKcommon/Testing.h
@@ -439,14 +439,14 @@ public:
         startRealTime(SimTK::realTime()),
         subtestName(name)
     {
-        std::clog << "  " << subtestName << " ... " << std::flush;
+        std::clog << "  " << subtestName << " ...\n" << std::flush;
     }
     ~Subtest() {
         const double finalRealTime=SimTK::realTime();
         const double finalCpuTime=SimTK::cpuTime();
         std::ostringstream fmt;
         fmt << std::fixed << std::setprecision(1);
-        fmt << "\n  " << subtestName << " done."
+        fmt << "  " << subtestName << " done."
             << " real/CPU ms: " << (finalRealTime-startRealTime)*1000
             << " / "  << (finalCpuTime-startCpuTime)*1000 <<std::endl;
         std::clog << fmt.str();


### PR DESCRIPTION
@chrisdembia  pointed out in PR #253 that Simbody's `Test` class timing counted only CPU time and therefore was no good for checking if multithreading worked properly.

`Test` was using the ancient `std::clock()` timer. I switched it to use Simbody's high precision real time and CPU time functions. This required some formatting changes for the output -- please check if they are reasonable.
