### PR TITLE
Fix some cppcheck warnings

### DIFF
--- a/SimTKcommon/Simulation/src/System.cpp
+++ b/SimTKcommon/Simulation/src/System.cpp
@@ -941,7 +941,7 @@ int System::Guts::calcEventTriggerInfoImpl
         Array_<EventTriggerInfo> subinfo;
         sub.calcEventTriggerInfo(s, subinfo);
         for (Array_<EventTriggerInfo>::const_iterator e = subinfo.begin(); 
-             e != subinfo.end(); e++) 
+             e != subinfo.end(); ++e)
         {
             info.push_back(*e);
         }
@@ -1143,14 +1143,14 @@ public:
         info.eventIdCounter = 0;
         for (Array_<ScheduledEventHandler*>::const_iterator 
                  e = scheduledEventHandlers.begin(); 
-                 e != scheduledEventHandlers.end(); e++) {
+                 e != scheduledEventHandlers.end(); ++e) {
             EventId id;
             createScheduledEvent(s, id);
             info.scheduledEventIds.push_back(id);
         }
         for (Array_<TriggeredEventHandler*>::const_iterator 
                  e = triggeredEventHandlers.begin(); 
-                 e != triggeredEventHandlers.end(); e++) {
+                 e != triggeredEventHandlers.end(); ++e) {
             EventId id;
             EventTriggerByStageIndex index;
             createTriggeredEvent(s, id, index, (*e)->getRequiredStage());
@@ -1159,14 +1159,14 @@ public:
         }
         for (Array_<ScheduledEventReporter*>::const_iterator 
                  e = scheduledEventReporters.begin(); 
-                 e != scheduledEventReporters.end(); e++) {
+                 e != scheduledEventReporters.end(); ++e) {
             EventId id;
             createScheduledEvent(s, id);
             info.scheduledReportIds.push_back(id);
         }
         for (Array_<TriggeredEventReporter*>::const_iterator 
                  e = triggeredEventReporters.begin(); 
-                 e != triggeredEventReporters.end(); e++) {
+                 e != triggeredEventReporters.end(); ++e) {
             EventId id;
             EventTriggerByStageIndex index;
             createTriggeredEvent(s, id, index, (*e)->getRequiredStage());

--- a/SimTKcommon/src/tinyxml.h
+++ b/SimTKcommon/src/tinyxml.h
@@ -364,7 +364,7 @@ protected:
         {
             //strncpy( _value, p, *length );    // lots of compilers don't like this function (unsafe),
                                                 // and the null terminator isn't needed
-            for( int i=0; p[i] && i<*length; ++i ) {
+            for( int i=0; i<*length && p[i]; ++i ) {
                 _value[i] = p[i];
             }
             return p + (*length);

--- a/SimTKmath/Optimizers/src/IpOpt/IpAdaptiveMuUpdate.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpAdaptiveMuUpdate.cpp
@@ -432,7 +432,7 @@ namespace Ipopt
           Number curr_error = quality_function_pd_system();
           std::list<Number>::iterator iter;
           for (iter = refs_vals_.begin(); iter != refs_vals_.end();
-               iter++) {
+               ++iter) {
             if ( curr_error <= refs_red_fact_*(*iter) ) {
               retval = true;
             }
@@ -482,7 +482,7 @@ namespace Ipopt
           Index num_refs = 0;
           std::list<Number>::iterator iter;
           for (iter = refs_vals_.begin(); iter != refs_vals_.end();
-               iter++) {
+               ++iter) {
             num_refs++;
             Jnlst().Printf(J_MOREDETAILED, J_BARRIER_UPDATE,
                            "pd system reference[%2d] = %.6e\n", num_refs, *iter);
@@ -532,10 +532,10 @@ namespace Ipopt
     DBG_ASSERT(refs_vals_.size()>0);
     std::list<Number>::iterator iter = refs_vals_.begin();
     min_ref = *iter;
-    iter++;
+    ++iter;
     while (iter != refs_vals_.end()) {
       min_ref = Min(min_ref, *iter);
-      iter++;
+      ++iter;
     }
     return min_ref;
   }
@@ -548,10 +548,10 @@ namespace Ipopt
     DBG_ASSERT(refs_vals_.size()>0);
     std::list<Number>::iterator iter = refs_vals_.begin();
     max_ref = *iter;
-    iter++;
+    ++iter;
     while (iter != refs_vals_.end()) {
       max_ref = Max(max_ref, *iter);
-      iter++;
+      ++iter;
     }
     return max_ref;
   }
@@ -685,6 +685,7 @@ namespace Ipopt
         break;
         case 2:
         centrality = complty/xi;
+        break;
         case 3:
         centrality = complty/pow(xi,3);
         break;

--- a/SimTKmath/Optimizers/src/IpOpt/IpFilter.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpFilter.cpp
@@ -45,7 +45,7 @@ namespace Ipopt
     bool acceptable = true;
     std::list<FilterEntry*>::iterator iter;
     for (iter = filter_list_.begin(); iter != filter_list_.end();
-         iter++) {
+         ++iter) {
       if (!(*iter)->Acceptable(vals)) {
         acceptable = false;
         break;
@@ -63,13 +63,13 @@ namespace Ipopt
     while (iter != filter_list_.end()) {
       if ((*iter)->Dominated(vals)) {
         std::list<FilterEntry*>::iterator iter_to_remove = iter;
-        iter++;
+        ++iter;
         FilterEntry* entry_to_remove = *iter_to_remove;
         filter_list_.erase(iter_to_remove);
         delete entry_to_remove;
       }
       else {
-        iter++;
+        ++iter;
       }
     }
     FilterEntry* new_entry = new FilterEntry(vals, iteration);
@@ -97,7 +97,7 @@ namespace Ipopt
     std::list<FilterEntry*>::iterator iter;
     Index count = 0;
     for (iter = filter_list_.begin(); iter != filter_list_.end();
-         iter++) {
+         ++iter) {
       if (count % 10 == 0) {
         jnlst.Printf(J_VECTOR, J_LINE_SEARCH,
                      "                phi                    theta            iter\n");

--- a/SimTKmath/Optimizers/src/IpOpt/IpObserver.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpObserver.hpp
@@ -288,7 +288,7 @@ namespace Ipopt
 #endif
 
     std::vector<Observer*>::iterator iter;
-    for (iter = observers_.begin(); iter != observers_.end(); iter++) {
+    for (iter = observers_.begin(); iter != observers_.end(); ++iter) {
       (*iter)->ProcessNotification(Observer::NT_BeingDestroyed, this);
     }
   }
@@ -346,7 +346,7 @@ namespace Ipopt
 #endif
 
     std::vector<Observer*>::iterator iter;
-    for (iter = observers_.begin(); iter != observers_.end(); iter++) {
+    for (iter = observers_.begin(); iter != observers_.end(); ++iter) {
       (*iter)->ProcessNotification(notify_type, this);
     }
   }

--- a/SimTKmath/Optimizers/src/IpOpt/IpOptionsList.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpOptionsList.cpp
@@ -506,7 +506,7 @@ namespace Ipopt
     list += buffer;
     for(std::map< std::string, OptionValue >::const_iterator p = options_.begin();
         p != options_.end();
-        p++ ) {
+        ++p ) {
       sprintf(buffer, "%40s = %-20s %6d\n", p->first.c_str(),
               p->second.Value().c_str(), p->second.Counter());
       list += buffer;
@@ -521,7 +521,7 @@ namespace Ipopt
     list += buffer;
     for(std::map< std::string, OptionValue >::const_iterator p = options_.begin();
         p != options_.end();
-        p++ ) {
+        ++p ) {
       if (!p->second.DontPrint()) {
         const char yes[] = "yes";
         const char no[] = "no";

--- a/SimTKmath/Optimizers/src/IpOpt/IpReferenced.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpReferenced.hpp
@@ -226,7 +226,7 @@ namespace Ipopt
 
     bool found = false;
     std::list<const Referencer*>::iterator iter;
-    for (iter = referencers_.begin(); iter != referencers_.end(); iter++) {
+    for (iter = referencers_.begin(); iter != referencers_.end(); ++iter) {
       if ((*iter) == referencer) {
         found = true;
         break;

--- a/SimTKmath/Optimizers/src/IpOpt/IpRegOptions.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRegOptions.cpp
@@ -112,7 +112,7 @@ namespace Ipopt
     else if (type_ ==OT_String) {
       std::vector<string_entry>::const_iterator i;
       jnlst.Printf(J_SUMMARY, J_DOCUMENTATION, "Valid Settings:\n");
-      for (i = valid_strings_.begin(); i != valid_strings_.end(); i++) {
+      for (i = valid_strings_.begin(); i != valid_strings_.end(); ++i) {
         jnlst.Printf(J_SUMMARY, J_DOCUMENTATION, "\t%s (%s)\n",
                      (*i).value_.c_str(), (*i).description_.c_str());
       }
@@ -220,7 +220,7 @@ namespace Ipopt
       jnlst.Printf(J_SUMMARY, J_DOCUMENTATION, "\\begin{itemize}\n");
       for (std::vector<string_entry>::const_iterator
            i = valid_strings_.begin();
-           i != valid_strings_.end(); i++) {
+           i != valid_strings_.end(); ++i) {
         std::string latex_value;
         MakeValidLatexString((*i).value_, latex_value);
         jnlst.Printf(J_SUMMARY, J_DOCUMENTATION, "   \\item %s: ",
@@ -240,7 +240,7 @@ namespace Ipopt
   void RegisteredOption::MakeValidLatexString(std::string source, std::string& dest) const
   {
     std::string::iterator c;
-    for (c=source.begin(); c!=source.end(); c++) {
+    for (c=source.begin(); c!=source.end(); ++c) {
       if (*c == '_') {
         dest.append("\\_");
       }
@@ -262,7 +262,7 @@ namespace Ipopt
 
     std::string::iterator c;
     bool found_e = false;
-    for (c=source.begin(); c!=source.end(); c++) {
+    for (c=source.begin(); c!=source.end(); ++c) {
       if (*c == 'e') {
         found_e = true;
         dest.append(" \\cdot 10^{");
@@ -348,7 +348,7 @@ namespace Ipopt
       jnlst.Printf(J_SUMMARY, J_DOCUMENTATION, "\n   Possible values:\n");
       for (std::vector<string_entry>::const_iterator
            i = valid_strings_.begin();
-           i != valid_strings_.end(); i++) {
+           i != valid_strings_.end(); ++i) {
         jnlst.Printf(J_SUMMARY, J_DOCUMENTATION, "    - %-23s [",
                      (*i).value_.c_str());
 
@@ -368,7 +368,7 @@ namespace Ipopt
     DBG_ASSERT(type_ == OT_String);
 
     std::vector<string_entry>::const_iterator i;
-    for (i = valid_strings_.begin(); i != valid_strings_.end(); i++) {
+    for (i = valid_strings_.begin(); i != valid_strings_.end(); ++i) {
       if (i->value_ == "*" || string_equal_insensitive(i->value_, value)) {
         return true;
       }
@@ -384,7 +384,7 @@ namespace Ipopt
     std::string matched_setting = "";
 
     std::vector<string_entry>::const_iterator i;
-    for (i = valid_strings_.begin(); i != valid_strings_.end(); i++) {
+    for (i = valid_strings_.begin(); i != valid_strings_.end(); ++i) {
       if (i->value_ == "*") {
         matched_setting = value;
       }
@@ -404,7 +404,7 @@ namespace Ipopt
 
     Index cnt = 0;
     std::vector<string_entry>::const_iterator i;
-    for (i = valid_strings_.begin(); i != valid_strings_.end(); i++) {
+    for (i = valid_strings_.begin(); i != valid_strings_.end(); ++i) {
       ASSERT_EXCEPTION(i->value_ != "*", IpoptException,
                        "Cannot map a wildcard setting to an enumeration");
       if (string_equal_insensitive(i->value_, value)) {
@@ -435,8 +435,8 @@ namespace Ipopt
     while(i1!=s1.end()) {
       if (toupper(*i1)!=toupper(*i2))
         return false;
-      i1++;
-      i2++;
+      ++i1;
+      ++i2;
     }
     return true;
   }
@@ -833,20 +833,20 @@ namespace Ipopt
 
     std::list
     <std::string>::iterator i;
-    for (i = categories.begin(); i != categories.end(); i++) {
+    for (i = categories.begin(); i != categories.end(); ++i) {
       jnlst.Printf(J_SUMMARY, J_DOCUMENTATION,
                    "\n### %s ###\n\n", (*i).c_str());
       std::map<Index, SmartPtr<RegisteredOption> > class_options;
       std::map <std::string, SmartPtr<RegisteredOption> >::iterator option;
       for (option = registered_options_.begin();
-           option != registered_options_.end(); option++) {
+           option != registered_options_.end(); ++option) {
         if (option->second->RegisteringCategory() == (*i)) {
 
           class_options[option->second->Counter()] = option->second;
         }
       }
       std::map<Index, SmartPtr<RegisteredOption> >::const_iterator co;
-      for (co = class_options.begin(); co != class_options.end(); co++) {
+      for (co = class_options.begin(); co != class_options.end(); ++co) {
         co->second->OutputShortDescription(jnlst);
       }
       jnlst.Printf(J_SUMMARY, J_DOCUMENTATION, "\n");
@@ -862,7 +862,7 @@ namespace Ipopt
       std::list<std::string>::iterator coption;
       for (coption = options_to_print.begin();
            coption != options_to_print.end();
-           coption++) {
+           ++coption) {
         //    std::map <std::string, SmartPtr<RegisteredOption> >::iterator option;
         SmartPtr<RegisteredOption> option = registered_options_[*coption];
         DBG_ASSERT(IsValid(option));
@@ -873,7 +873,7 @@ namespace Ipopt
       std::map <std::string, SmartPtr<RegisteredOption> >::iterator option;
       for (option = registered_options_.begin();
            option != registered_options_.end();
-           option++) {
+           ++option) {
         option->second->OutputLatexDescription(jnlst);
       }
     }

--- a/SimTKmath/Optimizers/src/IpOpt/IpTripletToCSRConverter.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTripletToCSRConverter.cpp
@@ -57,7 +57,7 @@ namespace Ipopt
     std::list<TripletEntry>::iterator list_iterator = entry_list.begin();
     for (Index i=0; i<nonzeros; i++) {
       list_iterator->Set(airn[i], ajcn[i], i);
-      list_iterator++;
+      ++list_iterator;
     }
     DBG_ASSERT(list_iterator == entry_list.end());
 
@@ -89,7 +89,7 @@ namespace Ipopt
     ja_tmp[0] = 1;
     ipos_first_tmp[0] = list_iterator->PosTriplet();
 
-    list_iterator++;
+    ++list_iterator;
     Index idouble = 0;
     while (list_iterator != entry_list.end()) {
       Index irow = list_iterator->IRow();
@@ -117,7 +117,7 @@ namespace Ipopt
         }
       }
 
-      list_iterator++;
+      ++list_iterator;
     }
     nonzeros_compressed_++;
     ia_[dim_] = nonzeros_compressed_;


### PR DESCRIPTION
(style) Array index 'i' is used before limits check
(performance) Prefer prefix ++/-- operators for non-primitive types
(warning) Variable 'centrality' is reassigned a value before the old one has been used. 'break;' missing?
