### PR TITLE
Fixed element-initializing Matrix constructor (failing in Debug builds)

### DIFF
--- a/SimTKcommon/BigMatrix/src/MatrixHelper.cpp
+++ b/SimTKcommon/BigMatrix/src/MatrixHelper.cpp
@@ -771,12 +771,12 @@ MatrixHelperRep<S>::subIn(const MatrixHelper<typename CNT<S>::TNeg>& nh) {
 template <class S> void
 MatrixHelperRep<S>::fillWith(const S* eltp) {
     if (hasContiguousData()) {
-        int len = length();
+        const ptrdiff_t len = nelt();
         if (getEltSize() == 1)
-            for (int i = 0; i < len; i++)
+            for (ptrdiff_t i = 0; i < len; i++)
                 m_data[i] = *eltp;
         else
-            for (int i = 0; i < len; i++)
+            for (ptrdiff_t i = 0; i < len; i++)
                 for (int j = 0; j < getEltSize(); j++)
                     m_data[i*getEltSize()+j] = eltp[j];
     }

--- a/SimTKcommon/BigMatrix/src/MatrixHelper.cpp
+++ b/SimTKcommon/BigMatrix/src/MatrixHelper.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors:                                                              *
  *                                                                            *

--- a/SimTKcommon/tests/TestBigMatrix.cpp
+++ b/SimTKcommon/tests/TestBigMatrix.cpp
@@ -6,9 +6,9 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2007-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2007-15 Stanford University and the Authors.        *
  * Authors: Peter Eastman                                                     *
- * Contributors:                                                              *
+ * Contributors: Michael Sherman                                              *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -33,6 +33,14 @@ using std::endl;
 using namespace SimTK;
 using namespace std;
 
+template <class T>
+static bool isNaN(const T& v) { return v.isNaN(); }
+
+template<> static bool isNaN(const double& v) {return SimTK::isNaN(v);}
+template<> static bool isNaN(const float& v) {return SimTK::isNaN(v);}
+template<> static bool isNaN(const negator<double>& v) {return SimTK::isNaN(v);}
+template<> static bool isNaN(const negator<float>& v) {return SimTK::isNaN(v);}
+
 template <class T, int N>
 void testVector(const T& value, const Vec<N>& expected) {
     ASSERT(value.size() == N);
@@ -47,7 +55,7 @@ void testVector(const T& value, const Vec<N>& expected) {
 }
 
 template <class T, int M, int N>
-void testMatrix(const T& value, const Mat<M, N>& expected) {
+void testMatrix(const T& value, const Mat<M, N, typename T::E>& expected) {
     ASSERT(value.nrow() == M);
     ASSERT(value.ncol() == N);
     for (int i = 0; i < M; ++i)
@@ -123,6 +131,17 @@ int main() {
     try {
         // Currently, this only tests a small number of operations that were recently added.
         // It should be expanded into a more comprehensive test of the big matrix classes.
+
+        // Test matrix elementwise initialization.
+        Matrix minit(2,3, 5.25);
+        testMatrix<Matrix,2,3>(minit, Mat23(5.25, 5.25, 5.25,
+                                            5.25, 5.25, 5.25));
+
+        const Vec2 v12(1,2);
+        Matrix_<Vec2> mvinit(3,2, v12);
+        testMatrix<Matrix_<Vec2>,3,2>(mvinit, Mat<3,2,Vec2>(v12,v12,
+                                                            v12,v12,
+                                                            v12,v12));
 
         testMatDivision();
         testTransform();

--- a/SimTKcommon/tests/TestBigMatrix.cpp
+++ b/SimTKcommon/tests/TestBigMatrix.cpp
@@ -36,10 +36,10 @@ using namespace std;
 template <class T>
 static bool isNaN(const T& v) { return v.isNaN(); }
 
-template<> static bool isNaN(const double& v) {return SimTK::isNaN(v);}
-template<> static bool isNaN(const float& v) {return SimTK::isNaN(v);}
-template<> static bool isNaN(const negator<double>& v) {return SimTK::isNaN(v);}
-template<> static bool isNaN(const negator<float>& v) {return SimTK::isNaN(v);}
+template<> bool isNaN(const double& v) {return SimTK::isNaN(v);}
+template<> bool isNaN(const float& v) {return SimTK::isNaN(v);}
+template<> bool isNaN(const negator<double>& v) {return SimTK::isNaN(v);}
+template<> bool isNaN(const negator<float>& v) {return SimTK::isNaN(v);}
 
 template <class T, int N>
 void testVector(const T& value, const Vec<N>& expected) {


### PR DESCRIPTION
Fixes #366. The Matrix element-initializing constructor like Matrix(2,3, 3.14) was failing in Debug builds for any Matrix where all the data is contiguous, due to a broken optimization for that case.

Added test cases.

/cc @aseth1