### PR TITLE
Improve creation of symlink from docs to lib installation folder on UNIX systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,9 +24,6 @@ PROJECT(Simbody)
 # C:/Program Files/Simbody, C:/Program Files (x86)/Simbody, or the local
 # language equivalent.
 
-# Include GNUInstallDirs to get canonical paths
-include(GNUInstallDirs)
-
 IF(WIN32)
   set (CMAKE_INSTALL_DOCDIR doc)
 ELSE()
@@ -34,6 +31,9 @@ ELSE()
   # problems with some platforms: NTFS on Win, XFS or JFS variants
   set (CMAKE_INSTALL_DOCDIR ${CMAKE_INSTALL_DATAROOTDIR}/doc/simbody)
 ENDIF()
+
+# Include GNUInstallDirs to get canonical paths
+include(GNUInstallDirs)
 
 SET(SIMBODY_MAJOR_VERSION 3)
 SET(SIMBODY_MINOR_VERSION 6)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,11 +25,11 @@ PROJECT(Simbody)
 # language equivalent.
 
 IF(WIN32)
-  set (CMAKE_INSTALL_DOCDIR doc)
+  set (CMAKE_INSTALL_DOCDIR doc CACHE PATH "documentation root (DATAROOTDIR/doc/PROJECT_NAME)")
 ELSE()
   # Redefine DOCDIR to use the project name in lowercase to avoid
   # problems with some platforms: NTFS on Win, XFS or JFS variants
-  set (CMAKE_INSTALL_DOCDIR ${CMAKE_INSTALL_DATAROOTDIR}/doc/simbody)
+  set (CMAKE_INSTALL_DOCDIR share/doc/simbody CACHE PATH "documentation root (DATAROOTDIR/doc/PROJECT_NAME)")
 ENDIF()
 
 # Include GNUInstallDirs to get canonical paths

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -67,9 +67,17 @@ IF(WIN32)
   SET(EXAMPLES_INSTALL_BIN examples/bin/)
   SET(EXAMPLES_INSTALL_SRC examples/src/)
 ELSE()
-  SET(EXAMPLES_INSTALL_BIN ${CMAKE_INSTALL_FULL_LIBDIR}/simbody/examples/)
+  SET(EXAMPLES_INSTALL_BIN ${CMAKE_INSTALL_LIBDIR}/simbody/examples/) # if this changes, change the corresponding
+                                                                      # FULL version in file(RELATIVE_PATH ) command
   SET(EXAMPLES_INSTALL_SRC ${CMAKE_INSTALL_DOCDIR}/examples/src/)
-  SET(EXAMPLES_SYMLINK_BIN ${CMAKE_INSTALL_DOCDIR}/examples/)
+  # Use full paths for the following as it will be used to create a symlink
+  # The symlink itself will be a relative path, so the package will be relocatable
+  # Cannot use CMAKE_INSTALL_FULL_DOCDIR as it evaluates to a different value,
+  # as CMAKE_INSTALL_DOCDIR is changed as a "normal" variable, not in CACHE
+  SET(EXAMPLES_SYMLINK_BIN ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}/examples)
+  file(RELATIVE_PATH EXAMPLE_INSTALL_BIN_REL_TO_DOC
+      ${EXAMPLES_SYMLINK_BIN}
+      ${CMAKE_INSTALL_FULL_LIBDIR}/simbody/examples/)
 ENDIF()
 
 # CMAKE_INSTALL_PREFIX may be a relative path name; we want to bake in
@@ -152,17 +160,6 @@ FOREACH(EX_PROG ${EXAMPLES})
     ENDIF()
 ENDFOREACH()
 
-IF(NOT WIN32)
-  FILE(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tmp)
-  EXECUTE_PROCESS(COMMAND "${CMAKE_COMMAND}" -E create_symlink
-                  ${EXAMPLES_INSTALL_BIN}
-                  ${CMAKE_CURRENT_BINARY_DIR}/tmp/bin
-  )
-  INSTALL(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/tmp/
-          DESTINATION ${EXAMPLES_SYMLINK_BIN}
-  )
-ENDIF()
-
 # install top-level source for examples
 FILE(GLOB SRC_FILES "*.cpp" "*.h")
 INSTALL(FILES ${SRC_FILES} DESTINATION ${EXAMPLES_INSTALL_SRC})
@@ -191,3 +188,8 @@ ENDFOREACH()
 # install the installed version of CMakeLists.txt
 INSTALL(FILES InstalledCMakeLists.txt DESTINATION ${EXAMPLES_INSTALL_SRC}
     RENAME CMakeLists.txt)
+
+if(NOT WIN32)
+  install(CODE "EXECUTE_PROCESS(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink
+          ${EXAMPLE_INSTALL_BIN_REL_TO_DOC} ${EXAMPLES_SYMLINK_BIN}/bin)")
+endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -72,9 +72,7 @@ ELSE()
   SET(EXAMPLES_INSTALL_SRC ${CMAKE_INSTALL_DOCDIR}/examples/src/)
   # Use full paths for the following as it will be used to create a symlink
   # The symlink itself will be a relative path, so the package will be relocatable
-  # Cannot use CMAKE_INSTALL_FULL_DOCDIR as it evaluates to a different value,
-  # as CMAKE_INSTALL_DOCDIR is changed as a "normal" variable, not in CACHE
-  SET(EXAMPLES_SYMLINK_BIN ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_DOCDIR}/examples)
+  SET(EXAMPLES_SYMLINK_BIN ${CMAKE_INSTALL_FULL_DOCDIR}/examples)
   file(RELATIVE_PATH EXAMPLE_INSTALL_BIN_REL_TO_DOC
       ${EXAMPLES_SYMLINK_BIN}
       ${CMAKE_INSTALL_FULL_LIBDIR}/simbody/examples/)


### PR DESCRIPTION
As mentioned in #356, right now the symbolic link between the examples docs directory and the libexec directory that contains example binaries is wrong when the installation prefix is changes after the first CMake pass. This PR addresses this issue creating the symlink at installation time and without the need for a temporary symlink in the build directory. Also, the symlink is a relative path, in accordance to https://www.debian.org/doc/debian-policy/ch-files.html#s10.5 (please let me know if I am following the wrong policy :confused: )