### PR TITLE
SimbodyConfig.cmake allows relocation of installation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,11 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get update -qq; fi
   - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get install -qq g++-4.8; fi
   - if [[ "$TRAVIS_OS_NAME" = "linux" && "$CXX" = "g++" ]]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  
+  # CMake 2.8.11 on Ubuntu.
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:kalakris/cmake -y; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get update -qq; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get install cmake; fi
 
 install:
   - mkdir ~/simbody-build && cd ~/simbody-build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 #    (5) Build examples
 #
 #-------------------------------------------------------------------------------
-cmake_minimum_required(VERSION 2.8.6)
+cmake_minimum_required(VERSION 2.8.8)
 
 if(COMMAND cmake_policy)
         cmake_policy(SET CMP0003 NEW)
@@ -576,9 +576,21 @@ elseif (UNIX)
   set(SIMBODY_CMAKE_DIR ${CMAKE_INSTALL_FULL_LIBDIR}/cmake/simbody/)
 endif ()
 
-CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/cmake/SimbodyConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/cmake/SimbodyConfig.cmake @ONLY)
-INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/SimbodyConfig.cmake 
+# Configure SimbodyConfig.cmake in a way that allows the installation to be
+# relocatable.
+INCLUDE(CMakePackageConfigHelpers)
+CONFIGURE_PACKAGE_CONFIG_FILE(
+    ${CMAKE_SOURCE_DIR}/cmake/SimbodyConfig.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/cmake/SimbodyConfig.cmake
+    INSTALL_DESTINATION "${SIMBODY_CMAKE_DIR}"
+    PATH_VARS # Variables to edit in the SimbodyConfig.cmake.in.
+        CMAKE_INSTALL_PREFIX
+        SIMBODY_INCLUDE_INSTALL_DIR
+        CMAKE_INSTALL_LIBDIR
+        SIMBODY_VISUALIZER_INSTALL_DIR
+        SIMBODY_INSTALL_DOXYGENDIR
+    )
+INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/SimbodyConfig.cmake
     DESTINATION ${SIMBODY_CMAKE_DIR})
 
 # Create a file that allows clients to Simbody to ensure they have the version
@@ -586,7 +598,6 @@ INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/SimbodyConfig.cmake
 # Requires CMake 2.8.6.
 # Note: this is actually deprecated in the latest CMake. Eventually,
 # we are to use WRITE_BASIC_PACKAGE_VERSION_FILE instead.
