### PR TITLE
[WIP] Update Debian files for release 3.5.

### DIFF
--- a/doc/debian/copyright
+++ b/doc/debian/copyright
@@ -4,7 +4,7 @@ Upstream-Contact: https://simtk.org/sendmessage.php?touser=106
 Source: https://simtk.org 
 
 Files: *
-Copyright: 2005-13, Stanford University and the Authors. 
+Copyright: 2005-14, Stanford University and the Authors. 
 License: Apache
  See '/usr/share/common-licenses/Apache-2.0'.
 

--- a/doc/debian/libsimbody-dev.install
+++ b/doc/debian/libsimbody-dev.install
@@ -1,3 +1,4 @@
 usr/include/*
 usr/lib/*/*.so
 usr/lib/*/cmake/*
+usr/lib/*/pkgconfig/*

--- a/doc/debian/rules
+++ b/doc/debian/rules
@@ -10,7 +10,7 @@
 override_dh_auto_configure:
 	dh_auto_configure --  \
 	    -DCMAKE_INSTALL_PREFIX:PATH=/usr \
-	    -DBUILD_EXAMPLES:BOOL=False \
+	    -DBUILD_EXAMPLES:BOOL=True \
 	    -DMAKE_BUILD_TYPE:STRING=RelWithDebInfo
 
 override_dh_auto_build-indep:


### PR DESCRIPTION
I opened this PR to finish up the debian mods for release 3.5, which I would like to get out asap.

This reflects the conversation in issue #275 as I understand it. I turned on the example building and didn't add the diff that unlisted the example binaries installation directory, which I believe is `/usr/lib/*/simbody/*`. But I'm fuzzy about this; I just wanted to start a PR where we can finish it.

@j-rivero, @chrisdembia you both can push directly to this PR's branch, please do!
