### PR TITLE
Enable Markdown support in Doxygen and require 1.8.6 or later.

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -291,7 +291,7 @@ EXTENSION_MAPPING      =
 # case of backward compatibilities issues.
 # The default value is: YES.
 
-MARKDOWN_SUPPORT       = NO
+MARKDOWN_SUPPORT       = YES
 
 # When enabled doxygen tries to link words that correspond to documented
 # classes, or namespaces to their corresponding documentation. Such a link can

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Simbody depends on the following:
 * compiler: [Visual Studio](http://www.visualstudio.com) 2013 or later (Windows only), [gcc](http://gcc.gnu.org/) 4.8.1 or later (typically on Linux), or [Clang](http://clang.llvm.org/) 3.4 or later (typically on Mac, possibly through Xcode)
 * linear algebra: [LAPACK](http://www.netlib.org/lapack/) and [BLAS](http://www.netlib.org/blas/)
 * visualization (optional): [FreeGLUT](http://freeglut.sourceforge.net/), [Xi and Xmu](http://www.x.org/wiki/)
-* API documentation (optional): [Doxygen](http://www.stack.nl/~dimitri/doxygen/) 1.7.6 or later; we recommend at least 1.8.8.
+* API documentation (optional): [Doxygen](http://www.stack.nl/~dimitri/doxygen/) 1.8.6 or later; we recommend at least 1.8.8.
 
 
 Using Simbody


### PR DESCRIPTION
Doxygen had a bug that prevented us from being able to use Markdown syntax in Doxygen comments so we disabled it in Simbody and OpenSim. Dimitri fixed that bug in doxygen 1.8.6. 

Since doxygen is now at 1.8.8 I would like to require 1.8.6 and enable Markdown from now on since it makes it easier to make nicely formatted doxygen comments.

We should consider this for OpenSim also; I filed issue opensim-org/opensim-core#305.
