### PR TITLE
Update debian changelog to 3.5.1

### DIFF
--- a/doc/debian/changelog
+++ b/doc/debian/changelog
@@ -1,3 +1,9 @@
+simbody (3.5.1~trusty) trusty; urgency=medium
+
+  * simbody 3.5.1~1 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Mon, 12 Jan 2015 18:02:59 +0100
+
 simbody (3.5-1~quantal) quantal; urgency=low
 
   * master branch version (development)

--- a/doc/debian/changelog
+++ b/doc/debian/changelog
@@ -1,6 +1,6 @@
-simbody (3.5.1~trusty) trusty; urgency=medium
+simbody (3.5.1-1~trusty) trusty; urgency=medium
 
-  * simbody 3.5.1~1 release
+  * simbody 3.5.1-1~1 release
 
  -- Jose Luis Rivero <jrivero@osrfoundation.org>  Mon, 12 Jan 2015 18:02:59 +0100
 


### PR DESCRIPTION
Update ubuntu distribution and release number. This is part of our work to release the simbody-3.5.1 under the OSRF repository for Ubuntu trusty (probably precise too). In parallel, I'm working on getting it into debian, so we will get the update on Ubuntu Vivid as well.