### PR TITLE
Improve the operative system detection in preprocessor code

### DIFF
--- a/SimTKcommon/src/ParallelExecutor.cpp
+++ b/SimTKcommon/src/ParallelExecutor.cpp
@@ -166,13 +166,13 @@ void ParallelExecutor::execute(Task& task, int times) {
 #ifdef __APPLE__
    #include <sys/sysctl.h>
    #include <dlfcn.h>
+#elif _WIN32
+   #include <windows.h>
+#elif __linux__
+   #include <dlfcn.h>
+   #include <unistd.h>
 #else
-   #ifdef __linux
-      #include <dlfcn.h>
-      #include <unistd.h>
-   #else
-      #include <windows.h>
-   #endif
+  #error "Architecture unsupported"
 #endif
 
 int ParallelExecutor::getNumProcessors() {
@@ -187,7 +187,7 @@ int ParallelExecutor::getNumProcessors() {
        return(1);
     }
 #else
-#ifdef __linux
+#ifdef __linux__
     long nProcessorsOnline     = sysconf(_SC_NPROCESSORS_ONLN);
     if( nProcessorsOnline == -1 )  {
         return(1);


### PR DESCRIPTION
For some reason (my hypothesis is the use of [\__linux keyword instead of the POSIX \__linux\__](http://sourceforge.net/p/predef/wiki/OperatingSystems/))  I'm receiving [failures of Ubuntu Simbody](
https://launchpad.net/ubuntu/+source/simbody/3.5.1+dfsg-1~exp1~vivid1/+build/6951817/+files/buildlog_ubuntu-vivid-powerpc.simbody_3.5.1%2Bdfsg-1%7Eexp1%7Evivid1_FAILEDTOBUILD.txt.gz) when is compiled in the Linux/PPC architecture (it fails looking for the windows.h header).

This pull request implement a small variation in the logic of operative system checking and fix the linux keyword according to POSIX.

Untested on PPC but should be enough.