### PR TITLE
deconstructPathRelativeToSWD

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/Pathname.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Pathname.h
@@ -89,23 +89,26 @@ class SimTK_SimTKCOMMON_EXPORT Pathname {
 public:
     /// Given a specified working directory (swd) and path, this function
     /// evaluates the absolute path of a given path relative to the swd and
-    /// returns the directory, fileName, and extension of the canonicalized absolute
-    /// path. This means that instead of evaluating "." as the current working
-    /// directory (cwd), the swd is used. In general, some rules are as follows
+    /// returns the directory, fileName, and extension of the canonicalized path
+    /// with respect to a swd, if needed. This means, for the path, that instead of 
+    /// evaluating "." as the current working directory (cwd), the swd is used. This
+    /// function also returns a boolean (dontApplySearchPath) to indicate if a search
+    /// path should not be applied. The following rules are applied in order:
     /// 1) If an absolute path is given by path, swd is not used. An absolute path
-    ///    is defined as a a root-relative path name and on Windows it will begin 
-    ///    with an explicit drive letter (e.g. /usr/* or c:/documents/*, respectively).
-    /// 2) If a relative path without a drive letter is given by path (e.g. "./*" or "*"), 
-    ///    then the absolute path of the swd is prepended to path.
+    ///    is defined as a a root-relative path name and on Windows it may begin 
+    ///    with a drive letter (e.g. /usr/file.ext or c:/documents/file.ext).
+    /// 2) If a relative path without a drive letter is given by path (e.g. "./dir/file.ext" 
+    ///    or "dir/file.ext"), then the absolute path of the swd is prepended to path.
     /// 3) To resolve drive ambiguities, if swd provides a drive, it is used. 
-    ///    If not, then the path drive is used (e.g. path = "X:*"). If neither provides 
-    ///    a drive, then the current drive is used.
+    ///    If not, then the path drive is used (e.g. path = "X:dir/file.ext"). If neither 
+    ///    provides a drive, then the current drive is used.
     /// 4) If swd is an empty string, then swd = cwd.
-    static void findAbsolutePathUsingSpecifiedWorkingDirectory(const std::string& swd,
+    static void deconstructPathnameUsingSpecifiedWorkingDirectory(const std::string& swd,
                                              const std::string& path,
                                              std::string& directory,
                                              std::string& fileName,
-                                             std::string& extension);
+                                             std::string& extension,
+                                             bool& dontApplySearchPath);
 
     /// Dismantle a supplied pathname into its component
     /// parts. This can take pathnames like <pre>   
@@ -185,6 +188,17 @@ public:
         if (!absPath.empty() && absPath[absPath.size()-1] != getPathSeparatorChar())
             absPath += getPathSeparatorChar();
         return absPath;
+    }
+
+    static std::string getAbsolutePathnameUsingSpecifiedWorkingDirectory(const std::string& swd,
+                                                                         const std::string& path) {
+        std::string directory, fileName, extension;
+        bool dontApplySearchPath;
+        deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+        if (!dontApplySearchPath) {
+            directory = getCurrentWorkingDirectory() + directory;
+        }
+        return directory + fileName + extension;
     }
 
     /// Return true if the given pathname names a file that exists and is

--- a/SimTKcommon/include/SimTKcommon/internal/Pathname.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Pathname.h
@@ -91,7 +91,7 @@ public:
     /// evaluates the absolute path of a given path relative to the swd and
     /// returns the directory, fileName, and extension of the canonicalized absolute
     /// path. This means that instead of evaluating "." as the current working
-    /// directory (cwd), the swd is used. In general, some rules followed are as follows
+    /// directory (cwd), the swd is used. In general, some rules are as follows
     /// 1) If an absolute path is given by path, swd is not used. An absolute path
     ///    is defined as a a root-relative path name and on Windows it will begin 
     ///    with an explicit drive letter (e.g. /usr/* or c:/documents/*, respectively).

--- a/SimTKcommon/include/SimTKcommon/internal/Pathname.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Pathname.h
@@ -163,6 +163,19 @@ public:
                                                                   std::string& directory,
                                                                   std::string& fileName,
                                                                   std::string& extension);
+    
+    /// Give back the deconstructed canonicalized absolute pathname for a given path.
+    /// If the path is not an absolute path, it will be made into an absolute path first
+    /// following the rules of deconstructPathname() (which it uses).
+    static void deconstructAbsolutePathname(const std::string& path,
+                                            std::string& directory,
+                                            std::string& fileName,
+                                            std::string& extension) {
+        bool dontApplySearchPath;
+        deconstructPathname(path, dontApplySearchPath, directory, fileName, extension);
+        if (!dontApplySearchPath)
+            directory = getCurrentWorkingDirectory() + directory;
+    }
 
     /// Get canonicalized absolute pathname from a given pathname which 
     /// can be relative or absolute. Canonicalizing means
@@ -182,11 +195,8 @@ public:
     /// from deconstructPathname(), plus inserting the current working
     /// directory in front if the path name was relative.
     static std::string getAbsolutePathname(const std::string& pathname) {
-        bool isAbsolutePath;
         std::string directory, fileName, extension;
-        deconstructPathname(pathname, isAbsolutePath, directory, fileName, extension);
-        if (!isAbsolutePath)
-            directory = getCurrentWorkingDirectory() + directory;
+        deconstructAbsolutePathname(pathname, directory, fileName, extension);
         return directory + fileName + extension;
     }
 

--- a/SimTKcommon/include/SimTKcommon/internal/Pathname.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Pathname.h
@@ -128,7 +128,7 @@ public:
     /// for the currently running platform (i.e. backslash for
     /// Windows and forward slash everywhere else).
     static void deconstructPathname(    const std::string& name,
-                                        bool&        isAbsolutePath,
+                                        bool&        dontApplySearchPath,
                                         std::string& directory,
                                         std::string& fileName,
                                         std::string& extension);
@@ -139,7 +139,7 @@ public:
     /// the canonicalized path with respect to a swd, if needed. This means, for 
     /// the path, that instead of evaluating "." as the current working directory 
     /// (cwd), the swd is used. Unlike deconstructPathname(), this function will
-    /// always return an absolute path, and no bool isAbsolutePath is returned.
+    /// always return an absolute path, and no bool dontApplySearchPath is returned.
     /// Rules:
     /// - If the swd is empty (after removing whitespace), deconstructPathname()
     ///   is called, and cwd is prepended if needed to make it an absolute path.
@@ -151,8 +151,8 @@ public:
     /// 2) If path is a root-relative path name (and on Windows this includes a drive) 
     ///    (e.g. /usr/file.ext or c:/documents/file.ext), then swd is ignored, and the
     ///    absolute path is returned.
-    /// 3) Otherwise, if a path is given relative to the cwd (e.g. "./dir/file.ext" 
-    ///    or "dir/file.ext"), then the swd is prepended to path.
+    /// 3) Otherwise, if a path is given relative to a directory that is not the root 
+    ///    (e.g. "./dir/file.ext" or "dir/file.ext"), then the swd is prepended to path.
     /// 4) To resolve drive ambiguities, if swd provides a drive, it is used. If not, 
     ///    then the path drive is used. If neither provides a drive, then the current 
     ///    drive is used.

--- a/SimTKcommon/include/SimTKcommon/internal/Pathname.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Pathname.h
@@ -87,28 +87,7 @@ namespace SimTK {
  */
 class SimTK_SimTKCOMMON_EXPORT Pathname {
 public:
-    /// Given a specified working directory (swd) and path, this function
-    /// evaluates the absolute path of a given path relative to the swd and
-    /// returns the directory, fileName, and extension of the canonicalized path
-    /// with respect to a swd, if needed. This means, for the path, that instead of 
-    /// evaluating "." as the current working directory (cwd), the swd is used. This
-    /// function also returns a boolean (dontApplySearchPath) to indicate if a search
-    /// path should not be applied. The following rules are applied in order:
-    /// 1) If an absolute path is given by path, swd is not used. An absolute path
-    ///    is defined as a a root-relative path name and on Windows it may begin 
-    ///    with a drive letter (e.g. /usr/file.ext or c:/documents/file.ext).
-    /// 2) If a relative path without a drive letter is given by path (e.g. "./dir/file.ext" 
-    ///    or "dir/file.ext"), then the absolute path of the swd is prepended to path.
-    /// 3) To resolve drive ambiguities, if swd provides a drive, it is used. 
-    ///    If not, then the path drive is used (e.g. path = "X:dir/file.ext"). If neither 
-    ///    provides a drive, then the current drive is used.
-    /// 4) If swd is an empty string, then swd = cwd.
-    static void deconstructPathnameUsingSpecifiedWorkingDirectory(const std::string& swd,
-                                             const std::string& path,
-                                             std::string& directory,
-                                             std::string& fileName,
-                                             std::string& extension,
-                                             bool& dontApplySearchPath);
+
 
     /// Dismantle a supplied pathname into its component
     /// parts. This can take pathnames like <pre>   
@@ -154,6 +133,35 @@ public:
                                         std::string& fileName,
                                         std::string& extension);
 
+    /// An extension of deconstructPathname(). Given a specified working directory 
+    /// (swd) and path, this function evaluates the absolute path of a given path
+    /// relative to the swd and returns the directory, fileName, and extension of 
+    /// the canonicalized path with respect to a swd, if needed. This means, for 
+    /// the path, that instead of evaluating "." as the current working directory 
+    /// (cwd), the swd is used. Unlike deconstructPathname(), this function will
+    /// always return an absolute path, and no bool isAbsolutePath is returned.
+    /// Rules:
+    /// - If the swd is empty (after removing whitespace), deconstructPathname()
+    ///   is called, and cwd is prepended if needed to make it an absolute path.
+    /// - Otherwise, we evaluate path relative to the swd. These steps are as follows:
+    /// 1) Preprocess the swd. This means that if the swd is of any form that denotes
+    ///    an absolute path (i.e. "C:/file.ext", "C:file.ext", "./file.ext", "/file.ext")
+    ///    we change the swd to reflect the absolute path (e.g. "./file.ext" may change
+    ///    to "/cwd/file.ext" or "C:/cwdOnC/file.ext").
+    /// 2) If path is a root-relative path name (and on Windows this includes a drive) 
+    ///    (e.g. /usr/file.ext or c:/documents/file.ext), then swd is ignored, and the
+    ///    absolute path is returned.
+    /// 3) Otherwise, if a path is given relative to the cwd (e.g. "./dir/file.ext" 
+    ///    or "dir/file.ext"), then the swd is prepended to path.
+    /// 4) To resolve drive ambiguities, if swd provides a drive, it is used. If not, 
+    ///    then the path drive is used. If neither provides a drive, then the current 
+    ///    drive is used.
+    static void deconstructPathnameUsingSpecifiedWorkingDirectory(const std::string& swd,
+                                                                  const std::string& path,
+                                                                  std::string& directory,
+                                                                  std::string& fileName,
+                                                                  std::string& extension);
+
     /// Get canonicalized absolute pathname from a given pathname which 
     /// can be relative or absolute. Canonicalizing means
     ///   - drive designator is recognized if we're on Windows;
@@ -190,14 +198,10 @@ public:
         return absPath;
     }
 
