### PR TITLE
Put doxygen in quiet mode to make it easier to see warnings.

### DIFF
--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -694,7 +694,7 @@ CITE_BIB_FILES         =
 # messages are off.
 # The default value is: NO.
 
-QUIET                  = NO
+QUIET                  = YES
 
 # The WARNINGS tag can be used to turn on/off the warning messages that are
 # generated to standard error ( stderr) by doxygen. If WARNINGS is set to YES


### PR DESCRIPTION
Following opensim-org/opensim-core#319.