### PR TITLE
[doxygen] Consistent bolding in list.

### DIFF
--- a/SimTKmath/include/simmath/Optimizer.h
+++ b/SimTKmath/include/simmath/Optimizer.h
@@ -328,8 +328,8 @@ private:
  * - <b>stopTolFunHist</b> (real) Stop if function value differences of best
  *   values are smaller than stopTolFunHist.
  * - <b>stopTolX</b> (real) Stop if step sizes are smaller than stopTolX.
- * - <b>stopTolUpXFactor</b> (real) Stop if std dev increases by more than
- *   stopTolUpXFactor.
+ * - <b>stopTolUpXFactor</b> (real) Stop if standard deviation increases
+ *   by more than stopTolUpXFactor.
  * - <b>parallel</b> (str) To run the optimization with multiple threads, set
  *   this to "multithreading". Only use this if your OptimizerSystem is
  *   threadsafe: you can't reliably modify any mutable variables in your


### PR DESCRIPTION
My doxygen documentation of CMAES had a small inconsistency. In my list of advanced options, I had bolded some option names, while others were not bolded. Now, all option names are bolded.

Can we get this in before 3.5?
