### PR TITLE
[doxygen] Direct users to cmaes default values.

### DIFF
--- a/SimTKmath/include/simmath/Optimizer.h
+++ b/SimTKmath/include/simmath/Optimizer.h
@@ -310,6 +310,9 @@ private:
  *      - 3: output to console, and all files are written to the current
  *
  * Advanced options:
+ * 
+ * The default values for options whose name begins with "stop" are specified
+ * at https://github.com/CMA-ES/c-cmaes/blob/master/cmaes_initials.par
  *
  * - <b>lambda</b> (int; default: depends on number of parameters) The
  *   population size.


### PR DESCRIPTION
@sherm1 feel free to merge this without waiting for travis, since I've only updated a comment. I don't want to slow you down if you are prepping the 3.5 release.
