### PR TITLE
Find ContactSurfaceIndex of surface 

### DIFF
--- a/Simbody/include/simbody/internal/Body.h
+++ b/Simbody/include/simbody/internal/Body.h
@@ -84,7 +84,7 @@ const MassProperties& getDefaultRigidBodyMassProperties() const;
 
 /** Add a piece of decorative geometry fixed at some pose on this Body. 
 This can be used for visualization of the Body's motion. Returns a small 
-integer that can be used to identify this decoration in any copy of this
+integer ordinal that can be used to identify this decoration in any copy of this
 %Body. The supplied DecorativeGeometry object is copied and transformed by the
 given Transform so that the actual geometry is always stored relative to the
 body's frame. The copy's "index on body" is set to the same value as returned
@@ -93,22 +93,22 @@ by this method.
 int addDecoration(const Transform& X_BD, const DecorativeGeometry& geometry);
 
 /** Convenience method for when the decorative geometry is to be placed at the
-body frame. This is the same as addDecoration(Transform(),geometry). **/
+body frame. This is the same as `addDecoration(Transform(),geometry)`. **/
 int addDecoration(const DecorativeGeometry& geometry)
 {   return addDecoration(Transform(), geometry); }
 
 /** Obtain a count nd of how many pieces of DecorativeGeometry have been
-attached to this Body. The indices i for individual decorations will be numbered
-0 <= i < nd. **/
+attached to this Body. The ordinals i for individual decorations will be 
+numbered 0 <= i < nd. **/
 int getNumDecorations() const;
 
 /** Get a read-only reference to the i'th piece of DecorativeGeometry that 
-was added to this Body, with 0 <= i < getNumDecorations(). The index i is
+was added to this Body, with 0 <= i < getNumDecorations(). The ordinal i is
 the small integer that was returned by addDecoration(). **/
 const DecorativeGeometry& getDecoration(int i) const;
 
 /** Get a writable reference to the i'th piece of DecorativeGeometry that 
-was added to this Body, with 0 <= i < getNumDecorations().  The index i is
+was added to this Body, with 0 <= i < getNumDecorations().  The ordinal i is
 the small integer that was returned by addDecoration(). Note that we allow
 writable access to decorations even on a const Body -- these are after all
 just decorations. **/
@@ -117,32 +117,32 @@ DecorativeGeometry& updDecoration(int i) const;
 /** Create a new ContactSurface on a body and place it using the indicated
 Transform. Unlike decorations, the Transform is kept separately rather than used
 to transform the copied surface in place. You can obtain it later with 
-getContactSurfaceTransform(). A small integer index is returned that can be used
-to identify this ContactSurface in any copy of this %Body. That integer
+getContactSurfaceTransform(). A small integer ordinal is returned that can be 
+used to identify this ContactSurface in any copy of this %Body. That integer
 saved in the new ContactSurface object, using its setIndexOnBody() method. 
 @see ContactSurface::setIndexOnBody() **/
 int addContactSurface(const Transform&          X_BS,
                       const ContactSurface&     shape); 
 
 /** Convenience method for when the contact surface is to be placed at the
-body frame. This is the same as addContactSurface(Transform(),shape). **/
+body frame. This is the same as `addContactSurface(Transform(),shape)`. **/
 int addContactSurface(const ContactSurface& shape)
 {   return addContactSurface(Transform(), shape); }
 
 /** Obtain the number of contact surfaces ns attached to this Body. The valid
-body-local index values i will be 0 <= i < ns. **/
+body-local ordinals i will be 0 <= i < ns. **/
 int getNumContactSurfaces() const;
 /** Get a reference to the i'th contact surface on this body; be sure to get
-the Transform also. **/
+the Transform also. @see getContactSurfaceTransform() **/
 const ContactSurface& getContactSurface(int i) const;
-/** Get the transform specifying the placement of the i'th contact surface
+/** Get the Transform specifying the placement of the i'th contact surface
 on this Body. **/
 const Transform& getContactSurfaceTransform(int i) const;
 /** Get write access to the i'th unique contact surface owned by this Body. This
-is a Topology-stage change that will require a new realizeTopology() call if 
+is a Topology-stage change that will require a new `realizeTopology()` call if 
 this Body is part of a System. **/
 ContactSurface& updContactSurface(int i);
-/** Get a writable reference to the transform specifying the placement of the 
+/** Get a writable reference to the Transform specifying the placement of the 
 i'th contact surface on this Body. This is a Topology-stage change that will 
 require a new realizeTopology() call if this Body is part of a System. **/
 Transform& updContactSurfaceTransform(int i);

--- a/Simbody/include/simbody/internal/ContactTrackerSubsystem.h
+++ b/Simbody/include/simbody/internal/ContactTrackerSubsystem.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2011-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2011-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman, Peter Eastman                                    *
  * Contributors:                                                              *
  *                                                                            *
@@ -37,12 +37,12 @@ class ContactTracker;
 class Contact;
 class ContactSnapshot;
 
