### PR TITLE
cppcheck: fix Exception should be caught by reference

### DIFF
--- a/SimTKcommon/src/ParallelExecutor.cpp
+++ b/SimTKcommon/src/ParallelExecutor.cpp
@@ -141,7 +141,7 @@ void* threadBody(void* args) {
                     index += threadCount;
                 }
             }
-            catch (std::exception ex) {
+            catch (const std::exception &ex) {
                 std::cerr <<"The parallel task threw an unhandled exception:"<< std::endl;
                 std::cerr <<ex.what()<< std::endl;
             }

--- a/SimTKcommon/tests/PolynomialTest.cpp
+++ b/SimTKcommon/tests/PolynomialTest.cpp
@@ -262,13 +262,13 @@ void testSolveQuadratic() {
         testQuadratic(Vec3(0.0, 1.0, 1.0), Vec<2,Complex>(0.0, 0.0));
         ASSERT(false)
     }
-    catch (PolynomialRootFinder::ZeroLeadingCoefficient ex) {
+    catch (PolynomialRootFinder::ZeroLeadingCoefficient) {
     }
     try {
         testQuadratic(Vec<3,Complex>(0.0, 1.0, 1.0), Vec<2,Complex>(0.0, 0.0));
         ASSERT(false)
     }
-    catch (PolynomialRootFinder::ZeroLeadingCoefficient ex) {
+    catch (PolynomialRootFinder::ZeroLeadingCoefficient) {
     }
 }
 
@@ -322,13 +322,13 @@ void testSolveCubic() {
         testCubic(Vec4(0.0, 0.0, 0.0, 0.0), Vec<3,Complex>(0.0, 0.0, 0.0));
         ASSERT(false)
     }
-    catch (PolynomialRootFinder::ZeroLeadingCoefficient ex) {
+    catch (PolynomialRootFinder::ZeroLeadingCoefficient) {
     }
     try {
         testCubic(Vec<4,Complex>(0.0, 0.0, 0.0, 0.0), Vec<3,Complex>(0.0, 0.0, 0.0));
         ASSERT(false)
     }
-    catch (PolynomialRootFinder::ZeroLeadingCoefficient ex) {
+    catch (PolynomialRootFinder::ZeroLeadingCoefficient) {
     }
 }
 
@@ -374,14 +374,14 @@ void testSolveArbitrary() {
         PolynomialRootFinder::findRoots(realCoeff, roots);
         ASSERT(false)
     }
-    catch (PolynomialRootFinder::ZeroLeadingCoefficient ex) {
+    catch (PolynomialRootFinder::ZeroLeadingCoefficient) {
     }
     try {
         complexCoeff[0] = 0.0;
         PolynomialRootFinder::findRoots(complexCoeff, roots);
         ASSERT(false)
     }
-    catch (PolynomialRootFinder::ZeroLeadingCoefficient ex) {
+    catch (PolynomialRootFinder::ZeroLeadingCoefficient) {
     }
 }
 

--- a/SimTKmath/Integrators/src/VerletIntegrator.cpp
+++ b/SimTKmath/Integrators/src/VerletIntegrator.cpp
@@ -227,7 +227,7 @@ bool VerletIntegratorRep::attemptDAEStep
 
     return converged;
   }
-  catch (std::exception ex) {
+  catch (std::exception) {
     return false;
   }
 }

--- a/Simbody/src/OBSOLETE_LengthConstraints.cpp
+++ b/Simbody/src/OBSOLETE_LengthConstraints.cpp
@@ -554,7 +554,7 @@ LengthConstraints::enforcePositionConstraints(State& s, const Real& requiredTol,
                         CalcPosZ(s, &pvConstraints[i]));
         }
     }
-    catch ( SimTK::Exception::NewtonRaphsonFailure cptn ) {
+    catch ( const SimTK::Exception::NewtonRaphsonFailure &cptn ) {
         cout << "LengthConstraints::enforcePositionConstraints: exception: "
              << cptn.getMessage() << '\n';
     } 
@@ -579,7 +579,7 @@ LengthConstraints::enforceVelocityConstraints(State& s, const Real& requiredTol,
                         CalcVelZ(s, &pvConstraints[i]));
         }
     }
-    catch ( SimTK::Exception::NewtonRaphsonFailure cptn ) {
+    catch ( const SimTK::Exception::NewtonRaphsonFailure &cptn ) {
         cout << "LengthConstraints::enforceVelocityConstraints: exception: "
              << cptn.getMessage() << '\n';
     } 

--- a/Simbody/src/ObservedPointFitter.cpp
+++ b/Simbody/src/ObservedPointFitter.cpp
@@ -343,7 +343,7 @@ Real ObservedPointFitter::findBestFit
             }
             //body.setQFromVector(tempState, copyMatter.getMobilizedBody(copyBodyIxs[currentBodyIndex]).getQAsVector(copyState));
         }
-        catch (Exception::OptimizerFailed ex) {
+        catch (const Exception::OptimizerFailed &ex) {
             std::cout << "Optimization failure for body "<<i<<": "<<ex.getMessage() << std::endl;
             // Just leave this body's state variables set to 0, and rely on the final optimization to fix them.
         }

--- a/examples/ParameterConstrainedOptimization.cpp
+++ b/examples/ParameterConstrainedOptimization.cpp
@@ -104,7 +104,7 @@ int main() {
        f = opt.optimize( results );
     }
 
-    catch (SimTK::Exception::Base e) {
+    catch (const SimTK::Exception::Base &e) {
         std::cout << "ParameterConstrainedOptimization.cpp Caught exception :" <<  std::endl;
         std::cout << e.what() << std::endl;
     }

--- a/examples/UnconstrainedOptimization.cpp
+++ b/examples/UnconstrainedOptimization.cpp
@@ -75,7 +75,7 @@ int main() {
     
        f = opt.optimize( results );
     }
-    catch  (SimTK::Exception::Base e) {
+    catch  (const SimTK::Exception::Base &e) {
        std::cout << "UnconstrainedOptimization.cpp Caught exception :" <<  std::endl;
        std::cout << e.what() << std::endl;
     }


### PR DESCRIPTION
Add const when it's possible to indicate the arg isn't changed
Remove arg name when not used
