### PR TITLE
Backport SpatialInertia::shift() fix from 4.0 branch to master

### DIFF
--- a/SimTKcommon/Mechanics/src/MassProperties.cpp
+++ b/SimTKcommon/Mechanics/src/MassProperties.cpp
@@ -117,7 +117,8 @@ halfCrossDiff(const Vec<3,P>& v, const Mat<3,3,P,CS1,RS1>& F, const Mat<3,3,P,CS
 //      F' = F + sx*M
 //      J' = J + (sx*~F - F'*sx)
 // where the parenthesized quantity is symmetric although its
-// individual terms are not. Cost is 72 flops.
+// individual terms are not. Unfortunately this is a shift by -s rather than s.
+// Cost is 72 flops.
 template <class P> ArticulatedInertia_<P>
 ArticulatedInertia_<P>::shift(const Vec3P& s) const {
     const Mat33P    Fp = F + s % M; // same meaning as sx*M but faster (33 flops)

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/SmallMatrixMixed.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/SmallMatrixMixed.h
@@ -692,7 +692,8 @@ Row<2,E> crossMat(const Row<2,negator<E>,S>& r) {return crossMat(r.positionalTra
 
     // CROSS MAT SQ
 
-/// Calculate matrix S(v) such that S(v)*w = -v % (v % w) = (v % w) % v. S is a symmetric,
+/// Calculate matrix S(v) such that S(v)*w = -v % (v % w) = (v % w) % v. 
+/// S is a symmetric,
 /// 3x3 matrix with nonnegative diagonals that obey the triangle inequality. 
 /// If M(v) = crossMat(v), then S(v) = square(M(v)) = ~M(v)*M(v) = -M(v)*M(v) 
 /// since M is skew symmetric.
@@ -708,9 +709,9 @@ Row<2,E> crossMat(const Row<2,negator<E>,S>& r) {return crossMat(r.positionalTra
 ///            -xz       -yz     x^2+y^2
 /// </pre>
 /// where "T" indicates that the element is identical to the symmetric one.
-/// This requires 11 flops to form.
-/// We produce the same S(v) regardless of whether v is a column or row.
-/// Note that there is no 2D equivalent of this operator.
+/// Note that S(-v)=S(v). This requires 11 flops to form.
+/// We produce the same S(v) regardless of whether v is a column or row. 
+/// There is no 2D equivalent of this operator.
 template <class E, int S> inline
 SymMat<3,E>
 crossMatSq(const Vec<3,E,S>& v) {


### PR DESCRIPTION
This PR has some cherry-picked commits to fix the bug reported in issue #334 in the master branch.