-include(WriteBasicConfigVersionFile)
 # Writes a ConfigVersion file for us.
 WRITE_BASIC_CONFIG_VERSION_FILE(
     ${CMAKE_CURRENT_BINARY_DIR}/cmake/SimbodyConfigVersion.cmake

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Dependencies
 
 Simbody depends on the following:
 
-* cross-platform building: [CMake](http://www.cmake.org/cmake/resources/software.html) 2.8.6 or later
+* cross-platform building: [CMake](http://www.cmake.org/cmake/resources/software.html) 2.8.8 or later
 * compiler: [Visual Studio](http://www.visualstudio.com) 2013 or later (Windows only), [gcc](http://gcc.gnu.org/) 4.8.1 or later (typically on Linux), or [Clang](http://clang.llvm.org/) 3.4 or later (typically on Mac, possibly through Xcode)
 * linear algebra: [LAPACK](http://www.netlib.org/lapack/) and [BLAS](http://www.netlib.org/blas/)
 * visualization (optional): [FreeGLUT](http://freeglut.sourceforge.net/), [Xi and Xmu](http://www.x.org/wiki/)
@@ -143,7 +143,7 @@ Windows using Visual Studio
 All needed library dependencies are provided with the Simbody installation on Windows, including linear algebra and visualization dependencies. 
 
 1. Download and install [Microsoft Visual Studio](http://www.visualstudio.com), version 2013 or higher. The "Community Edition" is free for "non-enterprise" use. The "Express" edition is another free option, in that case use *Visual Studio Express for Windows Desktop*.
-2. Download and install [CMake](http://www.cmake.org/download), version 2.8.6 or higher.
+2. Download and install [CMake](http://www.cmake.org/download), version 2.8.8 or higher.
 3. (optional) If you want to build API documentation, download and install Doxygen, version 1.8.8 or higher.
 
 #### Download the Simbody source code

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ framework. Mac's come with the visualization dependencies.
 
 On Ubuntu, we need to get the dependencies ourselves. Open a terminal and run the following commands.
 
-1. Get the necessary dependencies: `$ sudo apt-get install cmake liblapack-dev`
+1. Get the necessary dependencies: `$ sudo apt-get install cmake liblapack-dev`. The cmake on Ubuntu 12.04 is not new enough; you could instead download it from [cmake.org](http://www.cmake.org/download/) or use [this third party PPA](https://launchpad.net/~robotology/+archive/ubuntu/ppa).
 2. If you want to use the CMake GUI, install `cmake-qt-gui`.
 3. For visualization (optional): `$ sudo apt-get install freeglut3-dev libxi-dev libxmu-dev`
 4. For API documentation (optional): `$ sudo apt-get install doxygen`

--- a/cmake/SimbodyConfig.cmake.in
+++ b/cmake/SimbodyConfig.cmake.in
@@ -29,35 +29,37 @@
 #
 #   TAGFILES = "\@Simbody_DOXYGEN_TAGFILE\@=\@Simbody_DOXYGEN_DIR\@"
 
+# To make the Simbody installation relocatable:
+@PACKAGE_INIT@
+
 if (@PKG_NAME@_CONFIG_INCLUDED)
   return()
 endif()
 set(@PKG_NAME@_CONFIG_INCLUDED TRUE)
 
 # Watch out for spaces in pathnames -- must quote.
-list(APPEND @PKG_NAME@_ROOT_DIR 
-            "@CMAKE_INSTALL_PREFIX@")
+set_and_check(@PKG_NAME@_ROOT_DIR
+              "@PACKAGE_CMAKE_INSTALL_PREFIX@")
 
-list(APPEND @PKG_NAME@_INCLUDE_DIR 
-            "@CMAKE_INSTALL_PREFIX@/@SIMBODY_INCLUDE_INSTALL_DIR@")
+set_and_check(@PKG_NAME@_INCLUDE_DIR 
+              "@PACKAGE_SIMBODY_INCLUDE_INSTALL_DIR@")
 
-list(APPEND @PKG_NAME@_LIB_DIR 
-            "@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@")
+set_and_check(@PKG_NAME@_LIB_DIR 
+              "@PACKAGE_CMAKE_INSTALL_LIBDIR@")
 
 list(APPEND @PKG_NAME@_BIN_DIR 
-            "@SIMBODY_VISUALIZER_INSTALL_DIR@")
+            "@PACKAGE_SIMBODY_VISUALIZER_INSTALL_DIR@")
 
 list(APPEND @PKG_NAME@_CFLAGS 
-            -I"@CMAKE_INSTALL_PREFIX@/@SIMBODY_INCLUDE_INSTALL_DIR@")
+            -I"@PACKAGE_SIMBODY_INCLUDE_INSTALL_DIR@")
 
 list(APPEND @PKG_NAME@_LDFLAGS 
-            -L"@CMAKE_INSTALL_PREFIX@/@CMAKE_INSTALL_LIBDIR@")
+            -L"@PACKAGE_CMAKE_INSTALL_LIBDIR@")
 
 if (NOT "@SIMBODY_DOXYGEN_TAGFILE_NAME@" STREQUAL "")
     # Must check tagfile variable, since the doxygen install dir is created
     # even if Doxygen documentation is not install.
-    set(temp_doxygen_dir
-        "@CMAKE_INSTALL_PREFIX@/@SIMBODY_INSTALL_DOXYGENDIR@")
+    set(temp_doxygen_dir "@PACKAGE_SIMBODY_INSTALL_DOXYGENDIR@")
     set(temp_tagfile_path
         "${temp_doxygen_dir}/@SIMBODY_DOXYGEN_TAGFILE_NAME@")
     if (EXISTS "${temp_tagfile_path}")
@@ -215,3 +217,5 @@ unset(Simbody_DEBUG_LIBRARY CACHE)
 unset(Simbody_STATIC_LIBRARY CACHE)
 unset(Simbody_STATIC_DEBUG_LIBRARY CACHE)
 mark_as_advanced(Simbody_LIBRARIES Simbody_STATIC_LIBRARIES)
+
+check_required_components(Simbody)


### PR DESCRIPTION
Previously, SimbodyConfig.cmake contained hardcoded paths to the installation
directory. This is fine on Linux, but may be an issue on Windows where users
choose the installation directory long after the build process.

To do this, I used CMake module that comes with CMake 2.8.8. We currently only
support up through CMake 2.8.6. Since Ubuntu 12.04 uses 2.8.6 and it is likely
that our users will be running Ubuntu 12.04, we cannot use CMake 2.8.8 yet.
Instead, I copied the necessary CMake module from 2.8.8 and committed it to the
repo.

I tested this on Linux by compiling a Simbody-using client project, and by
changing the name of the install directory after the installation was complete.
In both cases, my client project was able to correctly find Simbody. I do not
think a Windows test is necessary, as I did not change any platform specific
behavior.

@scpeters @j-rivero could you take a peek? Thank you!