### PR TITLE
Shorten pragma in visualizer

### DIFF
--- a/Simbody/Visualizer/simbody-visualizer/simbody-visualizer.cpp
+++ b/Simbody/Visualizer/simbody-visualizer/simbody-visualizer.cpp
@@ -47,11 +47,7 @@
 #if defined(__APPLE__)
     // OSX comes with a glut implementation. In OSX 10.9 and 10.10, this
     // glut is deprecated and emits deprecation warnings.
-    #if defined(__clang__)
-        #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    #elif defined(__GNUC__)
-        #pragma gcc diagnostic ignored "-Wdeprecated-declarations"
-    #endif
+    #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     #include <GLUT/glut.h>
 #elif defined(_WIN32)
     #include "glut32/glut.h"    // we have our own private headers


### PR DESCRIPTION
I believe this will work because clang follows many of the GCC pragmas. We'll see what travis says of course.