-/** This subsystem identifies and tracks potential contacts between bodies of
-a multibody system, but does not generate any physical responses to those 
-contacts. It operates on the \e undeformed, material-independent geometry of 
-ContactSurfaces that have been associated with those bodies, identifying and
+/** This subsystem identifies and tracks potential contacts between the 
+mobilized bodies of a multibody system. It operates on the \e undeformed, 
+material-independent geometry of ContactSurface objects that have been 
+associated with those mobilized bodies, identifying and
 characterizing pairwise geometric relationships that occur between surfaces, 
-and tracking the evolution of particular Contacts through time. No physical 
+and tracking the evolution of particular contacts through time. No physical 
 response to contact is generated here; this subsystem provides only a general 
 contact-tracking service that can be used by other parts of the MultibodySystem
 to generate forces, impulses, visualizations, messages, noises, or whatever. 
@@ -50,26 +50,26 @@ The goal here is to provide robust and extremely high performance
 characterization of geometric interactions in a way that is useful for a 
 variety of contact response models.
 
-The ContactTrackerSubsystem maintains an evolving set of tracked Contacts 
-throughout a simulation; for any given state of the system the subsystem can
-calculate the current value of that set, which we call the "contact status" of 
-that state. The most recently known \e prior valid contact status is maintained
-as part of the system state because the correct instantaneous evaluation of 
-contact status may require past information, and because we are interested in 
-discrete contact events such as initiation and breaking of contact as well as 
-ongoing interactions. 
+The %ContactTrackerSubsystem maintains an evolving set of tracked Contact
+objects throughout a simulation; for any given State of the system the subsystem
+can calculate the current value of that set, which we call the "contact status"
+of that state. The most recently known \e prior valid contact status is 
+maintained as part of the system state because the correct instantaneous 
+evaluation of contact status may require past information, and because we are 
+interested in discrete contact events such as initiation and breaking of contact
+as well as ongoing interactions. 
 
 Each Contact being tracked represents the interaction between a unique pair of
-ContactSurfaces; by definition there is at most one Contact between any such 
-pair (per ContactTrackerSubsystem). The presence of a Contact in the set does 
-not necessarily mean its two surfaces are touching, just that their proximity 
-is interesting in some way. Each Contact is characterized as impending, 
-initiated, ongoing, broken, or separating. At each evaluation, the last-known 
-set of Contacts is used in conjuction with the current State to determine a 
-disposition for each of the tracked Contacts. Contacts that have become boring
-are removed from the tracked set, and newly-interesting ones are assigned a 
-new ContactId and added to the tracked contacts set. The ContactId persists as 
-long as that Contact continues to remain in the set.
+ContactSurface objects; by definition there is at most one Contact between any 
+such pair (per %ContactTrackerSubsystem). The presence of a Contact in the set 
+does not necessarily mean its two surfaces are touching, just that their 
+proximity is interesting in some way. Each Contact is characterized as 
+impending, initiated, ongoing, broken, or separating. At each evaluation, the 
+last-known set of Contacts is used in conjuction with the current State to 
+determine a disposition for each of the tracked Contacts. Contacts that have 
+become boring are removed from the tracked set, and newly-interesting ones are 
+assigned a new ContactId and added to the tracked contacts set. The ContactId 
+persists as long as that Contact continues to remain in the set.
 
 Ambiguous or impossible contact situations can occur during trial steps and 
 can be detected as long as we know the correct contact status in the immediate
@@ -86,82 +86,141 @@ to make a "best guess" at which surfaces are in contact; those can be
 overridden by a knowledgable human.
 
 As mentioned above, we track at most one Contact at a time between any pair 
-of ContactSurfaces. However, for some surface types a single Contact may 
+of ContactSurface objects. However, for some surface types a single Contact may 
 involve many geometric interactions; a mesh Contact, for example, may include 
-a list of all the mesh faces that overlap between the two surfaces, and 
-these do not have to be contiguous over the mesh surface. You may 
-want to break up a concave surface into several ContactSurfaces so that you 
-can separately track several Contacts between that surface and others.
+a list of all the mesh faces that overlap between the two surfaces, and these do
+not have to be contiguous over the mesh surface. You may want to break up a 
+concave surface into several ContactSurface objects so that you can separately 
+track several Contacts between that surface and others.
 
 A ContactSurface consists of a piece of surface geometry and a contact material
 that describes the contact-related physical properties of the surface.
 A body may have many ContactSurface objects attached to it, each with its own
-associated contact material. Within an instance of the ContactTrackerSubsystem,
+associated contact material. Within an instance of the %ContactTrackerSubsystem,
 each ContactSurface is assigned a unique ContactSurfaceIndex. If you have
-multiple ContactTrackerSubsystems, they will each have independent sets of
-ContactSurfaces (and know nothing about one another), so the (Subsystem,
-ContactSurfaceIndex) pair would be unique but not the index alone.
+more than one ContactTrackerSubsystem (not common), they will each have 
+independent sets of ContactSurface objects (and know nothing about one another),
+so the (Subsystem,ContactSurfaceIndex) pair would be unique but not the index 
+alone. You can map between the assigned ContactSurfaceIndex and the actual
+surface using methods of this class.
 
-Within a ContactTrackerSubsystem, all the ContactSurfaces are presumed to be
-capable of interacting with one another unless they share membership in a 
-"contact clique". All surfaces attached to the same body are placed together
-in a clique, so they will never interact. It is also common to create a clique
-associated with each joint and place nearby contact surfaces on adjacent 
-bodies into that clique to avoid having to build excessively precise geometry 
-around joints.
+Within a %ContactTrackerSubsystem, all the contact surfaces are presumed to be 
+capable of interacting with one another unless they share membership in a
+"contact clique". All surfaces attached to the same mobilized body are placed
+together in a clique, so they will never interact. It is also common to create a
+clique associated with each joint and place nearby contact surfaces on adjacent 
+mobilized bodies into that clique to avoid having to build excessively precise 
+geometry around joints.
 
 Each concrete type of ContactGeometry object (whether provided as part of 
 Simbody or as an extension by the user) has a unique integer 
 ContactGeometryTypeId. Ordered pairs of these Ids are used as a key to select 
-a ContactTracker that is able to identify and manage contacts or 
-potential contacts between those two kinds of geometric objects.
-You can provide a default tracking algorithm for unhandled pairs that will
-either ignore them or throw an error. Note that a ContactTracker
-is invoked only for "narrow phase" contact; the ContactTrackerSubsytem handles
-the "broad phase" and weeds out all but a few possible contacting surfaces
-that are then passed to ContactTracker for final disposition.
-All the ContactTrackers to be used with a given 
-ContactTrackerSubsystem must be registered with that subsystem during
-extended construction (Topology stage). Simbody provides default 
-ContactTrackers for interactions among most of its built-in
-Geometry types, such as Sphere-Sphere, Sphere-HalfSpace, Mesh-Sphere, 
-Mesh-Mesh, etc. These will be pre-registered in every ContactTrackerSubsystem
-but you can replace them with something else if you want.
+a ContactTracker that is able to identify and manage contacts or potential 
+contacts between those two kinds of geometric objects. You can provide a default
+tracking algorithm for unhandled pairs that will either ignore them or throw an 
+error. Note that a ContactTracker is invoked only for "narrow phase" contact; 
+the %ContactTrackerSubsytem handles the "broad phase" and weeds out all but a 
+few possible contacting surfaces that are then passed to ContactTracker for 
+final disposition. All the ContactTracker objects to be used with a given 
+%ContactTrackerSubsystem must be registered with that subsystem during
+extended construction (Topology stage). Simbody provides default ContactTracker
+implementations for interactions among most of its built-in ContactGeometry 
+types, such as Sphere-Sphere, Sphere-HalfSpace, Mesh-Sphere, Mesh-Mesh, etc. 
+These will be pre-registered in every %ContactTrackerSubsystem but you can 
+replace them with something else if you want.
 
 @note ContactGeometryTypeIds are unique and persistent within any execution of
 a program that uses them, but they are assigned at run time, possibly by 
 multiple asynchronous threads, and are likely to be different in different 
 programs and in separate runs of the same program.
 
-The result of a ContactTracker when applied to a pair of contact
-surfaces, is either a determination that the surfaces are not in contact,
-or a Contact object describing their contact interaction. There are different
-types of these Contact objects (for example, PointContact, LineContact, 
-MeshContact) and the same algorithm may result in different kinds of Contact 
-under different circumstances. At each evaluation, the subsystem passes in the 
-previous Contact object, if any, that was associated with two ContactSurfaces,
-then receives an update from the algorithm. **/
+The result of a ContactTracker when applied to a pair of contact surfaces, is 
+either a determination that the surfaces are not in contact, or a Contact object
+describing their contact interaction. There are different types of these Contact
+objects (for example, PointContact, LineContact, MeshContact) and the same 
+algorithm may result in different kinds of Contact under different 
+circumstances. At each evaluation, the subsystem passes in the previous Contact 
+object, if any, that was associated with two ContactSurface objects, then 
+receives an update from the algorithm. **/
 //==============================================================================
 //                          CONTACT TRACKER SUBSYSTEM
 //==============================================================================
 class SimTK_SIMBODY_EXPORT ContactTrackerSubsystem : public Subsystem {
 public:
-ContactTrackerSubsystem();
-explicit ContactTrackerSubsystem(MultibodySystem&);
+/** Create a new %ContactTrackerSubsystem and install it into the given 
+MultibodySystem. **/
+explicit ContactTrackerSubsystem(MultibodySystem& system);
+
+/**@name                     Find Active Contacts
+Determine what contacts are occurring. **/
+/**@{**/
+/** Get the calculated value of the ContactSnapshot cache entry representing the
+current set of Contact pairs for this system, as determined by the various 
+Tracker algorithms registered with this subsystem. You can call this at 
+Stage::Position or later; computation of contact status will be initiated if 
+needed. Only the past contact status and current positions are used.  This
+cache entry value is precisely what will become the "previous active contacts" 
+state variable at the beginning of the next time step. An error will be thrown 
+if we have to calculate the contacts here but fail to do so; if you don't want 
+to deal with the possibility that an error might occur here, you can realize
+contacts explicitly first (not common). 
+@see realizeActiveContacts() **/
+const ContactSnapshot& getActiveContacts(const State& state) const;
+
+/** (Advanced) Get an additional set of predicted Contacts that can be 
+anticipated from current velocity and acceleration information. You can call 
+this at Stage::Acceleration; computation will be initiated if needed. This
+cache entry value is precisely what will become the "previous predicted
+contacts" state variable at the beginning of the next time step. An error
+will be thrown if we have to calculate the contacts here but fail to do so; 
+to avoid that you can realize them explicitly first (not common). 
+@see realizePredictedContacts()  **/
+const ContactSnapshot& getPredictedContacts(const State& state) const;
+/**@}**/
+
+
+/**@name                    Contact Surface Identification
+These methods map between the assigned ContactSurfaceIndex and the surfaces
+that were attached to each MobilizedBody in the MultibodySystem. **/
+/**@{**/
 
 /** Get the number of surfaces being managed by this contact tracker subsystem.
 These are identified by ContactSurfaceIndex values from 0 to 
-getNumSurfaces()-1. This is available after realizeTopology() and does not
-change subsequently. **/
+`getNumSurfaces()-1`. This is available after `realizeTopology()` and does not
+change subsequently. You can find out which ContactSurfaceIndex got assigned
+any particular ContactSurface using `getContactSurfaceIndex()`. **/
 int getNumSurfaces() const;
+
+/** Obtain the ContactSurfaceIndex that was assigned by this 
+%ContactTrackerSubsystem to a particular instance of a ContactSurface 
+on a MobilizedBody. A ContactSurface is attached to a body description using 
+`Body::addContactSurface()` and then that body description is used to create
+an actual body instance in a MobilizedBody. The surface is identified here by 
+specifying the MobilizedBody of interest and the small integer ordinal that was
+returned when `Body::addContactSurface()` was called. (You can provide either a 
+MobilizedBody or MobilizedBodyIndex here; there is an implicit conversion from 
+MobilizedBody to its MobilizedBodyIndex.) This method will throw an exception 
+if either argument is illegal or out of range.
+@see Body::addContactSurface() **/
+ContactSurfaceIndex getContactSurfaceIndex(MobilizedBodyIndex mobod, 
+                                           int contactSurfaceOrdinal) const;
+
 /** Get the MobilizedBody associated with a particular contact surface. **/
 const MobilizedBody& getMobilizedBody(ContactSurfaceIndex surfIx) const;
+
 /** Get the ContactSurface object (detailed geometry and material properties)
 that is associated with the given ContactSurfaceIndex. **/
 const ContactSurface& getContactSurface(ContactSurfaceIndex surfIx) const;
+
 /** Get the transform X_BS that gives the pose of the indicated contact
 surface with respect to the body frame of the body to which it is attached. **/
 const Transform& getContactSurfaceTransform(ContactSurfaceIndex surfIx) const;
+/**@}**/
+
+
+/**@name                     Contact Tracker management
+Most users won't need to use these methods. **/
+/**@{**/
 
 /** Register the contact tracking algorithm to use for a particular pair of 
 ContactGeometry types, replacing the existing tracker if any. If the tracker 
@@ -184,40 +243,24 @@ be false. If no tracker was registered, this will be the default tracker. **/
 const ContactTracker& getContactTracker(ContactGeometryTypeId surface1, 
                                         ContactGeometryTypeId surface2,
                                         bool& reverseOrder) const;
+/**@}**/
 
-/** Obtain the value of the ContactSnapshot state variable representing the 
-most recently known set of Contacts for this system. **/
+/**@name                     Advanced/Obscure
+You probably don't want to call any of these methods. Some may be 
+unimplemented. **/
+/**@{**/
+
+/** (Advanced) Obtain the value of the ContactSnapshot state variable 
+representing the most recently known set of Contacts for this system. **/
 const ContactSnapshot& getPreviousActiveContacts(const State& state) const;
 
-/** Obtain the value of the ContactSnapshot state variable representing the 
-most recently predicted set of \e impending Contacts for this system. **/
+/** (Advanced) Obtain the value of the ContactSnapshot state variable 
+representing the most recently predicted set of \e impending Contacts for this
+system. **/
 const ContactSnapshot& getPreviousPredictedContacts(const State& state) const;
 
-/** Get the calculated value of the ContactSnapshot cache entry representing the
-current set of Contacts for this system, as determined by the various Tracker
-algorithms registered with this subsystem. You can call this at Position 
-stage or later; computation of contact status will be initiated if needed. 
-Only the past contact status and current positions are used.  This
-cache entry value is precisely what will become the "previous active
-contacts" state variable at the beginning of the next time step. An error
-will be thrown if we have to calculate the contacts here but fail to do so; 
-if you don't want to deal with the possibility that an error might occur here,
-you should realize contacts explicitly first. 
-@see realizeActiveContacts() **/
-const ContactSnapshot& getActiveContacts(const State& state) const;
-
-/** Get an additional set of predicted Contacts that can be anticipated from 
-current velocity and acceleration information. You can call this at 
-Acceleration stage; computation will be initiated if needed. This
-cache entry value is precisely what will become the "previous impending
-contacts" state variable at the beginning of the next time step. An error
-will be thrown if we have to calculate the contacts here but fail to do so; 
-to avoid that you should realize them explicitly first. 
-@see realizePredictedContacts()  **/
-const ContactSnapshot& getPredictedContacts(const State& state) const;
-
-/** Calculate the current ActiveContacts set at Position stage or later if
-it hasn't already been done and return true if successful. If we can't 
+/** (Advanced) Calculate the current ActiveContacts set at Position stage or 
+later if it hasn't already been done and return true if successful. If we can't 
 unambiguously determine the contact status, we'll return false and give the
 caller a hint as to the latest time at which we think we could have succeeded.
 If \a lastTry is true, then we throw an error on failure rather than 
@@ -226,12 +269,17 @@ bool realizeActiveContacts(const State& state,
                            bool         lastTry,
                            Real&        stepAdvice) const;
 
-/** Calculate the set of anticipated Contacts set at Acceleration
+/** (Advanced) Calculate the set of anticipated Contacts set at Acceleration
 stage if not already calculated and return true if successful. Otherwise,
 problems are handled as for realizeActiveContacts(). **/
 bool realizePredictedContacts(const State& state, 
                               bool         lastTry,
                               Real&        stepAdvice) const;
+
+/** (Advanced) Default constructor creates an empty Subsystem not associated 
+with any MultibodySystem; not very useful. **/
+ContactTrackerSubsystem();
+/**@}**/
 
 SimTK_PIMPL_DOWNCAST(ContactTrackerSubsystem, Subsystem);
 

--- a/Simbody/include/simbody/internal/MobilizedBody.h
+++ b/Simbody/include/simbody/internal/MobilizedBody.h
@@ -69,7 +69,7 @@ typedef MobilizedBody Mobod;
 //==============================================================================
 /** A %MobilizedBody is Simbody's fundamental body-and-joint object used to
 parameterize a system's motion by constructing a multibody tree containing
-each body and its unique "mobilizer" (internal coordinate joint). A 
+each body and its unique *mobilizer* (internal coordinate joint). A 
 %MobilizedBody connects a new body (the "child", "outboard", or "successor" 
 body) with a mobilizer and a reference frame to an existing %MobilizedBody (the 
 "parent", "inboard", or "predecessor" body) that is already part of a 
@@ -113,7 +113,7 @@ reliably determined at compile time. These have names beginning with "find"
 or a more specific verb, as a reminder that they do not require a great deal 
 of computation. 
 
-<em>High Level Operators</em> combine responses and basic operators with 
+<em>High Level Operators</em> combine state access and basic operators with 
 run-time tests to calculate more complex quantities, with more complicated 
 implementations that can exploit special cases at run time. These begin with 
 "calc" (calculate) as a reminder that they may involve substantial run time 
@@ -143,15 +143,16 @@ rotation of the mobilizer. That motion is parameterized via generalized
 coordinates q and generalized speeds u, the specific meaning of which is a
 unique property of each type of mobilizer.
 
-In the API below, we'll refer to the current ("this") MobilizedBody as "body B". 
-It is the "object" or "main" body with which we are concerned. Often there will 
-be another body mentioned in the argument list as a target for some conversion. 
-That "another" body will be called "body A". The Ground body is abbreviated "G".
+In the API below, we'll refer to the current ("this") %MobilizedBody as 
+"body B". It is the "object" or "main" body with which we are concerned. Often 
+there will be another body mentioned in the argument list as a target for some 
+conversion. That "another" body will be called "body A". The Ground body is 
+abbreviated "G".
 
 We use Fo to mean "the origin of frame F", Bc is "the mass center of body B". 
 R_AF is the rotation matrix giving frame F's orientation in frame A, such that a 
 vector v expressed in F is reexpressed in A by v_A = R_AF*v_F. X_AF is the 
-spatial transform giving frame F's origin location and orientation in frame A, 
+spatial transform giving frame F's orientation and origin location in frame A, 
 such that a point P whose location is measured from F's origin Fo and expressed 
 in F by position vector p_FP (or more explicitly p_FoP) is remeasured from frame
 A's origin Ao and reexpressed in A via p_AP = X_AF*p_FP, where p_AP==p_AoP. 
@@ -1491,27 +1492,29 @@ System's realizeTopology() method must be called again. A reference to this
 operator. **/
 MobilizedBody& setBody(const Body&);
 
-/** Add decorative geometry specified relative to the new (outboard) body's 
-reference frame B. Note that the body itself may already have had some 
-decorative geometry on it when it was first put into this MobilizedBody; this 
-just adds more and the returned index is larger. Use the underlying Body 
-object's accessors to find this decorative geometry again. The given 
-\p geometry object is \e copied here; we do not keep a reference to the 
-supplied object. **/
+/** Convenience method to add DecorativeGeometry specified relative to the 
+new (outboard) body's reference frame B. This is equivalent to
+`this->updBody().addDecoration(X_BD,geometry)`. Note that the Body may already 
+have had some DecorativeGeometry on it when it was first put into this 
+%MobilizedBody; this just adds more and the returned ordinal is larger. The 
+given \p geometry object is *copied* here; we do not keep a reference to the 
+supplied object. Use the underlying Body object's accessors to obtain a
+reference to the DecorativeGeometry copy stored here. 
+@see getBody(), Body::addDecoration() **/
 int addBodyDecoration(const Transform&          X_BD, 
                       const DecorativeGeometry& geometry) {
     return updBody().addDecoration(X_BD, geometry);
 }
 /** Convenience method for use when the \p geometry is supplied in the body 
-frame. This is the same as addBodyDecoration(Transform(),geometry). **/
+frame. This is the same as `addBodyDecoration(Transform(),geometry)`. **/
 int addBodyDecoration(const DecorativeGeometry& geometry) {
     return updBody().addDecoration(geometry);
 }
 
 /** Add decorative geometry specified relative to the outboard mobilizer frame M
-attached to body B. If body B already has decorative geometry on it, this just 
-adds some more, but kept in a separate list from the body decorations and 
-inboard decorations. Returns a unique index that can be used to identify this 
+attached to body B, and associated with the mobilizer rather than the body. This
+DecorativeGeometry is kept in a separate list from the body decorations and 
+inboard decorations. Returns an ordinal that can be used to identify this 
 outboard decoration later (numbered starting from zero for outboard decorations 
 only). **/
 int addOutboardDecoration(const Transform&          X_MD, 
@@ -1524,10 +1527,10 @@ const DecorativeGeometry& getOutboardDecoration(int i) const;
 DecorativeGeometry& updOutboardDecoration(int i);
 
 /** Add decorative geometry specified relative to the inboard mobilizer frame F 
-attached to the parent body P. If body P already has decorative geometry on it, 
-this just adds some more, but kept in a separate list from the body decorations 
-and outboard decorations. Returns a unique index that can be used to identify 
-this inboard decoration later (numbered starting from zero for inboard 
+attached to the parent body P, and associated with the mobilizer rather than
+the body. This DecorativeGeometry is kept in a separate list from the body 
+decorations and outboard decorations. Returns an ordinal that can be used to 
+identify this inboard decoration later (numbered starting from zero for inboard 
 decorations only). **/
 int addInboardDecoration(const Transform&          X_FD, 
                          const DecorativeGeometry& geometry);
@@ -1653,17 +1656,17 @@ implementation objects must be <em>the same object</em> not separate objects
 with identical contents. **/
 bool isSameMobilizedBody(const MobilizedBody& mobod) const;
 
-/** Determine whether this body is Ground, meaning that it is actually 
+/** Determine whether this %MobilizedBody is Ground, meaning that it is actually 
 body 0 of some matter subsytem, not just that its body type is Ground. **/
 bool isGround() const;
 
-/** Return this body's level in the tree of bodies, starting with ground at 0, 
-bodies directly connected to ground at 1, bodies directly connected to those at 
-2, etc. This is callable after realizeTopology(). This is the graph distance of 
-the body from Ground. **/
+/** Return this mobilized body's level in the tree of bodies, starting with 
+Ground at 0, mobilized bodies directly connected to Ground at 1, mobilized 
+bodies directly connected to those at 2, etc. This is callable after 
+realizeTopology(). This is the graph distance of the body from Ground. **/
 int getLevelInMultibodyTree() const;
     
-/** Create a new MobilizedBody which is identical to this one, except that it 
+/** Create a new %MobilizedBody which is identical to this one, except that it 
 has a different parent (and consequently might belong to a different 
 MultibodySystem). **/
 MobilizedBody& cloneForNewParent(MobilizedBody& parent) const;

--- a/Simbody/src/ContactTrackerSubsystem.cpp
+++ b/Simbody/src/ContactTrackerSubsystem.cpp
@@ -27,7 +27,7 @@
 #include "simbody/internal/SimbodyMatterSubsystem.h"
 #include "simbody/internal/ContactTrackerSubsystem.h"
 
-#include <algorithm>
+#include <utility>
 using std::pair; using std::make_pair;
 #include <iostream>
 using std::cout; using std::endl;
@@ -225,18 +225,29 @@ int realizeSubsystemTopologyImpl(State& state) const {
     const SimbodyMatterSubsystem& matter = getMatterSubsystem();
 
     const int numBodies = matter.getNumBodies();
+    wThis->m_mobodContactSurfaceIndex.resize(numBodies);
     wThis->m_surfaces.clear();
     wThis->m_bubbles.clear();
 
+    // ContactSurfaceIndex assignments are sequential within a MobilizedBody
+    // so we need only record the first one in order to be able to respond
+    // to getContactSurfaceIndex(mobod,ordinal) requests quickly.
+
     for (MobilizedBodyIndex mbx(0); mbx < numBodies; ++mbx) {
-        const MobilizedBody& mobod = matter.getMobilizedBody(mbx);
-        const Body&          body  = mobod.getBody();
-        for (int i=0; i < body.getNumContactSurfaces(); ++i) {
-            const ContactSurfaceIndex surfx(m_surfaces.size());
+        const MobilizedBody& mobod  = matter.getMobilizedBody(mbx);
+        const Body&          body   = mobod.getBody();
+        const int            nSurfs = body.getNumContactSurfaces();
+        const ContactSurfaceIndex firstIx = 
+            nSurfs ? ContactSurfaceIndex(m_surfaces.size())
+                   : InvalidContactSurfaceIndex;
+        wThis->m_mobodContactSurfaceIndex[mbx] = make_pair(firstIx,nSurfs);
+        for (int i=0; i < nSurfs; ++i) {
+            const ContactSurfaceIndex surfx(firstIx + i);
             wThis->m_surfaces.push_back(); // default construct
             Surface& surf = wThis->m_surfaces.back();
             surf.mobod   = &mobod; 
             surf.surface = &body.getContactSurface(i);
+            assert(surf.surface->getIndexOnBody() == i);
             surf.X_BS    =  body.getContactSurfaceTransform(i);
             const ContactGeometry& geo  = surf.surface->getShape();
             // for each bubble:
@@ -535,6 +546,25 @@ getContactTracker(ContactGeometryTypeId id1, ContactGeometryTypeId id2,
 int getNumSurfaces() const {return m_surfaces.size();}
 int getNumBubbles()  const {return m_bubbles.size();}
 
+ContactSurfaceIndex getContactSurfaceIndex(MobilizedBodyIndex mobod, 
+                                           int contactSurfaceOrdinal) const
+{
+    const int nMobods = (int)m_mobodContactSurfaceIndex.size();
+    SimTK_ERRCHK1_ALWAYS(mobod.isValid() && mobod < nMobods,
+        "ContactTrackerSubsystem::getContactSurfaceIndex()",
+        "Illegal mobilized body index %d.", (int)mobod);
+    const pair<ContactSurfaceIndex,int>& 
+        info = m_mobodContactSurfaceIndex[mobod];
+    const int nSurfaces = info.second;
+    SimTK_ERRCHK3_ALWAYS(
+        0 <= contactSurfaceOrdinal && contactSurfaceOrdinal < nSurfaces,
+        "ContactTrackerSubsystem::getContactSurfaceIndex()",
+        "Illegal ContactSurface ordinal %d; mobilized body %d has %d "
+        "contact surfaces.", contactSurfaceOrdinal, (int)mobod, nSurfaces);
+    assert(info.first.isValid());
+    return ContactSurfaceIndex(info.first + contactSurfaceOrdinal);
+}
+
 SimTK_DOWNCAST(ContactTrackerSubsystemImpl, Subsystem::Guts);
 
 private:
@@ -550,10 +580,14 @@ TrackerMap          m_contactTrackers;
 ContactTracker*     m_defaultTracker;
 
     // TOPOLOGY CACHE
-Array_<Surface,ContactSurfaceIndex> m_surfaces;
-Array_<Bubble,BubbleIndex>          m_bubbles;
-DiscreteVariableIndex               m_activeContactsIx;
-DiscreteVariableIndex               m_predictedContactsIx;
+// The pair is the first assigned index, and the number of contact surfaces
+// for a mobod, at last realizeSubsystemTopology() call.
+Array_<pair<ContactSurfaceIndex,int>, MobilizedBodyIndex>  
+                                        m_mobodContactSurfaceIndex;
+Array_<Surface,ContactSurfaceIndex>     m_surfaces;
+Array_<Bubble,BubbleIndex>              m_bubbles;
+DiscreteVariableIndex                   m_activeContactsIx;
+DiscreteVariableIndex                   m_predictedContactsIx;
 };
 
 
@@ -611,6 +645,11 @@ getContactSurface(ContactSurfaceIndex surfIx) const
 const Transform& ContactTrackerSubsystem::
 getContactSurfaceTransform(ContactSurfaceIndex surfIx) const
 {   return getImpl().m_surfaces[surfIx].X_BS; }
+
+ContactSurfaceIndex ContactTrackerSubsystem::
+getContactSurfaceIndex(MobilizedBodyIndex mobod, 
+                       int contactSurfaceOrdinal) const
+{   return getImpl().getContactSurfaceIndex(mobod,contactSurfaceOrdinal); }
 
 void ContactTrackerSubsystem::
 adoptContactTracker(ContactTracker* tracker)

--- a/Simbody/src/ContactTrackerSubsystem.cpp
+++ b/Simbody/src/ContactTrackerSubsystem.cpp
@@ -33,13 +33,14 @@ using std::pair; using std::make_pair;
 using std::cout; using std::endl;
 #include <set>
 
-
-namespace SimTK {
+using namespace SimTK;
 
 // We keep a list of all the ContactSurfaces being tracked by this
 // subsystem, and a separate list of "bubble wrap" spheres that are 
 // used in broad phase determination of which contact surfaces need
 // to be examined more closely by ContactTracker objects.
+
+namespace { // these are local to this file
 
 SimTK_DEFINE_UNIQUE_INDEX_TYPE(BubbleIndex);
 
@@ -96,7 +97,7 @@ typedef std::map< pair<ContactGeometryTypeId,ContactGeometryTypeId>,
 typedef std::map<ContactSurfaceIndex,const Contact*> ContactSurfaceSet;
 typedef std::map<ContactSurfaceIndex,ContactSurfaceSet> PairMap;
 
-static std::ostream& operator<<(std::ostream& o, const ContactSurfaceSet& css) {
+std::ostream& operator<<(std::ostream& o, const ContactSurfaceSet& css) {
     ContactSurfaceSet::const_iterator p = css.begin();
     o << "{";
     for (; p != css.end(); ++p) {
@@ -105,7 +106,8 @@ static std::ostream& operator<<(std::ostream& o, const ContactSurfaceSet& css) {
     }
     return o << "}";
 }
-static std::ostream& operator<<(std::ostream& o, const PairMap& pm) {
+
+std::ostream& operator<<(std::ostream& o, const PairMap& pm) {
     PairMap::const_iterator p = pm.begin();
     for (; p != pm.end(); ++p) {
         if (p != pm.begin()) o << endl;
@@ -114,8 +116,9 @@ static std::ostream& operator<<(std::ostream& o, const PairMap& pm) {
     return o;
 }
 
+} // end of anonymous namespace
 
-
+namespace SimTK {
 //==============================================================================
 //                       CONTACT TRACKER SUBSYSTEM IMPL
 //==============================================================================
@@ -590,7 +593,7 @@ DiscreteVariableIndex                   m_activeContactsIx;
 DiscreteVariableIndex                   m_predictedContactsIx;
 };
 
-
+} // namespace SimTK
 
 //==============================================================================
 //                        CONTACT TRACKER SUBSYSTEM
@@ -706,6 +709,4 @@ realizePredictedContacts(const State& state,
     return true;
 }
 
-
-} // namespace SimTK
 

--- a/Simbody/src/MobilizedBodyImpl.h
+++ b/Simbody/src/MobilizedBodyImpl.h
@@ -204,6 +204,9 @@ public:
         // Combine the placement frame and the transform already in the geometry
         // so we end up with geometry expressed directly in the M frame.
         outboardGeometry.back().setTransform(X_MD*g.getTransform());
+        // Record the assigned ordinal (not in the same ordinal space as
+        // body decorations).
+        outboardGeometry.back().setIndexOnBody(nxt);
         return nxt;
     }
     int addInboardDecoration(const Transform& X_FD, const DecorativeGeometry& g) {
@@ -212,6 +215,9 @@ public:
         // Combine the placement frame and the transform already in the geometry
         // so we end up with geometry expressed directly in the F frame.
         inboardGeometry.back().setTransform(X_FD*g.getTransform());
+        // Record the assigned ordinal (not in the same ordinal space as
+        // body decorations).
+        inboardGeometry.back().setIndexOnBody(nxt);
         return nxt;
     }
 

--- a/examples/ExampleContactPlayground.cpp
+++ b/examples/ExampleContactPlayground.cpp
@@ -397,6 +397,18 @@ int main() {
     // Initialize the system and state.
     
     system.realizeTopology();
+
+    // Show ContactSurfaceIndex for each contact surface
+    for (MobilizedBodyIndex mbx(0); mbx < matter.getNumBodies(); ++mbx) {
+        const MobilizedBody& mobod = matter.getMobilizedBody(mbx);
+        const int nsurfs = mobod.getBody().getNumContactSurfaces();
+        printf("mobod %d has %d contact surfaces\n", (int)mbx, nsurfs);
+        for (int i=0; i<nsurfs; ++i) {
+            printf("%2d: index %d\n", i, 
+                   (int)tracker.getContactSurfaceIndex(mbx,i)); 
+        }
+    }
+
     State state = system.getDefaultState();
     ball.setQToFitTransform(state, Transform(Rotation(Pi/2,XAxis),
                                              Vec3(0,-1.8,0)));


### PR DESCRIPTION
Previously there was no good way to map between a system's `ContactSurface` objects and the `ContactSurfaceIndex` assigned by the `ContactTrackerSubsystem`. The PR adds a method `ContactTrackerSubsystem::getContactSurfaceIndex(MobilizedBody, int contactSurfaceOrdinal)` where the ordinal is the small integrator returned by `Body::addContactSurface()`. With the `ContactSurfaceIndex` in hand it is possible to ask whether particular surfaces are currently in contact, so this fixes #263.

This PR also cleans up some doxygen and fixes mobilizer-associated inboard and outboard decorations to record their ordinal numbers (obscure).