-    static std::string getAbsolutePathnameUsingSpecifiedWorkingDirectory(const std::string& swd,
-                                                                         const std::string& path) {
+    static std::string findAbsolutePathnameUsingSpecifiedWorkingDirectory(const std::string& swd,
+                                                                          const std::string& path) {
         std::string directory, fileName, extension;
-        bool dontApplySearchPath;
-        deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-        if (!dontApplySearchPath) {
-            directory = getCurrentWorkingDirectory() + directory;
-        }
+        deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
         return directory + fileName + extension;
     }
 

--- a/SimTKcommon/include/SimTKcommon/internal/Pathname.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Pathname.h
@@ -87,21 +87,21 @@ namespace SimTK {
  */
 class SimTK_SimTKCOMMON_EXPORT Pathname {
 public:
-	/// Given a specified working directory (swd) and path, this function
-	/// evaluates the absolute path of a given path relative to the swd and
-	/// returns the directory, fileName, and extension of the final absolute
-	/// path. In general, some rules followed are as follows
-	/// 1) If a full absolute path is given by path, swd is not used.
-	/// 2) To resolve drive ambiguities, in general, if swd provides a drive,
-	///    it is used. If not, then the path drive is used. If neither provides
-	///    a drive, then the current drive is used.
-	/// 3) If swd is an empty string, then the path is evaluated as normal
-	///    in a shell.
-	static void deconstructPathRelativeToSWD(const std::string& swd,
-											 const std::string& path,
-											 std::string& directory,
-											 std::string& fileName,
-											 std::string& extension);
+    /// Given a specified working directory (swd) and path, this function
+    /// evaluates the absolute path of a given path relative to the swd and
+    /// returns the directory, fileName, and extension of the final absolute
+    /// path. In general, some rules followed are as follows
+    /// 1) If a full absolute path is given by path, swd is not used.
+    /// 2) To resolve drive ambiguities, in general, if swd provides a drive,
+    ///    it is used. If not, then the path drive is used. If neither provides
+    ///    a drive, then the current drive is used.
+    /// 3) If swd is an empty string, then the path is evaluated as normal
+    ///    in a shell.
+    static void deconstructPathRelativeToSWD(const std::string& swd,
+                                             const std::string& path,
+                                             std::string& directory,
+                                             std::string& fileName,
+                                             std::string& extension);
 
     /// Dismantle a supplied pathname into its component
     /// parts. This can take pathnames like <pre>   

--- a/SimTKcommon/include/SimTKcommon/internal/Pathname.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Pathname.h
@@ -89,15 +89,19 @@ class SimTK_SimTKCOMMON_EXPORT Pathname {
 public:
     /// Given a specified working directory (swd) and path, this function
     /// evaluates the absolute path of a given path relative to the swd and
-    /// returns the directory, fileName, and extension of the final absolute
-    /// path. In general, some rules followed are as follows
-    /// 1) If a full absolute path is given by path, swd is not used.
-    /// 2) To resolve drive ambiguities, in general, if swd provides a drive,
-    ///    it is used. If not, then the path drive is used. If neither provides
+    /// returns the directory, fileName, and extension of the canonicalized absolute
+    /// path. This means that instead of evaluating "." as the current working
+    /// directory (cwd), the swd is used. In general, some rules followed are as follows
+    /// 1) If an absolute path is given by path, swd is not used. An absolute path
+    ///    is defined as a a root-relative path name and on Windows it will begin 
+    ///    with an explicit drive letter (e.g. /usr/* or c:/documents/*, respectively).
+    /// 2) If a relative path without a drive letter is given by path (e.g. "./*" or "*"), 
+    ///    then the absolute path of the swd is prepended to path.
+    /// 3) To resolve drive ambiguities, if swd provides a drive, it is used. 
+    ///    If not, then the path drive is used (e.g. path = "X:*"). If neither provides 
     ///    a drive, then the current drive is used.
-    /// 3) If swd is an empty string, then the path is evaluated as normal
-    ///    in a shell.
-    static void deconstructPathRelativeToSWD(const std::string& swd,
+    /// 4) If swd is an empty string, then swd = cwd.
+    static void findAbsolutePathUsingSpecifiedWorkingDirectory(const std::string& swd,
                                              const std::string& path,
                                              std::string& directory,
                                              std::string& fileName,

--- a/SimTKcommon/include/SimTKcommon/internal/Pathname.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Pathname.h
@@ -141,16 +141,18 @@ public:
     /// (cwd), the swd is used. Unlike deconstructPathname(), this function will
     /// always return an absolute path, and no bool dontApplySearchPath is returned.
     /// Rules:
+    /// - If path is empty, directory, fileName and extension will be returned empty.
+    ///   This case probably should just use getCurrentworkingDirectory().
     /// - If the swd is empty (after removing whitespace), deconstructPathname()
     ///   is called, and cwd is prepended if needed to make it an absolute path.
     /// - Otherwise, we evaluate path relative to the swd. These steps are as follows:
-    /// 1) Preprocess the swd. This means that if the swd is of any form that denotes
+    /// 1) If path is a root-relative path name (and on Windows this includes a drive) 
+    ///    (e.g. /usr/file.ext or c:/documents/file.ext), then swd is ignored, and the
+    ///    absolute path is returned.
+    /// 2) Preprocess the swd. This means that if the swd is of any form that denotes
     ///    an absolute path (i.e. "C:/file.ext", "C:file.ext", "./file.ext", "/file.ext")
     ///    we change the swd to reflect the absolute path (e.g. "./file.ext" may change
     ///    to "/cwd/file.ext" or "C:/cwdOnC/file.ext").
-    /// 2) If path is a root-relative path name (and on Windows this includes a drive) 
-    ///    (e.g. /usr/file.ext or c:/documents/file.ext), then swd is ignored, and the
-    ///    absolute path is returned.
     /// 3) Otherwise, if a path is given relative to a directory that is not the root 
     ///    (e.g. "./dir/file.ext" or "dir/file.ext"), then the swd is prepended to path.
     /// 4) To resolve drive ambiguities, if swd provides a drive, it is used. If not, 

--- a/SimTKcommon/include/SimTKcommon/internal/Pathname.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Pathname.h
@@ -87,6 +87,22 @@ namespace SimTK {
  */
 class SimTK_SimTKCOMMON_EXPORT Pathname {
 public:
+	/// Given a specified working directory (swd) and path, this function
+	/// evaluates the absolute path of a given path relative to the swd and
+	/// returns the directory, fileName, and extension of the final absolute
+	/// path. In general, some rules followed are as follows
+	/// 1) If a full absolute path is given by path, swd is not used.
+	/// 2) To resolve drive ambiguities, in general, if swd provides a drive,
+	///    it is used. If not, then the path drive is used. If neither provides
+	///    a drive, then the current drive is used.
+	/// 3) If swd is an empty string, then the path is evaluated as normal
+	///    in a shell.
+	static void deconstructPathRelativeToSWD(const std::string& swd,
+											 const std::string& path,
+											 std::string& directory,
+											 std::string& fileName,
+											 std::string& extension);
+
     /// Dismantle a supplied pathname into its component
     /// parts. This can take pathnames like <pre>   
     ///     /usr/local/libMyDll_d.so

--- a/SimTKcommon/src/Pathname.cpp
+++ b/SimTKcommon/src/Pathname.cpp
@@ -139,12 +139,12 @@ static void removeDriveInPlace(string& inout, string& drive) {
 // If there is something ill-formed about the file name we'll return
 // false.
 void Pathname::deconstructPathname( const string&   name,
-                                    bool&           isAbsolutePath,
+                                    bool&           dontApplySearchPath,
                                     string&         directory,
                                     string&         fileName,
                                     string&         extension)
 {
-    isAbsolutePath = false;
+    dontApplySearchPath = false;
     directory.erase(); fileName.erase(); extension.erase();
 
     // Remove all the white space and make all the slashes be forward ones.
@@ -169,17 +169,17 @@ void Pathname::deconstructPathname( const string&   name,
         processed.insert(0, "./");
 
     if (processed.substr(0, 1) == "/") {
-        isAbsolutePath = true;
+        dontApplySearchPath = true;
         processed.erase(0, 1);
         if (drive.empty()) drive = getCurrentDriveLetter();
     }
     else if (processed.substr(0, 2) == "./") {
-        isAbsolutePath = true;
+        dontApplySearchPath = true;
         processed.replace(0, 2, getCurrentWorkingDirectory(drive));
         removeDriveInPlace(processed, drive);
     }
     else if (processed.substr(0, 2) == "@/") {
-        isAbsolutePath = true;
+        dontApplySearchPath = true;
         processed.replace(0, 2, getThisExecutableDirectory());
         removeDriveInPlace(processed, drive);
     }
@@ -188,7 +188,7 @@ void Pathname::deconstructPathname( const string&   name,
         // drive specification, e.g. X:something.txt, that is supposed
         // to be interpreted relative to the current working directory
         // on drive X, just as though it were X:./something.txt.
-        isAbsolutePath = true;
+        dontApplySearchPath = true;
         processed.insert(0, getCurrentWorkingDirectory(drive));
         removeDriveInPlace(processed, drive);
     }
@@ -220,7 +220,7 @@ void Pathname::deconstructPathname( const string&   name,
     }
 
     // Now we can put together the canonicalized directory.
-    if (isAbsolutePath) {
+    if (dontApplySearchPath) {
         if (!drive.empty())
             directory = drive + ":";
         directory += "/";
@@ -264,9 +264,9 @@ void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::stri
 
     // If swd is empty (or only white space) then use deconstructPathname().
     if (swdcleaned.empty() && swddrive.empty()) {
-        bool isAbsolutePath;
-        deconstructPathname(path, isAbsolutePath, directory, fileName, extension);
-        if (!isAbsolutePath)
+        bool dontApplySearchPath;
+        deconstructPathname(path, dontApplySearchPath, directory, fileName, extension);
+        if (!dontApplySearchPath)
             directory = getCurrentWorkingDirectory() + directory;
 
     // swd was not empty. If necessary, preprocess the swd. Then concatenate swd and path.

--- a/SimTKcommon/src/Pathname.cpp
+++ b/SimTKcommon/src/Pathname.cpp
@@ -110,157 +110,6 @@ static void removeDriveInPlace(string& inout, string& drive) {
     }
 }
 
-void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::string& swd,
-                                            const std::string& path,
-                                            std::string& directory,
-                                            std::string& fileName,
-                                            std::string& extension,
-                                            bool& dontApplySearchPath)
-{
-    directory.erase(); fileName.erase(); extension.erase();
-    string pathdrive, swddrive, finaldrive;
-    dontApplySearchPath = false;
-
-    // Remove all the white space and make all the slashes be forward ones.
-    // (For Windows they'll be changed to backslashes later.)
-    String pathcleaned = String::trimWhiteSpace(path).replaceAllChar('\\', '/');
-    if (pathcleaned.empty())
-        return; // path consisted only of white space
-    removeDriveInPlace(pathcleaned, pathdrive);
-
-    // Check for a drive, then map swd to an absolute path name if no drive given
-    String swdcleaned = String::trimWhiteSpace(swd).replaceAllChar('\\', '/');
-    if (!swdcleaned.empty() && swdcleaned[swdcleaned.size() - 1] != '/')
-        swdcleaned += '/';
-    removeDriveInPlace(swdcleaned, swddrive);
-
-    String processed;
-    if (pathcleaned.substr(0, 1) == "/" || pathcleaned.substr(0, 2) == "@/") {
-        processed = pathcleaned;
-        if (!pathdrive.empty()) swddrive = "";
-    }
-    else if (pathcleaned.substr(0, 2) == "./") {
-        if (!swd.empty()) {
-            pathcleaned.erase(0, 2);
-            processed = swdcleaned + pathcleaned;
-        }
-        else {
-            processed = pathcleaned;
-        }
-    }
-    // Looks like a relative path name.
-    else {
-        processed = swdcleaned + pathcleaned;
-    }
-
-    // If the pathname in its entirety is just one of these, append 
-    // a slash to avoid special cases below.
-    if (processed == "." || processed == ".." || processed == "@")
-        processed += "/";
-
-    // If the path begins with "../" we'll make it ./../ to simplify handling.
-    if (processed.substr(0, 3) == "../")
-        processed.insert(0, "./");
-
-    if (processed.substr(0, 1) == "/") {
-        dontApplySearchPath = true;
-        processed.erase(0, 1);
-        if (!swddrive.empty()) finaldrive = swddrive;
-        else if (!pathdrive.empty()) finaldrive = pathdrive;
-        else finaldrive = getCurrentDriveLetter();
-    }
-    else if (processed.substr(0, 2) == "./") {
-        dontApplySearchPath = true;
-        String discard;
-        // If swd was empty, then "./" came from path. Make sure not to write
-        // over current pathdrive or swddrive.
-        if (swd.empty()) {
-            processed.replace(0, 2, getCurrentWorkingDirectory(pathdrive));
-            removeDriveInPlace(processed, discard);
-        }
-        // Otherwise, "./" came from swd
-        else {
-            processed.replace(0, 2, getCurrentWorkingDirectory(swddrive));
-            removeDriveInPlace(processed, discard);
-        }
-        if (!swddrive.empty()) finaldrive = swddrive;
-        else if (!pathdrive.empty()) finaldrive = pathdrive;
-        else finaldrive = getCurrentDriveLetter();
-    }
-    else if (processed.substr(0, 2) == "@/") {
-        dontApplySearchPath = true;
-        processed.replace(0, 2, getThisExecutableDirectory());
-        removeDriveInPlace(processed, finaldrive);
-    }
-    // Looks like a relative path name. But if either swd or path had 
-    // an initial drive specification, e.g. X:something.txt, that is 
-    // supposed to be interpreted relative to the current working directory
-    // on drive X, just as though it were X:./something.txt.
-    // Check swd first as its drive takes precedence.
-    else if (!swddrive.empty()) {
-        dontApplySearchPath = true;
-        processed.insert(0, getCurrentWorkingDirectory(swddrive));
-        removeDriveInPlace(processed, finaldrive);
-    }
-    else if (!pathdrive.empty()) {
-        dontApplySearchPath = true;
-        // Even if swd did not provide a drive, swd may not have been empty.
-        // Make sure to still use pathdrive.
-        if (!swd.empty()) {
-            processed.insert(0, getCurrentWorkingDirectory(swddrive));
-            removeDriveInPlace(processed, swddrive);
-            finaldrive = pathdrive;
-        }
-        else {
-            processed.insert(0, getCurrentWorkingDirectory(pathdrive));
-            removeDriveInPlace(processed, finaldrive);
-        }
-        
-    }
-
-    // We may have picked up a new batch of backslashes above.
-    processed.replaceAllChar('\\', '/');
-
-    // Process the ".." segments and eliminate meaningless ones
-    // as we go through.
-    Array_<string> segmentsInReverse;
-    bool isFinalSegment = true; // first time around might be the fileName
-    int numDotDotsSeen = 0;
-    while (!processed.empty()) {
-        string component;
-        removeLastPathComponentInPlace(processed, component);
-        if (component == "..")
-            ++numDotDotsSeen;
-        else if (!component.empty() && component != ".") {
-            if (numDotDotsSeen)
-                --numDotDotsSeen;   // skip component
-            else if (isFinalSegment) fileName = component;
-            else segmentsInReverse.push_back(component);
-        }
-        isFinalSegment = false;
-    }
-
-    // Now we can put together the canonicalized directory.
-    if (dontApplySearchPath) {
-        if (!finaldrive.empty())
-            directory = finaldrive + ":";
-        directory += "/";
-    }
-
-    for (int i = (int)segmentsInReverse.size() - 1; i >= 0; --i)
-        directory += segmentsInReverse[i] + "/";
-
-    // Fix the slashes.
-    makeNativeSlashesInPlace(directory);
-
-    // If there is a .extension, strip it off.
-    string::size_type lastDot = fileName.rfind('.');
-    if (lastDot != string::npos) {
-        extension = fileName.substr(lastDot);
-        fileName.erase(lastDot);
-    }
-}
-
 // We assume a path name structure like this:
 //   (1) Everything up to and including the final directory separator
 //       character is the directory; the rest is the file name. On return
@@ -268,7 +117,7 @@ void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::stri
 //       system ('\' for Windows, '/' otherwise).
 //   (2) If the file name contains a ".", characters after the last
 //       "." are the extension and the last "." is removed.
-//   (5) What's left is the fileName.
+//   (3) What's left is the fileName.
 // We accept both "/" and "\" as separator characters. We leave the
 // case as it was supplied.
 // Leading and trailing white space is removed; embedded white space
@@ -295,7 +144,255 @@ void Pathname::deconstructPathname( const string&   name,
                                     string&         fileName,
                                     string&         extension)
 {
-    deconstructPathnameUsingSpecifiedWorkingDirectory("", name, directory, fileName, extension, isAbsolutePath);
+    isAbsolutePath = false;
+    directory.erase(); fileName.erase(); extension.erase();
+
+    // Remove all the white space and make all the slashes be forward ones.
+    // (For Windows they'll be changed to backslashes later.)
+    String processed = String::trimWhiteSpace(name).replaceAllChar('\\', '/');
+    if (processed.empty())
+        return; // name consisted only of white space
+
+    string drive;
+    removeDriveInPlace(processed, drive);
+
+    // Now the drive if any has been removed and we're looking at
+    // the beginning of the path name. 
+
+    // If the pathname in its entirety is just one of these, append 
+    // a slash to avoid special cases below.
+    if (processed == "." || processed == ".." || processed == "@")
+        processed += "/";
+
+    // If the path begins with "../" we'll make it ./../ to simplify handling.
+    if (processed.substr(0, 3) == "../")
+        processed.insert(0, "./");
+
+    if (processed.substr(0, 1) == "/") {
+        isAbsolutePath = true;
+        processed.erase(0, 1);
+        if (drive.empty()) drive = getCurrentDriveLetter();
+    }
+    else if (processed.substr(0, 2) == "./") {
+        isAbsolutePath = true;
+        processed.replace(0, 2, getCurrentWorkingDirectory(drive));
+        removeDriveInPlace(processed, drive);
+    }
+    else if (processed.substr(0, 2) == "@/") {
+        isAbsolutePath = true;
+        processed.replace(0, 2, getThisExecutableDirectory());
+        removeDriveInPlace(processed, drive);
+    }
+    else if (!drive.empty()) {
+        // Looks like a relative path name. But if it had an initial
+        // drive specification, e.g. X:something.txt, that is supposed
+        // to be interpreted relative to the current working directory
+        // on drive X, just as though it were X:./something.txt.
+        isAbsolutePath = true;
+        processed.insert(0, getCurrentWorkingDirectory(drive));
+        removeDriveInPlace(processed, drive);
+    }
+
+    // We may have picked up a new batch of backslashes above.
+    processed.replaceAllChar('\\', '/');
+
+    // Now we have the full path name if this is absolute, otherwise
+    // we're looking at a relative path name. In any case the last
+    // component is the file name if it isn't empty, ".", or "..".
+
+    // Process the ".." segments and eliminate meaningless ones
+    // as we go through.
+    Array_<string> segmentsInReverse;
+    bool isFinalSegment = true; // first time around might be the fileName
+    int numDotDotsSeen = 0;
+    while (!processed.empty()) {
+        string component;
+        removeLastPathComponentInPlace(processed, component);
+        if (component == "..")
+            ++numDotDotsSeen;
+        else if (!component.empty() && component != ".") {
+            if (numDotDotsSeen)
+                --numDotDotsSeen;   // skip component
+            else if (isFinalSegment) fileName = component;
+            else segmentsInReverse.push_back(component);
+        }
+        isFinalSegment = false;
+    }
+
+    // Now we can put together the canonicalized directory.
+    if (isAbsolutePath) {
+        if (!drive.empty())
+            directory = drive + ":";
+        directory += "/";
+    }
+
+    for (int i = (int)segmentsInReverse.size() - 1; i >= 0; --i)
+        directory += segmentsInReverse[i] + "/";
+
+    // Fix the slashes.
+    makeNativeSlashesInPlace(directory);
+
+    // If there is a .extension, strip it off.
+    string::size_type lastDot = fileName.rfind('.');
+    if (lastDot != string::npos) {
+        extension = fileName.substr(lastDot);
+        fileName.erase(lastDot);
+    }
+}
+
+void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::string& swd,
+                                                                 const std::string& path,
+                                                                 std::string& directory,
+                                                                 std::string& fileName,
+                                                                 std::string& extension)
+{
+    directory.erase(); fileName.erase(); extension.erase();
+    string pathdrive, swddrive, finaldrive;
+    String processed;
+
+    // Remove all the white space and make all the slashes be forward ones.
+    // (For Windows they'll be changed to backslashes later.)
+    String pathcleaned = String::trimWhiteSpace(path).replaceAllChar('\\', '/');
+    if (pathcleaned.empty())
+        return; // path consisted only of white space
+    removeDriveInPlace(pathcleaned, pathdrive);
+
+    String swdcleaned = String::trimWhiteSpace(swd).replaceAllChar('\\', '/');
+    if (!swdcleaned.empty() && swdcleaned[swdcleaned.size() - 1] != '/')
+        swdcleaned += '/';
+    removeDriveInPlace(swdcleaned, swddrive);
+
+    // If swd is empty (or only white space) then use deconstructPathname().
+    if (swdcleaned.empty() && swddrive.empty()) {
+        bool isAbsolutePath;
+        deconstructPathname(path, isAbsolutePath, directory, fileName, extension);
+        if (!isAbsolutePath)
+            directory = getCurrentWorkingDirectory() + directory;
+
+    // swd was not empty. If necessary, preprocess the swd. Then concatenate swd and path.
+    // Finally, resolve drives.
+    }
+    else {
+        /* PREPROCESSING THE SWD. */
+        // Preprocess the swd if it leads with a "./"
+        if (swdcleaned.substr(0, 2) == "./") {
+            swdcleaned.replace(0, 2, getCurrentWorkingDirectory(swddrive));
+            removeDriveInPlace(swdcleaned, swddrive);
+            swdcleaned.insert(0, "/"); // ensure swd starts with "/" to denote full path
+        }
+        // Also preprocess the swd if it leads with "/". Just grab current drive letter.
+        else if (swdcleaned.substr(0, 1) == "/" && swddrive.empty()) {
+            swddrive = getCurrentDriveLetter();
+        }
+        // Also preprocess if swd starts with something of the form "C:folder/". Resolve
+        // by finding the current directory of this drive.
+        else if (!swddrive.empty()) {
+            swdcleaned.insert(0, getCurrentWorkingDirectory(swddrive));
+            removeDriveInPlace(swdcleaned, swddrive);
+            swdcleaned.insert(0, "/"); // ensure swd starts with "/" to denote full path
+        }
+
+        /* CHECKING IF THE SWD SHOULD BE PREPENDED TO THE PATH. */
+        // If path was an absolute path (on Windows this includes a drive or begins with "@/")
+        // then we should not prepend the swd.
+        if (pathcleaned.substr(0, 1) == "/" || pathcleaned.substr(0, 2) == "@/") {
+            processed = pathcleaned;
+            // Ensure that if there was a pathdrive, ignore the swddrive.
+            if (!pathdrive.empty()) swddrive = "";
+        }
+
+        // If path starts with "./", we remove the "./" and concatenate with swdcleaned.
+        else if (pathcleaned.substr(0, 2) == "./") {
+            pathcleaned.erase(0, 2);
+            processed = swdcleaned + pathcleaned;
+        }
+        // Looks like a relative path name (i.e. pathcleaned starts immediately with
+        // a directory or file name).
+        else {
+            processed = swdcleaned + pathcleaned;
+        }
+
+        // If the pathname in its entirety is just one of these, append 
+        // a slash to avoid special cases below.
+        if (processed == "." || processed == ".." || processed == "@")
+            processed += "/";
+
+        // If the path begins with "../" we'll make it ./../ to simplify handling.
+        if (processed.substr(0, 3) == "../")
+            processed.insert(0, "./");
+
+        /* RESOLVING THE FULL PATH */
+        // Full path is determined except for drive letter. Resolve drive letter with
+        // swd, then path, then current drive.
+        if (processed.substr(0, 1) == "/") {
+            processed.erase(0, 1);
+            if (!swddrive.empty()) finaldrive = swddrive;
+            else if (!pathdrive.empty()) finaldrive = pathdrive;
+            else finaldrive = getCurrentDriveLetter();
+        }
+
+        else if (processed.substr(0, 2) == "@/") {
+            processed.replace(0, 2, getThisExecutableDirectory());
+            removeDriveInPlace(processed, finaldrive);
+        }
+        // Looks like a relative path name. But if either path had 
+        // an initial drive specification, e.g. X:something.txt, that is 
+        // supposed to be interpreted relative to the current working directory
+        // on drive X, just as though it were X:./something.txt.
+        // Note that we do not need to check swd as it has either been preprocessed
+        // (and thus has been taken care of in the "/" case) or is of the form 
+        // "folder/file.ext".
+        else if (!pathdrive.empty()) {
+            processed.insert(0, getCurrentWorkingDirectory(pathdrive));
+            removeDriveInPlace(processed, finaldrive);
+        }
+        
+        // Must be a relative pathname. Just prepend the current working directory.
+        else {
+            processed.insert(0, getCurrentWorkingDirectory());
+            removeDriveInPlace(processed, finaldrive);
+        }
+
+        // We may have picked up a new batch of backslashes above.
+        processed.replaceAllChar('\\', '/');
+
+        // Process the ".." segments and eliminate meaningless ones
+        // as we go through.
+        Array_<string> segmentsInReverse;
+        bool isFinalSegment = true; // first time around might be the fileName
+        int numDotDotsSeen = 0;
+        while (!processed.empty()) {
+            string component;
+            removeLastPathComponentInPlace(processed, component);
+            if (component == "..")
+                ++numDotDotsSeen;
+            else if (!component.empty() && component != ".") {
+                if (numDotDotsSeen)
+                    --numDotDotsSeen;   // skip component
+                else if (isFinalSegment) fileName = component;
+                else segmentsInReverse.push_back(component);
+            }
+            isFinalSegment = false;
+        }
+
+        // Now we can put together the canonicalized directory.
+        if (!finaldrive.empty())
+            directory = finaldrive + ":";
+        directory += "/";
+
+        for (int i = (int)segmentsInReverse.size() - 1; i >= 0; --i)
+            directory += segmentsInReverse[i] + "/";
+
+        // Fix the slashes.
+        makeNativeSlashesInPlace(directory);
+
+        // If there is a .extension, strip it off.
+        string::size_type lastDot = fileName.rfind('.');
+        if (lastDot != string::npos) {
+            extension = fileName.substr(lastDot);
+            fileName.erase(lastDot);
+        }
+    }
 }
 
 bool Pathname::fileExists(const std::string& fileName) {

--- a/SimTKcommon/src/Pathname.cpp
+++ b/SimTKcommon/src/Pathname.cpp
@@ -173,17 +173,17 @@ void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::stri
     }
     else if (processed.substr(0, 2) == "./") {
         dontApplySearchPath = true;
-        // If swd was empty, then "./" came from path
+        String discard;
+        // If swd was empty, then "./" came from path. Make sure not to write
+        // over current pathdrive or swddrive.
         if (swd.empty()) {
             processed.replace(0, 2, getCurrentWorkingDirectory(pathdrive));
-            processed.erase(0, 2);
-            //removeDriveInPlace(processed, pathdrive);
+            removeDriveInPlace(processed, discard);
         }
         // Otherwise, "./" came from swd
         else {
             processed.replace(0, 2, getCurrentWorkingDirectory(swddrive));
-            processed.erase(0, 2);
-            //removeDriveInPlace(processed, swddrive);
+            removeDriveInPlace(processed, discard);
         }
         if (!swddrive.empty()) finaldrive = swddrive;
         else if (!pathdrive.empty()) finaldrive = pathdrive;

--- a/SimTKcommon/src/Pathname.cpp
+++ b/SimTKcommon/src/Pathname.cpp
@@ -134,7 +134,6 @@ void Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(const std::string&
     if (swddrive.empty())
         swdcleaned = getAbsoluteDirectoryPathname(swd);
 
-
     // If the pathname in its entirety is just one of these, append 
     // a slash to avoid special cases below.
     if (pathcleaned == "." || pathcleaned == "..")
@@ -153,6 +152,7 @@ void Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(const std::string&
 
     // If swd was not empty, find the correct absolute path to the intended directory.
     else if (!swd.empty()) {
+        
         // Path was of the form "X:/*" or "/*"
         if (pathcleaned.substr(0, 1) == "/") {
             pathcleaned.erase(0, 1);
@@ -170,8 +170,10 @@ void Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(const std::string&
                     finaldrive = getCurrentDriveLetter();
             }
         }
+        
         // Path was of the form "X:./*" or "./*". 
         else if (pathcleaned.substr(0, 2) == "./") {
+           
             // If swd provided a drive, use it
             if (!swddrive.empty()) {
                 finaldrive = swddrive;
@@ -193,6 +195,7 @@ void Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(const std::string&
 
         // Path was of the form "X:*" or "*"
         else {
+            
             // If swd provided a drive, use it
             if (!swddrive.empty()) {
                 finaldrive = swddrive;
@@ -203,9 +206,7 @@ void Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(const std::string&
             // has a path, use the absolute path of the swd.
             else if (swddrive.empty()) {
                 string swdfullpath = getAbsoluteDirectoryPathname(swdcleaned);
-                
                 removeDriveInPlace(swdfullpath, swddrive);
-                
                 if (!pathdrive.empty())
                     finaldrive = pathdrive;
                 else if (pathdrive.empty())

--- a/SimTKcommon/src/Pathname.cpp
+++ b/SimTKcommon/src/Pathname.cpp
@@ -269,10 +269,7 @@ void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::stri
     String pathcleaned = String::trimWhiteSpace(path).replaceAllChar('\\', '/');
     // If path is an absolute path, then just call deconstructPathname() on the path.
     if (isAbsolutePath(pathcleaned) || isExecutableDirectoryPath(pathcleaned)) {
-        bool dontApplySearchPath;
-        deconstructPathname(path, dontApplySearchPath, directory, fileName, extension);
-        if (!dontApplySearchPath)
-            directory = getCurrentWorkingDirectory() + directory;
+        deconstructAbsolutePathname(path, directory, fileName, extension);
         return;
     }
     if (pathcleaned.empty())
@@ -282,10 +279,7 @@ void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::stri
     String swdcleaned = String::trimWhiteSpace(swd).replaceAllChar('\\', '/');
     // If swd was empty, then just call deconstructPathname() on the path.
     if (swdcleaned.empty()) {
-        bool dontApplySearchPath;
-        deconstructPathname(path, dontApplySearchPath, directory, fileName, extension);
-        if (!dontApplySearchPath) 
-            directory = getCurrentWorkingDirectory() + directory;
+        deconstructAbsolutePathname(path, directory, fileName, extension);
         return;
     }
 
@@ -371,13 +365,11 @@ void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::stri
         removeDriveInPlace(processed, finaldrive);
     }
 
-    bool dontApplySearchPath;
-    processed.insert(0, "/");
-    if (!finaldrive.empty())
-        processed.insert(0, finaldrive + ":");
-    deconstructPathname(processed, dontApplySearchPath, directory, fileName, extension);
-    if (!dontApplySearchPath)
-        directory = getCurrentWorkingDirectory() + directory;
+    // Build up the final path name, then use deconstructAbsolutePathname() to
+    // find the final directory, fileName, and extension.
+    if (processed.substr(0, 1) != "/") processed.insert(0, "/");
+    if (!finaldrive.empty()) processed.insert(0, finaldrive + ":");
+    deconstructAbsolutePathname(processed, directory, fileName, extension);
 }
 
 bool Pathname::fileExists(const std::string& fileName) {

--- a/SimTKcommon/src/Pathname.cpp
+++ b/SimTKcommon/src/Pathname.cpp
@@ -111,161 +111,161 @@ static void removeDriveInPlace(string& inout, string& drive) {
 }
 
 void Pathname::deconstructPathRelativeToSWD(const std::string& swd,
-	const std::string& path,
-	std::string& directory,
-	std::string& fileName,
-	std::string& extension)
+                                            const std::string& path,
+                                            std::string& directory,
+                                            std::string& fileName,
+                                            std::string& extension)
 {
-	directory.erase(); fileName.erase(); extension.erase();
+    directory.erase(); fileName.erase(); extension.erase();
 
-	// Remove all the white space and make all the slashes be forward ones.
-	// (For Windows they'll be changed to backslashes later.)
-	String pathcleaned = String::trimWhiteSpace(path).replaceAllChar('\\', '/');
-	if (pathcleaned.empty())
-		return; // path consisted only of white space
+    // Remove all the white space and make all the slashes be forward ones.
+    // (For Windows they'll be changed to backslashes later.)
+    String pathcleaned = String::trimWhiteSpace(path).replaceAllChar('\\', '/');
+    if (pathcleaned.empty())
+        return; // path consisted only of white space
 
-	// Remove all the white space and make all the slashes be forward ones.
-	// (For Windows they'll be changed to backslashes later.)
-	// Then add a path seprator if needed.
-	String swdcleaned = String::trimWhiteSpace(swd).replaceAllChar('\\', '/');
-	if (!swdcleaned.empty() && swdcleaned[swdcleaned.size() - 1] != getPathSeparatorChar())
-		swdcleaned += getPathSeparatorChar();
+    // Remove all the white space and make all the slashes be forward ones.
+    // (For Windows they'll be changed to backslashes later.)
+    // Then add a path seprator if needed.
+    String swdcleaned = String::trimWhiteSpace(swd).replaceAllChar('\\', '/');
+    if (!swdcleaned.empty() && swdcleaned[swdcleaned.size() - 1] != getPathSeparatorChar())
+        swdcleaned += "/";
 
-	string pathdrive, swddrive, finaldrive;
-	removeDriveInPlace(pathcleaned, pathdrive);
-	removeDriveInPlace(swdcleaned, swddrive);
+    string pathdrive, swddrive, finaldrive;
+    removeDriveInPlace(pathcleaned, pathdrive);
+    removeDriveInPlace(swdcleaned, swddrive);
 
 
-	// If the pathname in its entirety is just one of these, append 
-	// a slash to avoid special cases below.
-	if (pathcleaned == "." || pathcleaned == "..")
-		pathcleaned += "/";
+    // If the pathname in its entirety is just one of these, append 
+    // a slash to avoid special cases below.
+    if (pathcleaned == "." || pathcleaned == "..")
+        pathcleaned += "/";
 
-	// If the path begins with "../" we'll make it ./../ to simplify handling.
-	if (pathcleaned.substr(0, 3) == "../")
-		pathcleaned.insert(0, "./");
-	
-	// If swd is empty, then process path as usual.
-	if (swd.empty()) {
-		
-		if (pathcleaned.substr(0, 1) == "/") {
-			pathcleaned.erase(0, 1);
-			if (pathdrive.empty()) pathdrive = getCurrentDriveLetter();
-		}
-		else if (pathcleaned.substr(0, 2) == "./") {
-			pathcleaned.replace(0, 2, getCurrentWorkingDirectory(pathdrive));
-			removeDriveInPlace(pathcleaned, pathdrive);
-		}
-		// Otherwise, the path was "X:*" or "*", so find the working directory.
-		else {
-			pathcleaned.insert(0, getCurrentWorkingDirectory(pathdrive));
-			removeDriveInPlace(pathcleaned, pathdrive);
-		}
-		finaldrive = pathdrive;
-	}
+    // If the path begins with "../" we'll make it ./../ to simplify handling.
+    if (pathcleaned.substr(0, 3) == "../")
+        pathcleaned.insert(0, "./");
+    
+    // If swd is empty, then process path as usual.
+    if (swd.empty()) {
+        
+        if (pathcleaned.substr(0, 1) == "/") {
+            pathcleaned.erase(0, 1);
+            if (pathdrive.empty()) pathdrive = getCurrentDriveLetter();
+        }
+        else if (pathcleaned.substr(0, 2) == "./") {
+            pathcleaned.replace(0, 2, getCurrentWorkingDirectory(pathdrive));
+            removeDriveInPlace(pathcleaned, pathdrive);
+        }
+        // Otherwise, the path was "X:*" or "*", so find the working directory.
+        else {
+            pathcleaned.insert(0, getCurrentWorkingDirectory(pathdrive));
+            removeDriveInPlace(pathcleaned, pathdrive);
+        }
+        finaldrive = pathdrive;
+    }
 
-	// If swd was not empty, find the correct absolute path to the intended directory.
-	else if (!swd.empty()) {
-		// Path was of the form "X:/*" or "/*"
-		if (pathcleaned.substr(0, 1) == "/") {
-			pathcleaned.erase(0, 1);
+    // If swd was not empty, find the correct absolute path to the intended directory.
+    else if (!swd.empty()) {
+        // Path was of the form "X:/*" or "/*"
+        if (pathcleaned.substr(0, 1) == "/") {
+            pathcleaned.erase(0, 1);
 
-			// Path is of the form "X:/*"
-			if (!pathdrive.empty())
-				finaldrive = pathdrive;
+            // Path is of the form "X:/*"
+            if (!pathdrive.empty())
+                finaldrive = pathdrive;
 
-			// If path does not provide a drive, but swd provides a drive, use it.
-			// If neither provides a drive, use the current drive.
-			else if (pathdrive.empty()) {
-				if (!swddrive.empty())
-					finaldrive = swddrive;
-				else if (swddrive.empty())
-					finaldrive = getCurrentDriveLetter();
-			}
-		}
-		// Path was of the form "X:./*" or "./*". 
-		else if (pathcleaned.substr(0, 2) == "./") {
-			// If swd provided a drive, use it
-			if (!swddrive.empty()) {
-				finaldrive = swddrive;
-				pathcleaned.replace(0, 2, swdcleaned);
-			}
+            // If path does not provide a drive, but swd provides a drive, use it.
+            // If neither provides a drive, use the current drive.
+            else if (pathdrive.empty()) {
+                if (!swddrive.empty())
+                    finaldrive = swddrive;
+                else if (swddrive.empty())
+                    finaldrive = getCurrentDriveLetter();
+            }
+        }
+        // Path was of the form "X:./*" or "./*". 
+        else if (pathcleaned.substr(0, 2) == "./") {
+            // If swd provided a drive, use it
+            if (!swddrive.empty()) {
+                finaldrive = swddrive;
+                pathcleaned.replace(0, 2, swdcleaned);
+            }
 
-			// Otherwise, check if path provided a drive and use it. If neither
-			// has a path, use the absolute path of the swd.
-			else if (swddrive.empty()) {
-				string swdfullpath = getAbsoluteDirectoryPathname(swdcleaned);
-				removeDriveInPlace(swdfullpath, swddrive);
-				if (!pathdrive.empty())
-					finaldrive = pathdrive;
-				else if (pathdrive.empty())
-					finaldrive = swddrive;
-				pathcleaned.replace(0, 2, swdfullpath);
-			}
-		}
+            // Otherwise, check if path provided a drive and use it. If neither
+            // has a path, use the absolute path of the swd.
+            else if (swddrive.empty()) {
+                string swdfullpath = getAbsoluteDirectoryPathname(swdcleaned);
+                removeDriveInPlace(swdfullpath, swddrive);
+                if (!pathdrive.empty())
+                    finaldrive = pathdrive;
+                else if (pathdrive.empty())
+                    finaldrive = swddrive;
+                pathcleaned.replace(0, 2, swdfullpath);
+            }
+        }
 
-		// Path was of the form "X:*" or "*"
-		else {
-			// If swd provided a drive, use it
-			if (!swddrive.empty()) {
-				finaldrive = swddrive;
-				pathcleaned.insert(0, swdcleaned);
-			}
+        // Path was of the form "X:*" or "*"
+        else {
+            // If swd provided a drive, use it
+            if (!swddrive.empty()) {
+                finaldrive = swddrive;
+                pathcleaned.insert(0, swdcleaned);
+            }
 
-			// Otherwise, check if path provided a drive and use it. If neither
-			// has a path, use the absolute path of the swd.
-			else if (swddrive.empty()) {
-				string swdfullpath = getAbsoluteDirectoryPathname(swdcleaned);
-				
-				removeDriveInPlace(swdfullpath, swddrive);
-				
-				if (!pathdrive.empty())
-					finaldrive = pathdrive;
-				else if (pathdrive.empty())
-					finaldrive = swddrive;
-				pathcleaned.insert(0, swdfullpath);
-			}
-		}
-	}
+            // Otherwise, check if path provided a drive and use it. If neither
+            // has a path, use the absolute path of the swd.
+            else if (swddrive.empty()) {
+                string swdfullpath = getAbsoluteDirectoryPathname(swdcleaned);
+                
+                removeDriveInPlace(swdfullpath, swddrive);
+                
+                if (!pathdrive.empty())
+                    finaldrive = pathdrive;
+                else if (pathdrive.empty())
+                    finaldrive = swddrive;
+                pathcleaned.insert(0, swdfullpath);
+            }
+        }
+    }
 
-	// We may have picked up a new batch of backslashes above.
-	pathcleaned.replaceAllChar('\\', '/');
+    // We may have picked up a new batch of backslashes above.
+    pathcleaned.replaceAllChar('\\', '/');
 
-	// Process the ".." segments and eliminate meaningless ones
-	// as we go through.
-	Array_<string> segmentsInReverse;
-	bool isFinalSegment = true; // first time around might be the fileName
-	int numDotDotsSeen = 0;
-	while (!pathcleaned.empty()) {
-		string component;
-		removeLastPathComponentInPlace(pathcleaned, component);
-		if (component == "..")
-			++numDotDotsSeen;
-		else if (!component.empty() && component != ".") {
-			if (numDotDotsSeen)
-				--numDotDotsSeen;   // skip component
-			else if (isFinalSegment) fileName = component;
-			else segmentsInReverse.push_back(component);
-		}
-		isFinalSegment = false;
-	}
-	// Now we can put together the canonicalized directory.
-	if (!finaldrive.empty())
-		directory = finaldrive + ":";
-	directory += "/";
+    // Process the ".." segments and eliminate meaningless ones
+    // as we go through.
+    Array_<string> segmentsInReverse;
+    bool isFinalSegment = true; // first time around might be the fileName
+    int numDotDotsSeen = 0;
+    while (!pathcleaned.empty()) {
+        string component;
+        removeLastPathComponentInPlace(pathcleaned, component);
+        if (component == "..")
+            ++numDotDotsSeen;
+        else if (!component.empty() && component != ".") {
+            if (numDotDotsSeen)
+                --numDotDotsSeen;   // skip component
+            else if (isFinalSegment) fileName = component;
+            else segmentsInReverse.push_back(component);
+        }
+        isFinalSegment = false;
+    }
+    // Now we can put together the canonicalized directory.
+    if (!finaldrive.empty())
+        directory = finaldrive + ":";
+    directory += "/";
 
-	for (int i = (int)segmentsInReverse.size() - 1; i >= 0; --i)
-		directory += segmentsInReverse[i] + "/";
+    for (int i = (int)segmentsInReverse.size() - 1; i >= 0; --i)
+        directory += segmentsInReverse[i] + "/";
 
-	// Fix the slashes.
-	makeNativeSlashesInPlace(directory);
+    // Fix the slashes.
+    makeNativeSlashesInPlace(directory);
 
-	// If there is a .extension, strip it off.
-	string::size_type lastDot = fileName.rfind('.');
-	if (lastDot != string::npos) {
-		extension = fileName.substr(lastDot);
-		fileName.erase(lastDot);
-	}
+    // If there is a .extension, strip it off.
+    string::size_type lastDot = fileName.rfind('.');
+    if (lastDot != string::npos) {
+        extension = fileName.substr(lastDot);
+        fileName.erase(lastDot);
+    }
 }
 
 // We assume a path name structure like this:

--- a/SimTKcommon/src/Pathname.cpp
+++ b/SimTKcommon/src/Pathname.cpp
@@ -110,6 +110,163 @@ static void removeDriveInPlace(string& inout, string& drive) {
     }
 }
 
+void Pathname::deconstructPathRelativeToSWD(const std::string& swd,
+	const std::string& path,
+	std::string& directory,
+	std::string& fileName,
+	std::string& extension)
+{
+	directory.erase(); fileName.erase(); extension.erase();
+
+	// Remove all the white space and make all the slashes be forward ones.
+	// (For Windows they'll be changed to backslashes later.)
+	String pathcleaned = String::trimWhiteSpace(path).replaceAllChar('\\', '/');
+	if (pathcleaned.empty())
+		return; // path consisted only of white space
+
+	// Remove all the white space and make all the slashes be forward ones.
+	// (For Windows they'll be changed to backslashes later.)
+	// Then add a path seprator if needed.
+	String swdcleaned = String::trimWhiteSpace(swd).replaceAllChar('\\', '/');
+	if (!swdcleaned.empty() && swdcleaned[swdcleaned.size() - 1] != getPathSeparatorChar())
+		swdcleaned += getPathSeparatorChar();
+
+	string pathdrive, swddrive, finaldrive;
+	removeDriveInPlace(pathcleaned, pathdrive);
+	removeDriveInPlace(swdcleaned, swddrive);
+
+
+	// If the pathname in its entirety is just one of these, append 
+	// a slash to avoid special cases below.
+	if (pathcleaned == "." || pathcleaned == "..")
+		pathcleaned += "/";
+
+	// If the path begins with "../" we'll make it ./../ to simplify handling.
+	if (pathcleaned.substr(0, 3) == "../")
+		pathcleaned.insert(0, "./");
+	
+	// If swd is empty, then process path as usual.
+	if (swd.empty()) {
+		
+		if (pathcleaned.substr(0, 1) == "/") {
+			pathcleaned.erase(0, 1);
+			if (pathdrive.empty()) pathdrive = getCurrentDriveLetter();
+		}
+		else if (pathcleaned.substr(0, 2) == "./") {
+			pathcleaned.replace(0, 2, getCurrentWorkingDirectory(pathdrive));
+			removeDriveInPlace(pathcleaned, pathdrive);
+		}
+		// Otherwise, the path was "X:*" or "*", so find the working directory.
+		else {
+			pathcleaned.insert(0, getCurrentWorkingDirectory(pathdrive));
+			removeDriveInPlace(pathcleaned, pathdrive);
+		}
+		finaldrive = pathdrive;
+	}
+
+	// If swd was not empty, find the correct absolute path to the intended directory.
+	else if (!swd.empty()) {
+		// Path was of the form "X:/*" or "/*"
+		if (pathcleaned.substr(0, 1) == "/") {
+			pathcleaned.erase(0, 1);
+
+			// Path is of the form "X:/*"
+			if (!pathdrive.empty())
+				finaldrive = pathdrive;
+
+			// If path does not provide a drive, but swd provides a drive, use it.
+			// If neither provides a drive, use the current drive.
+			else if (pathdrive.empty()) {
+				if (!swddrive.empty())
+					finaldrive = swddrive;
+				else if (swddrive.empty())
+					finaldrive = getCurrentDriveLetter();
+			}
+		}
+		// Path was of the form "X:./*" or "./*". 
+		else if (pathcleaned.substr(0, 2) == "./") {
+			// If swd provided a drive, use it
+			if (!swddrive.empty()) {
+				finaldrive = swddrive;
+				pathcleaned.replace(0, 2, swdcleaned);
+			}
+
+			// Otherwise, check if path provided a drive and use it. If neither
+			// has a path, use the absolute path of the swd.
+			else if (swddrive.empty()) {
+				string swdfullpath = getAbsoluteDirectoryPathname(swdcleaned);
+				removeDriveInPlace(swdfullpath, swddrive);
+				if (!pathdrive.empty())
+					finaldrive = pathdrive;
+				else if (pathdrive.empty())
+					finaldrive = swddrive;
+				pathcleaned.replace(0, 2, swdfullpath);
+			}
+		}
+
+		// Path was of the form "X:*" or "*"
+		else {
+			// If swd provided a drive, use it
+			if (!swddrive.empty()) {
+				finaldrive = swddrive;
+				pathcleaned.insert(0, swdcleaned);
+			}
+
+			// Otherwise, check if path provided a drive and use it. If neither
+			// has a path, use the absolute path of the swd.
+			else if (swddrive.empty()) {
+				string swdfullpath = getAbsoluteDirectoryPathname(swdcleaned);
+				
+				removeDriveInPlace(swdfullpath, swddrive);
+				
+				if (!pathdrive.empty())
+					finaldrive = pathdrive;
+				else if (pathdrive.empty())
+					finaldrive = swddrive;
+				pathcleaned.insert(0, swdfullpath);
+			}
+		}
+	}
+
+	// We may have picked up a new batch of backslashes above.
+	pathcleaned.replaceAllChar('\\', '/');
+
+	// Process the ".." segments and eliminate meaningless ones
+	// as we go through.
+	Array_<string> segmentsInReverse;
+	bool isFinalSegment = true; // first time around might be the fileName
+	int numDotDotsSeen = 0;
+	while (!pathcleaned.empty()) {
+		string component;
+		removeLastPathComponentInPlace(pathcleaned, component);
+		if (component == "..")
+			++numDotDotsSeen;
+		else if (!component.empty() && component != ".") {
+			if (numDotDotsSeen)
+				--numDotDotsSeen;   // skip component
+			else if (isFinalSegment) fileName = component;
+			else segmentsInReverse.push_back(component);
+		}
+		isFinalSegment = false;
+	}
+	// Now we can put together the canonicalized directory.
+	if (!finaldrive.empty())
+		directory = finaldrive + ":";
+	directory += "/";
+
+	for (int i = (int)segmentsInReverse.size() - 1; i >= 0; --i)
+		directory += segmentsInReverse[i] + "/";
+
+	// Fix the slashes.
+	makeNativeSlashesInPlace(directory);
+
+	// If there is a .extension, strip it off.
+	string::size_type lastDot = fileName.rfind('.');
+	if (lastDot != string::npos) {
+		extension = fileName.substr(lastDot);
+		fileName.erase(lastDot);
+	}
+}
 
 // We assume a path name structure like this:
 //   (1) Everything up to and including the final directory separator

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -191,234 +191,233 @@ void testPathname() {
         && directory=="topdir"+sep+"seconddir"+sep
         && fileName=="myFileName" && extension==".ext");
 
-	std::string swd, path;
-	const std::string cwd = Pathname::getCurrentWorkingDirectory();
-	std::string cwd_nodrive = cwd; cwd_nodrive.erase(0,3);
-	const std::string cwdX = Pathname::getCurrentWorkingDirectory("x");
-	const std::string cwdY = Pathname::getCurrentWorkingDirectory("y");
+    std::string swd, path;
+    const std::string cwd = Pathname::getCurrentWorkingDirectory();
+    std::string cwd_nodrive = cwd; cwd_nodrive.erase(0,3);
+    const std::string cwdX = Pathname::getCurrentWorkingDirectory("x");
+    const std::string cwdY = Pathname::getCurrentWorkingDirectory("y");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "";
-	path = "X:/topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "";
+    path = "X:/topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "";
-	path = "/topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "";
+    path = "/topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "";
-	path = "X:topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == cwdX + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "";
+    path = "X:topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == cwdX + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "";
-	path = "./topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == cwd + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "";
+    path = "./topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == cwd + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "";
-	path = "topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == cwd + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "";
+    path = "topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == cwd + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	///
+    ///
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "Y:/specified";
-	path = "X:/topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "Y:/specified";
+    path = "X:/topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "Y:/specified";
-	path = "/topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "y:" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "Y:/specified";
+    path = "/topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "y:" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "Y:/specified";
-	path = "X:topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "Y:/specified";
+    path = "X:topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "Y:/specified";
-	path = "./topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "Y:/specified";
+    path = "./topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "Y:/specified";
-	path = "topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "Y:/specified";
+    path = "topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	///
+    ///
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "/specified";
-	path = "X:/topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "/specified";
+    path = "X:/topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "/specified";
-	path = "/topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "/specified";
+    path = "/topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "/specified";
-	path = "X:topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "x:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "/specified";
+    path = "X:topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "x:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "/specified";
-	path = "./topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "/specified";
+    path = "./topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "/specified";
-	path = "topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "/specified";
+    path = "topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	///
+    ///
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "Y:specified";
-	path = "X:/topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "Y:specified";
+    path = "X:/topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "Y:specified";
-	path = "/topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory ==  "y:" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "Y:specified";
+    path = "/topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory ==  "y:" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "Y:specified";
-	path = "X:topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "Y:specified";
+    path = "X:topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "Y:specified";
-	path = "./topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "Y:specified";
+    path = "./topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "Y:specified";
-	path = "topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "Y:specified";
+    path = "topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	///
+    ///
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "./specified";
-	path = "X:/topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "./specified";
+    path = "X:/topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "./specified";
-	path = "/topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "./specified";
+    path = "/topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "./specified";
-	path = "X:topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "./specified";
+    path = "X:topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "./specified";
-	path = "./topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "./specified";
+    path = "./topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "./specified";
-	path = "topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "./specified";
+    path = "topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	///
+    ///
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "specified";
-	path = "X:/topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "specified";
+    path = "X:/topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "specified";
-	path = "/topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "specified";
+    path = "/topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "specified";
-	path = "X:topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	cout << directory << endl;
-	SimTK_TEST(directory == "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "specified";
+    path = "X:topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    cout << directory << endl;
+    SimTK_TEST(directory == "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "specified";
-	path = "./topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "specified";
+    path = "./topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	directory = fileName = extension = "junk"; isAbsPath = true;
-	swd = "specified";
-	path = "topdir/seconddir/myFileName.ext";
-	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-	SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
-		&& fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; isAbsPath = true;
+    swd = "specified";
+    path = "topdir/seconddir/myFileName.ext";
+    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
+        && fileName == "myFileName" && extension == ".ext");
 
-	
 }
 
 void testPlugin() {

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -193,6 +193,7 @@ void testPathname() {
 
 #ifdef _WIN32
     std::string swd, path, dir;
+    bool dontApplySearchPath;
     const std::string cwd = Pathname::getCurrentWorkingDirectory();
     std::string cwd_nodrive = cwd; cwd_nodrive.erase(0,3);
     const std::string cwdX = Pathname::getCurrentWorkingDirectory("x");
@@ -200,323 +201,323 @@ void testPathname() {
 
     swd = ""; path = "X:/topdir/seconddir/myFileName.ext";
     dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = ""; path = "/topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = ""; path = "X:topdir/seconddir/myFileName.ext";
     dir = cwdX + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = ""; path = "./topdir/seconddir/myFileName.ext";
     dir = cwd + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = ""; path = "topdir/seconddir/myFileName.ext";
-    dir = cwd + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    dir = "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk"; dontApplySearchPath = true;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
 
     ///
 
     swd = "Y:/specified"; path = "X:/topdir/seconddir/myFileName.ext";
     dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "Y:/specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "Y:/specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "Y:/specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "Y:/specified"; path = "topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     ///
 
     swd = "/specified"; path = "X:/topdir/seconddir/myFileName.ext";
     dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "/specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "/specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = "x:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "/specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "/specified"; path = "topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     ///
 
     swd = "Y:specified"; path = "X:/topdir/seconddir/myFileName.ext";
     dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "Y:specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "Y:specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "Y:specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "Y:specified"; path = "topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     ///
 
     swd = "./specified"; path = "X:/topdir/seconddir/myFileName.ext";
     dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "./specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "./specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "./specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "./specified"; path = "topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     ///
 
     swd = "specified"; path = "X:/topdir/seconddir/myFileName.ext";
     dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "specified"; path = "./topdir/seconddir/myFileName.ext";
-    dir = curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    dir = "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk"; dontApplySearchPath = true;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
 
     swd = "specified"; path = "topdir/seconddir/myFileName.ext";
-    dir = curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    dir = "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk"; dontApplySearchPath = true;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
 
 #else
     std::string swd, path, dir;
     const std::string cwd = Pathname::getCurrentWorkingDirectory();
 
     swd = ""; path = "X:/topdir/seconddir/myFileName.ext";
-    dir = cwd + "X:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    dir = "X:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk"; dontApplySearchPath = true;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
 
     swd = ""; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = ""; path = "X:topdir/seconddir/myFileName.ext";
-    dir = cwd + "X:topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    dir = "X:topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk"; dontApplySearchPath = true;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
 
     swd = ""; path = "./topdir/seconddir/myFileName.ext";
     dir = cwd + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = ""; path = "topdir/seconddir/myFileName.ext";
-    dir = cwd + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    dir = "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk"; dontApplySearchPath = true;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
 
     ///
 
     swd = "/specified"; path = "X:/topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "X:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "/specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "/specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "X:topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "/specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "/specified"; path = "topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
  
     ///
 
     swd = "Y:specified"; path = "X:/topdir/seconddir/myFileName.ext";
-    dir = cwd + "Y:specified" + sep + "X:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    dir = "Y:specified" + sep + "X:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk"; dontApplySearchPath = true;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
 
     swd = "Y:specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "Y:specified"; path = "X:topdir/seconddir/myFileName.ext";
-    dir = cwd + "Y:specified" + sep + "X:topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    dir = "Y:specified" + sep + "X:topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk"; dontApplySearchPath = true;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
 
     swd = "Y:specified"; path = "./topdir/seconddir/myFileName.ext";
-    dir = cwd + "Y:specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    dir = "Y:specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk"; dontApplySearchPath = true;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
 
     swd = "Y:specified"; path = "topdir/seconddir/myFileName.ext";
-    dir = cwd + "Y:specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    dir = "Y:specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk"; dontApplySearchPath = true;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
 
     ///
 
     swd = "./specified"; path = "X:/topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "X:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "./specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "./specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "X:topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "./specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
     swd = "./specified"; path = "topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk";
-    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    directory = fileName = extension = "junk"; dontApplySearchPath = false;
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
 
 #endif
 

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -394,26 +394,31 @@ void testPathname() {
 
     swd = ""; path = "X:/topdir/seconddir/myFileName.ext";
     dir = cwd + "X:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = ""; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = ""; path = "X:topdir/seconddir/myFileName.ext";
     dir = cwd + "X:topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = ""; path = "./topdir/seconddir/myFileName.ext";
     dir = cwd + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = ""; path = "topdir/seconddir/myFileName.ext";
     dir = cwd + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
@@ -421,26 +426,31 @@ void testPathname() {
 
     swd = "/specified"; path = "X:/topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "X:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = "/specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = "/specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "X:topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = "/specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = "/specified"; path = "topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
  
@@ -448,26 +458,31 @@ void testPathname() {
 
     swd = "Y:specified"; path = "X:/topdir/seconddir/myFileName.ext";
     dir = cwd + "Y:specified" + sep + "X:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = "Y:specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = "Y:specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = cwd + "Y:specified" + sep + "X:topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = "Y:specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = cwd + "Y:specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = "Y:specified"; path = "topdir/seconddir/myFileName.ext";
     dir = cwd + "Y:specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
@@ -475,26 +490,31 @@ void testPathname() {
 
     swd = "./specified"; path = "X:/topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "X:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = "./specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = "./specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "X:topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = "./specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     swd = "./specified"; path = "topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
     Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -392,6 +392,7 @@ void testPathname() {
 #else
     std::string swd, path, dir;
     const std::string cwd = Pathname::getCurrentWorkingDirectory();
+    bool dontApplySearchPath;
 
     swd = ""; path = "X:/topdir/seconddir/myFileName.ext";
     dir = "X:" + sep + "topdir" + sep + "seconddir" + sep;

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -621,7 +621,7 @@ void testPathname() {
     ///
 
     swd = "specified"; path = "C:/topdir/seconddir/myFileName.ext";
-    dir = cwd + "specified" + "C:" + sep + "topdir" + sep + "seconddir" + sep;
+    dir = cwd + "specified" + sep + "C:" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
@@ -637,7 +637,7 @@ void testPathname() {
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "C:topdir/seconddir/myFileName.ext";
-    dir = cwd + "specified" + "C:topdir" + sep + "seconddir" + sep;
+    dir = cwd + "specified" + sep + "C:topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -168,7 +168,7 @@ void testPathname() {
     SimTK_TEST(Pathname::getRootDirectory() == "/");
 #endif
 
-    std::string name;
+	std::string name;
     bool isAbsPath;
     std::string directory, fileName, extension;
     const std::string curDrive = 
@@ -190,6 +190,235 @@ void testPathname() {
     SimTK_TEST(!isAbsPath
         && directory=="topdir"+sep+"seconddir"+sep
         && fileName=="myFileName" && extension==".ext");
+
+	std::string swd, path;
+	const std::string cwd = Pathname::getCurrentWorkingDirectory();
+	std::string cwd_nodrive = cwd; cwd_nodrive.erase(0,3);
+	const std::string cwdX = Pathname::getCurrentWorkingDirectory("x");
+	const std::string cwdY = Pathname::getCurrentWorkingDirectory("y");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "";
+	path = "X:/topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "";
+	path = "/topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "";
+	path = "X:topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == cwdX + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "";
+	path = "./topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == cwd + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "";
+	path = "topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == cwd + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	///
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "Y:/specified";
+	path = "X:/topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "Y:/specified";
+	path = "/topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "y:" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "Y:/specified";
+	path = "X:topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "Y:/specified";
+	path = "./topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "Y:/specified";
+	path = "topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	///
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "/specified";
+	path = "X:/topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "/specified";
+	path = "/topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "/specified";
+	path = "X:topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "x:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "/specified";
+	path = "./topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "/specified";
+	path = "topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	///
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "Y:specified";
+	path = "X:/topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "Y:specified";
+	path = "/topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory ==  "y:" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "Y:specified";
+	path = "X:topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "Y:specified";
+	path = "./topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "Y:specified";
+	path = "topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	///
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "./specified";
+	path = "X:/topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "./specified";
+	path = "/topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "./specified";
+	path = "X:topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "./specified";
+	path = "./topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "./specified";
+	path = "topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	///
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "specified";
+	path = "X:/topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "specified";
+	path = "/topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "specified";
+	path = "X:topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	cout << directory << endl;
+	SimTK_TEST(directory == "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "specified";
+	path = "./topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	directory = fileName = extension = "junk"; isAbsPath = true;
+	swd = "specified";
+	path = "topdir/seconddir/myFileName.ext";
+	Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
+	SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
+		&& fileName == "myFileName" && extension == ".ext");
+
+	
 }
 
 void testPlugin() {

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -487,7 +487,7 @@ void testPathname() {
     swd = ""; path = "topdir/seconddir/myFileName.ext";
     dir = cwd + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk";
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension,);
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
     pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -191,232 +191,314 @@ void testPathname() {
         && directory=="topdir"+sep+"seconddir"+sep
         && fileName=="myFileName" && extension==".ext");
 
-    std::string swd, path;
+#ifdef _WIN32
+    std::string swd, path, dir;
     const std::string cwd = Pathname::getCurrentWorkingDirectory();
     std::string cwd_nodrive = cwd; cwd_nodrive.erase(0,3);
     const std::string cwdX = Pathname::getCurrentWorkingDirectory("x");
     const std::string cwdY = Pathname::getCurrentWorkingDirectory("y");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "";
-    path = "X:/topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = ""; path = "X:/topdir/seconddir/myFileName.ext";
+    dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "";
-    path = "/topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = ""; path = "/topdir/seconddir/myFileName.ext";
+    dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "";
-    path = "X:topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == cwdX + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = ""; path = "X:topdir/seconddir/myFileName.ext";
+    dir = cwdX + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "";
-    path = "./topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == cwd + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = ""; path = "./topdir/seconddir/myFileName.ext";
+    dir = cwd + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "";
-    path = "topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == cwd + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = ""; path = "topdir/seconddir/myFileName.ext";
+    dir = cwd + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     ///
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "Y:/specified";
-    path = "X:/topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "Y:/specified"; path = "X:/topdir/seconddir/myFileName.ext";
+    dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "Y:/specified";
-    path = "/topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "y:" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "Y:/specified"; path = "/topdir/seconddir/myFileName.ext";
+    dir = "y:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "Y:/specified";
-    path = "X:topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "Y:/specified"; path = "X:topdir/seconddir/myFileName.ext";
+    dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "Y:/specified";
-    path = "./topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "Y:/specified"; path = "./topdir/seconddir/myFileName.ext";
+    dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "Y:/specified";
-    path = "topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "Y:/specified"; path = "topdir/seconddir/myFileName.ext";
+    dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     ///
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "/specified";
-    path = "X:/topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "/specified"; path = "X:/topdir/seconddir/myFileName.ext";
+    dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "/specified";
-    path = "/topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "/specified"; path = "/topdir/seconddir/myFileName.ext";
+    dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "/specified";
-    path = "X:topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "x:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "/specified"; path = "X:topdir/seconddir/myFileName.ext";
+    dir = "x:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "/specified";
-    path = "./topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "/specified"; path = "./topdir/seconddir/myFileName.ext";
+    dir = curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "/specified";
-    path = "topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "/specified"; path = "topdir/seconddir/myFileName.ext";
+    dir = curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     ///
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "Y:specified";
-    path = "X:/topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "Y:specified"; path = "X:/topdir/seconddir/myFileName.ext";
+    dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "Y:specified";
-    path = "/topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory ==  "y:" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "Y:specified"; path = "/topdir/seconddir/myFileName.ext";
+    dir = "y:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "Y:specified";
-    path = "X:topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "Y:specified"; path = "X:topdir/seconddir/myFileName.ext";
+    dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "Y:specified";
-    path = "./topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "Y:specified"; path = "./topdir/seconddir/myFileName.ext";
+    dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "Y:specified";
-    path = "topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "Y:specified"; path = "topdir/seconddir/myFileName.ext";
+    dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     ///
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "./specified";
-    path = "X:/topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "./specified"; path = "X:/topdir/seconddir/myFileName.ext";
+    dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "./specified";
-    path = "/topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "./specified"; path = "/topdir/seconddir/myFileName.ext";
+    dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "./specified";
-    path = "X:topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "./specified"; path = "X:topdir/seconddir/myFileName.ext";
+    dir = "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "./specified";
-    path = "./topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "./specified"; path = "./topdir/seconddir/myFileName.ext";
+    dir = curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "./specified";
-    path = "topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "./specified"; path = "topdir/seconddir/myFileName.ext";
+    dir = curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
     ///
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "specified";
-    path = "X:/topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == "x:" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "specified"; path = "X:/topdir/seconddir/myFileName.ext";
+    dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "specified";
-    path = "/topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == curDrive + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "specified"; path = "/topdir/seconddir/myFileName.ext";
+    dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "specified";
-    path = "X:topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    cout << directory << endl;
-    SimTK_TEST(directory == "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "specified"; path = "X:topdir/seconddir/myFileName.ext";
+    dir = "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "specified";
-    path = "./topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "specified"; path = "./topdir/seconddir/myFileName.ext";
+    dir = curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
 
-    directory = fileName = extension = "junk"; isAbsPath = true;
-    swd = "specified";
-    path = "topdir/seconddir/myFileName.ext";
-    Pathname::deconstructPathRelativeToSWD(swd, path, directory, fileName, extension);
-    SimTK_TEST(directory == curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep
-        && fileName == "myFileName" && extension == ".ext");
+    swd = "specified"; path = "topdir/seconddir/myFileName.ext";
+    dir = curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+#else
+    std::string swd, path, dir;
+    const std::string cwd = Pathname::getCurrentWorkingDirectory();
+
+    swd = ""; path = "X:/topdir/seconddir/myFileName.ext";
+    dir = cwd + "X:" + sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = ""; path = "/topdir/seconddir/myFileName.ext";
+    dir = sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = ""; path = "X:topdir/seconddir/myFileName.ext";
+    dir = cwd + "X:topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = ""; path = "./topdir/seconddir/myFileName.ext";
+    dir = cwd + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = ""; path = "topdir/seconddir/myFileName.ext";
+    dir = cwd + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    ///
+
+    swd = "/specified"; path = "X:/topdir/seconddir/myFileName.ext";
+    dir = sep + "specified" + sep + "X:" + sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = "/specified"; path = "/topdir/seconddir/myFileName.ext";
+    dir = sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = "/specified"; path = "X:topdir/seconddir/myFileName.ext";
+    dir = sep + "specified" + sep + "X:topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = "/specified"; path = "./topdir/seconddir/myFileName.ext";
+    dir = sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = "/specified"; path = "topdir/seconddir/myFileName.ext";
+    dir = sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+ 
+    ///
+
+    swd = "Y:specified"; path = "X:/topdir/seconddir/myFileName.ext";
+    dir = cwd + "Y:specified" + sep + "X:" + sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = "Y:specified"; path = "/topdir/seconddir/myFileName.ext";
+    dir = sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = "Y:specified"; path = "X:topdir/seconddir/myFileName.ext";
+    dir = cwd + "Y:specified" + sep + "X:topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = "Y:specified"; path = "./topdir/seconddir/myFileName.ext";
+    dir = cwd + "Y:specified" + sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = "Y:specified"; path = "topdir/seconddir/myFileName.ext";
+    dir = cwd + "Y:specified" + sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    ///
+
+    swd = "./specified"; path = "X:/topdir/seconddir/myFileName.ext";
+    dir = cwd + "specified" + sep + "X:" + sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = "./specified"; path = "/topdir/seconddir/myFileName.ext";
+    dir = sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = "./specified"; path = "X:topdir/seconddir/myFileName.ext";
+    dir = cwd + "specified" + sep + "X:topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = "./specified"; path = "./topdir/seconddir/myFileName.ext";
+    dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+    swd = "./specified"; path = "topdir/seconddir/myFileName.ext";
+    dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    Pathname::findAbsolutePathUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+
+#endif
 
 }
 

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -193,481 +193,471 @@ void testPathname() {
 
 #ifdef _WIN32
     std::string swd, path, dir, pathname;
-    bool dontApplySearchPath;
     const std::string cwd = Pathname::getCurrentWorkingDirectory();
     std::string cwd_nodrive = cwd; cwd_nodrive.erase(0,3);
-    const std::string cwdX = Pathname::getCurrentWorkingDirectory("x");
-    const std::string cwdY = Pathname::getCurrentWorkingDirectory("y");
+    const std::string cwdC = Pathname::getCurrentWorkingDirectory("c");
+    const std::string cwdD = Pathname::getCurrentWorkingDirectory("d");
 
-    swd = ""; path = "X:/topdir/seconddir/myFileName.ext";
-    dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "   "; path = "C:/topdir/seconddir/myFileName.ext";
+    dir = "c:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "/topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = ""; path = "X:topdir/seconddir/myFileName.ext";
-    dir = cwdX + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "  "; path = "C:topdir/seconddir/myFileName.ext";
+    dir = cwdC + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "./topdir/seconddir/myFileName.ext";
     dir = cwd + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = ""; path = "topdir/seconddir/myFileName.ext";
-    dir = "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = true;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
-
-    ///
-
-    swd = "Y:/specified"; path = "X:/topdir/seconddir/myFileName.ext";
-    dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == dir + "myFileName.ext");
-
-    swd = "Y:/specified"; path = "/topdir/seconddir/myFileName.ext";
-    dir = "y:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == dir + "myFileName.ext");
-
-    swd = "Y:/specified"; path = "X:topdir/seconddir/myFileName.ext";
-    dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == dir + "myFileName.ext");
-
-    swd = "Y:/specified"; path = "./topdir/seconddir/myFileName.ext";
-    dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == dir + "myFileName.ext");
-
-    swd = "Y:/specified"; path = "topdir/seconddir/myFileName.ext";
-    dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = " "; path = "topdir/seconddir/myFileName.ext";
+    dir = cwd + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
 
-    swd = "/specified"; path = "X:/topdir/seconddir/myFileName.ext";
-    dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "D:/specified"; path = "C:/topdir/seconddir/myFileName.ext";
+    dir = "c:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    swd = "D:/specified"; path = "/topdir/seconddir/myFileName.ext";
+    dir = "d:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    swd = "D:/specified"; path = "C:topdir/seconddir/myFileName.ext";
+    dir = "d:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    swd = "D:/specified"; path = "./topdir/seconddir/myFileName.ext";
+    dir = "d:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    swd = "D:/specified"; path = "topdir/seconddir/myFileName.ext";
+    dir = "d:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    ///
+
+    swd = "/specified"; path = "C:/topdir/seconddir/myFileName.ext";
+    dir = "c:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = "/specified"; path = "X:topdir/seconddir/myFileName.ext";
-    dir = "x:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "/specified"; path = "C:topdir/seconddir/myFileName.ext";
+    dir = curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
 
-    swd = "Y:specified"; path = "X:/topdir/seconddir/myFileName.ext";
-    dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "D:specified"; path = "C:/topdir/seconddir/myFileName.ext";
+    dir = "c:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = "Y:specified"; path = "/topdir/seconddir/myFileName.ext";
-    dir = "y:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "D:specified"; path = "/topdir/seconddir/myFileName.ext";
+    dir = "d:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = "Y:specified"; path = "X:topdir/seconddir/myFileName.ext";
-    dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "D:specified"; path = "C:topdir/seconddir/myFileName.ext";
+    dir = cwdD + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = "Y:specified"; path = "./topdir/seconddir/myFileName.ext";
-    dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "D:specified"; path = "./topdir/seconddir/myFileName.ext";
+    dir = cwdD + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = "Y:specified"; path = "topdir/seconddir/myFileName.ext";
-    dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "D:specified"; path = "topdir/seconddir/myFileName.ext";
+    dir = cwdD + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
 
-    swd = "./specified"; path = "X:/topdir/seconddir/myFileName.ext";
-    dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "./specified"; path = "C:/topdir/seconddir/myFileName.ext";
+    dir = "c:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = "./specified"; path = "X:topdir/seconddir/myFileName.ext";
-    dir = "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "./specified"; path = "C:topdir/seconddir/myFileName.ext";
+    dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "./topdir/seconddir/myFileName.ext";
-    dir = curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "topdir/seconddir/myFileName.ext";
-    dir = curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
 
-    swd = "specified"; path = "X:/topdir/seconddir/myFileName.ext";
-    dir = "x:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "specified"; path = "C:/topdir/seconddir/myFileName.ext";
+    dir = "c:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = "specified"; path = "X:topdir/seconddir/myFileName.ext";
-    dir = "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "specified"; path = "C:topdir/seconddir/myFileName.ext";
+    dir = cwdC + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "./topdir/seconddir/myFileName.ext";
-    dir = "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = true;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
+    dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "topdir/seconddir/myFileName.ext";
-    dir = "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = true;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
+    dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
 #else
     std::string swd, path, dir, pathname;
     const std::string cwd = Pathname::getCurrentWorkingDirectory();
-    bool dontApplySearchPath;
 
-    swd = ""; path = "X:/topdir/seconddir/myFileName.ext";
-    dir = "X:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = true;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
+    swd = ""; path = "C:/topdir/seconddir/myFileName.ext";
+    dir = cwd + "C:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = ""; path = "X:topdir/seconddir/myFileName.ext";
-    dir = "X:topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = true;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
+    swd = ""; path = "C:topdir/seconddir/myFileName.ext";
+    dir = cwd + "C:topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "./topdir/seconddir/myFileName.ext";
     dir = cwd + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "topdir/seconddir/myFileName.ext";
-    dir = "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = true;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
+    dir = cwd + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension,);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
 
-    swd = "/specified"; path = "X:/topdir/seconddir/myFileName.ext";
-    dir = sep + "specified" + sep + "X:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "/specified"; path = "C:/topdir/seconddir/myFileName.ext";
+    dir = sep + "specified" + sep + "C:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = "/specified"; path = "X:topdir/seconddir/myFileName.ext";
-    dir = sep + "specified" + sep + "X:topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "/specified"; path = "C:topdir/seconddir/myFileName.ext";
+    dir = sep + "specified" + sep + "C:topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
  
     ///
 
-    swd = "Y:specified"; path = "X:/topdir/seconddir/myFileName.ext";
-    dir = "Y:specified" + sep + "X:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = true;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
-
-    swd = "Y:specified"; path = "/topdir/seconddir/myFileName.ext";
-    dir = sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "D:specified"; path = "C:/topdir/seconddir/myFileName.ext";
+    dir = cwd + "D:specified" + sep + "C:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = "Y:specified"; path = "X:topdir/seconddir/myFileName.ext";
-    dir = "Y:specified" + sep + "X:topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = true;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
+    swd = "D:specified"; path = "/topdir/seconddir/myFileName.ext";
+    dir = sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = "Y:specified"; path = "./topdir/seconddir/myFileName.ext";
-    dir = "Y:specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = true;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
+    swd = "D:specified"; path = "C:topdir/seconddir/myFileName.ext";
+    dir = cwd + "D:specified" + sep + "C:topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
-    swd = "Y:specified"; path = "topdir/seconddir/myFileName.ext";
-    dir = "Y:specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = true;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
-    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
+    swd = "D:specified"; path = "./topdir/seconddir/myFileName.ext";
+    dir = cwd + "D:specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    swd = "D:specified"; path = "topdir/seconddir/myFileName.ext";
+    dir = cwd + "D:specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
 
-    swd = "./specified"; path = "X:/topdir/seconddir/myFileName.ext";
-    dir = cwd + "specified" + sep + "X:" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    swd = "./specified"; path = "C:/topdir/seconddir/myFileName.ext";
+    dir = cwd + "specified" + sep + "C:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "X:topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
-    directory = fileName = extension = "junk"; dontApplySearchPath = false;
-    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
-    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
-    pathname = "junk";
-    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    ///
+
+    swd = "specified"; path = "C:/topdir/seconddir/myFileName.ext";
+    dir = cwd + sep + "specified" + "C:" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    swd = "specified"; path = "/topdir/seconddir/myFileName.ext";
+    dir = sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    swd = "specified"; path = "C:topdir/seconddir/myFileName.ext";
+    dir = cwd + sep + "specified" + "C:topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    swd = "specified"; path = "./topdir/seconddir/myFileName.ext";
+    dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    swd = "specified"; path = "topdir/seconddir/myFileName.ext";
+    dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
 #endif

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -197,6 +197,7 @@ void testPathname() {
     std::string cwd_nodrive = cwd; cwd_nodrive.erase(0,3);
     const std::string cwdC = Pathname::getCurrentWorkingDirectory("c");
     const std::string cwdD = Pathname::getCurrentWorkingDirectory("d");
+    const std::string thisExeDir = Pathname::getThisExecutableDirectory();
 
     swd = "   "; path = "C:/topdir/seconddir/myFileName.ext";
     dir = "c:" + sep + "topdir" + sep + "seconddir" + sep;
@@ -448,9 +449,52 @@ void testPathname() {
     pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
+    ///
+
+    swd = "specified"; path = "topdir/../../seconddir/myFileName.ext";
+    dir = cwd + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    swd = "specified"; path = "";
+    dir = "";
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "" && extension == "");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir);
+
+    swd = "."; path = "";
+    dir = "";
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "" && extension == "");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir);
+
+    swd = ""; path = ".";
+    dir = cwd;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "" && extension == "");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir);
+
+    swd = "@"; path = "topdir/seconddir/myFileName.ext";
+    dir = thisExeDir + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
 #else
     std::string swd, path, dir, pathname;
     const std::string cwd = Pathname::getCurrentWorkingDirectory();
+    const std::string thisExeDir = Pathname::getThisExecutableDirectory();
 
     swd = ""; path = "C:/topdir/seconddir/myFileName.ext";
     dir = cwd + "C:" + sep + "topdir" + sep + "seconddir" + sep;
@@ -660,6 +704,47 @@ void testPathname() {
     pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
+    ///
+
+    swd = "specified"; path = "topdir/../../seconddir/myFileName.ext";
+    dir = cwd + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    swd = "specified"; path = "";
+    dir = "";
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "" && extension == "");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir);
+
+    swd = "."; path = "";
+    dir = "";
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "" && extension == "");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir);
+
+    swd = ""; path = ".";
+    dir = cwd;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "" && extension == "");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir);
+
+    swd = "@"; path = "topdir/seconddir/myFileName.ext";
+    dir = thisExeDir + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 #endif
 
 }

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -168,7 +168,7 @@ void testPathname() {
     SimTK_TEST(Pathname::getRootDirectory() == "/");
 #endif
 
-	std::string name;
+    std::string name;
     bool isAbsPath;
     std::string directory, fileName, extension;
     const std::string curDrive = 

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -192,7 +192,7 @@ void testPathname() {
         && fileName=="myFileName" && extension==".ext");
 
 #ifdef _WIN32
-    std::string swd, path, dir;
+    std::string swd, path, dir, pathname;
     bool dontApplySearchPath;
     const std::string cwd = Pathname::getCurrentWorkingDirectory();
     std::string cwd_nodrive = cwd; cwd_nodrive.erase(0,3);
@@ -204,30 +204,45 @@ void testPathname() {
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "/topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "X:topdir/seconddir/myFileName.ext";
     dir = cwdX + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "./topdir/seconddir/myFileName.ext";
     dir = cwd + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "topdir/seconddir/myFileName.ext";
     dir = "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = true;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
 
     ///
 
@@ -236,30 +251,45 @@ void testPathname() {
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "Y:/specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "Y:/specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "Y:/specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "Y:/specified"; path = "topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
 
@@ -268,30 +298,45 @@ void testPathname() {
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = "x:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
 
@@ -300,30 +345,45 @@ void testPathname() {
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "Y:specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "Y:specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "Y:specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "Y:specified"; path = "topdir/seconddir/myFileName.ext";
     dir = "y:" + sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
 
@@ -332,30 +392,45 @@ void testPathname() {
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
 
@@ -364,33 +439,48 @@ void testPathname() {
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = curDrive + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = "x:" + sep + cwd_nodrive + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = true;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
 
     swd = "specified"; path = "topdir/seconddir/myFileName.ext";
     dir = "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = true;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
 
 #else
-    std::string swd, path, dir;
+    std::string swd, path, dir, pathname;
     const std::string cwd = Pathname::getCurrentWorkingDirectory();
     bool dontApplySearchPath;
 
@@ -399,30 +489,45 @@ void testPathname() {
     directory = fileName = extension = "junk"; dontApplySearchPath = true;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
 
     swd = ""; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "X:topdir/seconddir/myFileName.ext";
     dir = "X:topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = true;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
 
     swd = ""; path = "./topdir/seconddir/myFileName.ext";
     dir = cwd + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "topdir/seconddir/myFileName.ext";
     dir = "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = true;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
 
     ///
 
@@ -431,30 +536,45 @@ void testPathname() {
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "X:topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
  
     ///
 
@@ -463,30 +583,45 @@ void testPathname() {
     directory = fileName = extension = "junk"; dontApplySearchPath = true;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
 
     swd = "Y:specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "Y:specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = "Y:specified" + sep + "X:topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = true;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
 
     swd = "Y:specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = "Y:specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = true;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
 
     swd = "Y:specified"; path = "topdir/seconddir/myFileName.ext";
     dir = "Y:specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = true;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && !dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == cwd + dir + "myFileName.ext");
 
     ///
 
@@ -495,30 +630,45 @@ void testPathname() {
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "/topdir/seconddir/myFileName.ext";
     dir = sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "X:topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "X:topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "./topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "topdir/seconddir/myFileName.ext";
     dir = cwd + "specified" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk"; dontApplySearchPath = false;
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension, dontApplySearchPath);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext" && dontApplySearchPath);
+    pathname = "junk";
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
 
 #endif
 

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -621,7 +621,7 @@ void testPathname() {
     ///
 
     swd = "specified"; path = "C:/topdir/seconddir/myFileName.ext";
-    dir = cwd + sep + "specified" + "C:" + sep + "topdir" + sep + "seconddir" + sep;
+    dir = cwd + "specified" + "C:" + sep + "topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
@@ -637,7 +637,7 @@ void testPathname() {
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "C:topdir/seconddir/myFileName.ext";
-    dir = cwd + sep + "specified" + "C:topdir" + sep + "seconddir" + sep;
+    dir = cwd + "specified" + "C:topdir" + sep + "seconddir" + sep;
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");


### PR DESCRIPTION
Addresses fixes to deconstructPathname (addresses issue #264). Introduces a new function deconstructPathRelativeToSWD that finds the absolute path to a given path name relative to a specified working directory (swd).