### PR TITLE
Minor follow up mods to `Pathname` specified working directory additions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 3.6 (in development)
 --------------------
-* Added C++11 features to the SimTK::Array_ container including std::initializer_list construction, move construction, and move assignment.
+* Added C++11 features to the `SimTK::Array_` container including `std::initializer_list` construction, move construction, move assignment, and `emplace` methods.
 * Make doxygen run silently so errors will be easier to see.
+* Added new methods to `Pathname` class for interpreting pathnames against a specified working directory instead
+of the current working directory (thanks to Carmichael Ong). See [Issue #264](https://github.com/simbody/simbody/issues/264) and [PR #307](https://github.com/simbody/simbody/pull/307). 
 * (There are more that haven't been added yet)
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -369,6 +369,7 @@ Michael Sherman    |@sherm1       |Lead developer; multibody dynamics
 Peter Eastman      |@peastman     |Much early Simbody development; visualizer
 Chris Dembia       |@chrisdembia  |Build, task space control, CMA optimizer, bug fixes & documentation
 Thomas Uchida      |@tkuchida     |Rigid impact theory & code; documentation
+Carmichael Ong     |@carmichaelong|Pathname deconstruction with specified working directory
 Ian Stavness       |@stavness     |Computational geometry
 Andreas Scholz     |@AndreasScholz|Computational geometry
 José Rivero        |@j-rivero     |Build, especially for Debian

--- a/SimTKcommon/include/SimTKcommon/internal/Pathname.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Pathname.h
@@ -9,8 +9,8 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2009-12 Stanford University and the Authors.        *
- * Authors: Michael Sherman                                                   *
+ * Portions copyright (c) 2009-15 Stanford University and the Authors.        *
+ * Authors: Michael Sherman, Carmichael Ong                                   *
  * Contributors:                                                              *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
@@ -41,7 +41,7 @@ namespace SimTK {
  * of three components:
  * <pre> [directory] [filename [extension]] </pre>
  * where the directory may be an absolute location or relative to a
- * current working directory. 
+ * current working directory or specified working directory. 
  *
  * Several special directory names are supported here:
  *  - root (/)
@@ -84,6 +84,9 @@ namespace SimTK {
  * a backslash; on other platforms the canonicalized name will always
  * begin with a forward slash.
  *
+ * @bug Eliminating ".." segments textually can cause them to behave incorrectly
+ *      in the presence of symbolic links. These should probably be left in
+ *      place with evaluation deferred.
  */
 class SimTK_SimTKCOMMON_EXPORT Pathname {
 public:
@@ -127,7 +130,7 @@ public:
     /// in the directory are changed to the appropriate slash
     /// for the currently running platform (i.e. backslash for
     /// Windows and forward slash everywhere else).
-    static void deconstructPathname(    const std::string& name,
+    static void deconstructPathname(    const std::string& pathname,
                                         bool&        dontApplySearchPath,
                                         std::string& directory,
                                         std::string& fileName,
@@ -146,20 +149,20 @@ public:
     /// - If the swd is empty (after removing whitespace), deconstructPathname()
     ///   is called, and cwd is prepended if needed to make it an absolute path.
     /// - Otherwise, we evaluate path relative to the swd. These steps are as follows:
-    /// 1) If path is a root-relative path name (and on Windows this includes a drive) 
-    ///    (e.g. /usr/file.ext or c:/documents/file.ext), then swd is ignored, and the
-    ///    absolute path is returned.
-    /// 2) Preprocess the swd. This means that if the swd is of any form that denotes
-    ///    an absolute path (i.e. "C:/file.ext", "C:file.ext", "./file.ext", "/file.ext")
-    ///    we change the swd to reflect the absolute path (e.g. "./file.ext" may change
-    ///    to "/cwd/file.ext" or "C:/cwdOnC/file.ext").
-    /// 3) Otherwise, if a path is given relative to a directory that is not the root 
-    ///    (e.g. "./dir/file.ext" or "dir/file.ext"), then the swd is prepended to path.
-    /// 4) To resolve drive ambiguities, if swd provides a drive, it is used. If not, 
-    ///    then the path drive is used. If neither provides a drive, then the current 
-    ///    drive is used.
+    ///   1. If path is an absolute path name (and on Windows this includes a drive) 
+    ///      (e.g. /usr/file.ext or c:/documents/file.ext), then swd is ignored, and the
+    ///      absolute path is returned.
+    ///   2. Preprocess the swd. This means that if the swd is of any form that denotes
+    ///      an absolute path (i.e. "C:/file.ext", "C:file.ext", "./file.ext", "/file.ext")
+    ///      we change the swd to reflect the absolute path (e.g. "./file.ext" may change
+    ///      to "/cwd/file.ext" or "C:/cwdOnC/file.ext").
+    ///   3. Otherwise, if a path is given relative to a directory that is not the root 
+    ///      (e.g. "./dir/file.ext" or "dir/file.ext"), then the swd is prepended to path.
+    ///   4. To resolve drive ambiguities, if swd provides a drive, it is used. If not, 
+    ///      then the path drive is used. If neither provides a drive, then the current 
+    ///      drive is used.
     static void deconstructPathnameUsingSpecifiedWorkingDirectory(const std::string& swd,
-                                                                  const std::string& path,
+                                                                  const std::string& pathname,
                                                                   std::string& directory,
                                                                   std::string& fileName,
                                                                   std::string& extension);
@@ -167,12 +170,12 @@ public:
     /// Give back the deconstructed canonicalized absolute pathname for a given path.
     /// If the path is not an absolute path, it will be made into an absolute path first
     /// following the rules of deconstructPathname() (which it uses).
-    static void deconstructAbsolutePathname(const std::string& path,
+    static void deconstructAbsolutePathname(const std::string& pathname,
                                             std::string& directory,
                                             std::string& fileName,
                                             std::string& extension) {
         bool dontApplySearchPath;
-        deconstructPathname(path, dontApplySearchPath, directory, fileName, extension);
+        deconstructPathname(pathname, dontApplySearchPath, directory, fileName, extension);
         if (!dontApplySearchPath)
             directory = getCurrentWorkingDirectory() + directory;
     }
@@ -210,16 +213,33 @@ public:
         return absPath;
     }
 
-    static std::string findAbsolutePathnameUsingSpecifiedWorkingDirectory(const std::string& swd,
-                                                                          const std::string& path) {
+    /// Same as getAbsolutePathname() but using a specified working directory
+    /// rather than the current working directory. See
+    /// deconstructPathnameUsingSpecifiedWorkingDirectory() for subtleties.
+    static std::string getAbsolutePathnameUsingSpecifiedWorkingDirectory
+       (const std::string& swd, const std::string& pathname) {
         std::string directory, fileName, extension;
-        deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+        deconstructPathnameUsingSpecifiedWorkingDirectory
+           (swd, pathname, directory, fileName, extension);
         return directory + fileName + extension;
+    }
+
+    /// Same as getAbsoluteDirectoryPathname() but using a specified working 
+    /// directory rather than the current working directory. See
+    /// deconstructPathnameUsingSpecifiedWorkingDirectory() for subtleties.
+    static std::string 
+    getAbsoluteDirectoryPathnameUsingSpecifiedWorkingDirectory
+       (const std::string& swd, const std::string& dirPathname) {
+        std::string absPath = 
+            getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, dirPathname);
+        if (!absPath.empty() && absPath[absPath.size()-1] != getPathSeparatorChar())
+            absPath += getPathSeparatorChar();
+        return absPath;
     }
 
     /// Return true if the given pathname names a file that exists and is
     /// readable.
-    static bool fileExists(const std::string& fileName);
+    static bool fileExists(const std::string& pathname);
 
     /// Get the default installation directory for this platform. This will
     /// be /usr/local/ for Linux and Apple, and the value of the \%ProgramFiles\%

--- a/SimTKcommon/include/SimTKcommon/internal/Pathname.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Pathname.h
@@ -247,8 +247,12 @@ public:
     static std::string getDefaultInstallDir();
 
     /// Append a subdirectory offset to an existing pathname (relative or absolute).
-    /// A leading "/" in the offset is ignored, and the result ends in "/".
-    static std::string addDirectoryOffset(const std::string& base, const std::string& offset);
+    /// A single slash will be inserted in between, ignoring any slash at the
+    /// end of `base` or start of `offset`, and the result will end with a 
+    /// slash. All slashes in the result will be the correct ones for the 
+    /// current platform.
+    static std::string addDirectoryOffset(const std::string& base, 
+                                          const std::string& offset);
 
     /// Find the installation directory for something, using the named
     /// installation directory environment variable if it exists, otherwise

--- a/SimTKcommon/src/Pathname.cpp
+++ b/SimTKcommon/src/Pathname.cpp
@@ -6,8 +6,8 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2009-12 Stanford University and the Authors.        *
- * Authors: Michael Sherman                                                   *
+ * Portions copyright (c) 2009-15 Stanford University and the Authors.        *
+ * Authors: Michael Sherman, Carmichael Ong                                   *
  * Contributors:                                                              *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
@@ -162,7 +162,7 @@ static void removeDriveInPlace(string& inout, string& drive) {
 // ill formed.)
 // If there is something ill-formed about the file name we'll return
 // false.
-void Pathname::deconstructPathname( const string&   name,
+void Pathname::deconstructPathname( const string&   pathname,
                                     bool&           dontApplySearchPath,
                                     string&         directory,
                                     string&         fileName,
@@ -173,15 +173,16 @@ void Pathname::deconstructPathname( const string&   name,
 
     // Remove all the white space and make all the slashes be forward ones.
     // (For Windows they'll be changed to backslashes later.)
-    String processed = String::trimWhiteSpace(name).replaceAllChar('\\', '/');
+    String processed = String::trimWhiteSpace(pathname)
+                       .replaceAllChar('\\', '/');
     if (processed.empty())
-        return; // name consisted only of white space
+        return; // pathname consisted only of white space
 
     string drive;
     removeDriveInPlace(processed, drive);
 
     // Now the drive if any has been removed and we're looking at
-    // the beginning of the path name. 
+    // the beginning of the pathname. 
 
     // If the pathname in its entirety is just one of these, append 
     // a slash to avoid special cases below.
@@ -208,7 +209,7 @@ void Pathname::deconstructPathname( const string&   name,
         removeDriveInPlace(processed, drive);
     }
     else if (!drive.empty()) {
-        // Looks like a relative path name. But if it had an initial
+        // Looks like a relative pathname. But if it had an initial
         // drive specification, e.g. X:something.txt, that is supposed
         // to be interpreted relative to the current working directory
         // on drive X, just as though it were X:./something.txt.
@@ -220,8 +221,8 @@ void Pathname::deconstructPathname( const string&   name,
     // We may have picked up a new batch of backslashes above.
     processed.replaceAllChar('\\', '/');
 
-    // Now we have the full path name if this is absolute, otherwise
-    // we're looking at a relative path name. In any case the last
+    // Now we have the full pathname if this is absolute, otherwise
+    // we're looking at a relative pathname. In any case the last
     // component is the file name if it isn't empty, ".", or "..".
 
     // Process the ".." segments and eliminate meaningless ones
@@ -264,11 +265,12 @@ void Pathname::deconstructPathname( const string&   name,
     }
 }
 
-void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::string& swd,
-                                                                 const std::string& path,
-                                                                 std::string& directory,
-                                                                 std::string& fileName,
-                                                                 std::string& extension)
+void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory
+   (const std::string&  swd,
+    const std::string&  pathname,
+    std::string&        directory,
+    std::string&        fileName,
+    std::string&        extension)
 {
     directory.erase(); fileName.erase(); extension.erase();
     string pathdrive, swddrive, finaldrive;
@@ -276,24 +278,28 @@ void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::stri
 
     // Remove all the white space and make all the slashes be forward ones.
     // (For Windows they'll be changed to backslashes later.)
-    String pathcleaned = String::trimWhiteSpace(path).replaceAllChar('\\', '/');
-    // If path is an absolute path, then just call deconstructPathname() on the path.
+    String pathcleaned = String::trimWhiteSpace(pathname)
+                         .replaceAllChar('\\', '/');
+
+    // If pathname is absolute it is handled as though there were no swd.
     if (isAbsolutePath(pathcleaned) || isExecutableDirectoryPath(pathcleaned)) {
-        deconstructAbsolutePathname(path, directory, fileName, extension);
+        deconstructAbsolutePathname(pathname, directory, fileName, extension);
         return;
     }
     if (pathcleaned.empty())
-        return; // path consisted only of white space
+        return; // pathname consisted only of white space
     removeDriveInPlace(pathcleaned, pathdrive);
 
-    String swdcleaned = String::trimWhiteSpace(swd).replaceAllChar('\\', '/');
-    // If swd was empty, then just call deconstructPathname() on the path.
+    String swdcleaned = String::trimWhiteSpace(swd)
+                        .replaceAllChar('\\', '/');
+
+    // If swd was empty, then use the usual cwd method instead.
     if (swdcleaned.empty()) {
-        deconstructAbsolutePathname(path, directory, fileName, extension);
+        deconstructAbsolutePathname(pathname, directory, fileName, extension);
         return;
     }
 
-    // If it wasn't empty, then add a trailing "/" if necessary.
+    // If swd wasn't empty, then add a trailing "/" if necessary.
     if (swdcleaned[swdcleaned.size() - 1] != '/')
         swdcleaned += '/';
     removeDriveInPlace(swdcleaned, swddrive);
@@ -309,31 +315,32 @@ void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::stri
         swdcleaned.replace(0, 2, getCurrentWorkingDirectory(swddrive));
         removeDriveInPlace(swdcleaned, swddrive);
     }
-    // Also preprocess if swd starts with something of the form "C:folder/". Resolve
-    // by finding the current directory of this drive.
+    // Also preprocess if swd starts with something of the form "C:folder/". 
+    // Resolve by finding the current directory of this drive.
     else if (!swddrive.empty()) {
         swdcleaned.insert(0, getCurrentWorkingDirectory(swddrive));
         removeDriveInPlace(swdcleaned, swddrive);
     }
 
     /* CHECKING IF THE SWD SHOULD BE PREPENDED TO THE PATH */
-    // If path starts with "/", use path for the whole path (but deal with drive later).
+    // If pathname starts with "/", use it for the whole path (but deal with 
+    // drive later).
     if (pathcleaned.substr(0, 1) == "/") {
         processed = pathcleaned;
     }
-    // If path starts with "./", we remove the "./" and concatenate with swdcleaned.
+    // If path starts with "./": remove the "./", concatenate with swdcleaned.
     else if (pathcleaned.substr(0, 2) == "./") {
         pathcleaned.erase(0, 2);
         processed = swdcleaned + pathcleaned;
     }
-    // Looks like a relative path name (i.e. pathcleaned starts immediately with
+    // Looks like a relative pathname (i.e. pathcleaned starts immediately with
     // a directory or file name).
     else {
         processed = swdcleaned + pathcleaned;
     }
 
     /* RESOLVING THE FULL PATH */
-    // We may have picked up some backslashes through getCurrentWorkingDirectory().
+    // May have picked up some backslashes through getCurrentWorkingDirectory().
     processed.replaceAllChar('\\', '/');
 
     // If the pathname in its entirety is just one of these, append 
@@ -345,8 +352,8 @@ void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::stri
     if (processed.substr(0, 3) == "../")
         processed.insert(0, "./");
 
-    // Full path is determined except for drive letter. Resolve drive letter with
-    // swd, then path, then current drive.
+    // Full path is determined except for drive letter. Resolve drive letter
+    // with swd, then path, then current drive.
     if (processed.substr(0, 1) == "/") {
         if (!swddrive.empty()) finaldrive = swddrive;
         else if (!pathdrive.empty()) finaldrive = pathdrive;
@@ -357,7 +364,7 @@ void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::stri
         processed.replace(0, 2, getThisExecutableDirectory());
         removeDriveInPlace(processed, finaldrive);
     }
-    // Looks like a relative path name. But if either path had 
+    // Looks like a relative pathname. But if either path had 
     // an initial drive specification, e.g. X:something.txt, that is 
     // supposed to be interpreted relative to the current working directory
     // on drive X, just as though it were X:./something.txt.
@@ -375,7 +382,7 @@ void Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(const std::stri
         removeDriveInPlace(processed, finaldrive);
     }
 
-    // Build up the final path name, then use deconstructAbsolutePathname() to
+    // Build up the final pathname, then use deconstructAbsolutePathname() to
     // find the final directory, fileName, and extension.
     if (processed.substr(0, 1) != "/") processed.insert(0, "/");
     if (!finaldrive.empty()) processed.insert(0, finaldrive + ":");

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -281,6 +281,14 @@ void testPathname() {
     pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
+    swd = "D:/specified"; path = "../seconddir/myFileName.ext";
+    dir = "d:" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
     ///
 
     swd = "/specified"; path = "C:/topdir/seconddir/myFileName.ext";
@@ -572,6 +580,14 @@ void testPathname() {
 
     swd = "/specified"; path = "topdir/seconddir/myFileName.ext";
     dir = sep + "specified" + sep + "topdir" + sep + "seconddir" + sep;
+    directory = fileName = extension = "junk";
+    Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
+    SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    SimTK_TEST(pathname == dir + "myFileName.ext");
+
+    swd = "/specified"; path = "../seconddir/myFileName.ext";
+    dir = sep + "seconddir" + sep;
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -204,7 +204,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "/topdir/seconddir/myFileName.ext";
@@ -212,7 +212,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "  "; path = "C:topdir/seconddir/myFileName.ext";
@@ -220,7 +220,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "./topdir/seconddir/myFileName.ext";
@@ -228,7 +228,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = " "; path = "topdir/seconddir/myFileName.ext";
@@ -236,7 +236,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
@@ -246,7 +246,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "D:/specified"; path = "/topdir/seconddir/myFileName.ext";
@@ -254,7 +254,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "D:/specified"; path = "C:topdir/seconddir/myFileName.ext";
@@ -262,7 +262,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "D:/specified"; path = "./topdir/seconddir/myFileName.ext";
@@ -270,7 +270,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "D:/specified"; path = "topdir/seconddir/myFileName.ext";
@@ -278,7 +278,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
@@ -288,7 +288,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "/topdir/seconddir/myFileName.ext";
@@ -296,7 +296,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "C:topdir/seconddir/myFileName.ext";
@@ -304,7 +304,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "./topdir/seconddir/myFileName.ext";
@@ -312,7 +312,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "topdir/seconddir/myFileName.ext";
@@ -320,7 +320,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
@@ -330,7 +330,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "D:specified"; path = "/topdir/seconddir/myFileName.ext";
@@ -338,7 +338,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "D:specified"; path = "C:topdir/seconddir/myFileName.ext";
@@ -346,7 +346,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "D:specified"; path = "./topdir/seconddir/myFileName.ext";
@@ -354,7 +354,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "D:specified"; path = "topdir/seconddir/myFileName.ext";
@@ -362,7 +362,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
@@ -372,7 +372,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "/topdir/seconddir/myFileName.ext";
@@ -380,7 +380,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "C:topdir/seconddir/myFileName.ext";
@@ -388,7 +388,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "./topdir/seconddir/myFileName.ext";
@@ -396,7 +396,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "topdir/seconddir/myFileName.ext";
@@ -404,7 +404,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
@@ -414,7 +414,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "/topdir/seconddir/myFileName.ext";
@@ -422,7 +422,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "C:topdir/seconddir/myFileName.ext";
@@ -430,7 +430,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "./topdir/seconddir/myFileName.ext";
@@ -438,7 +438,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "topdir/seconddir/myFileName.ext";
@@ -446,7 +446,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
@@ -456,7 +456,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "";
@@ -464,7 +464,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "" && extension == "");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir);
 
     swd = "."; path = "";
@@ -472,7 +472,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "" && extension == "");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir);
 
     swd = ""; path = ".";
@@ -480,7 +480,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "" && extension == "");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir);
 
     swd = "@"; path = "topdir/seconddir/myFileName.ext";
@@ -488,7 +488,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
 #else
@@ -501,7 +501,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "/topdir/seconddir/myFileName.ext";
@@ -509,7 +509,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "C:topdir/seconddir/myFileName.ext";
@@ -517,7 +517,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "./topdir/seconddir/myFileName.ext";
@@ -525,7 +525,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = ""; path = "topdir/seconddir/myFileName.ext";
@@ -533,7 +533,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
@@ -543,7 +543,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "/topdir/seconddir/myFileName.ext";
@@ -551,7 +551,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "C:topdir/seconddir/myFileName.ext";
@@ -559,7 +559,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "./topdir/seconddir/myFileName.ext";
@@ -567,7 +567,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "/specified"; path = "topdir/seconddir/myFileName.ext";
@@ -575,7 +575,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
  
     ///
@@ -585,7 +585,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "D:specified"; path = "/topdir/seconddir/myFileName.ext";
@@ -593,7 +593,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "D:specified"; path = "C:topdir/seconddir/myFileName.ext";
@@ -601,7 +601,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "D:specified"; path = "./topdir/seconddir/myFileName.ext";
@@ -609,7 +609,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "D:specified"; path = "topdir/seconddir/myFileName.ext";
@@ -617,7 +617,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
@@ -627,7 +627,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "/topdir/seconddir/myFileName.ext";
@@ -635,7 +635,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "X:topdir/seconddir/myFileName.ext";
@@ -643,7 +643,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "./topdir/seconddir/myFileName.ext";
@@ -651,7 +651,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "./specified"; path = "topdir/seconddir/myFileName.ext";
@@ -659,7 +659,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
@@ -669,7 +669,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "/topdir/seconddir/myFileName.ext";
@@ -677,7 +677,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "C:topdir/seconddir/myFileName.ext";
@@ -685,7 +685,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "./topdir/seconddir/myFileName.ext";
@@ -693,7 +693,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "topdir/seconddir/myFileName.ext";
@@ -701,7 +701,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     ///
@@ -711,7 +711,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 
     swd = "specified"; path = "";
@@ -719,7 +719,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "" && extension == "");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir);
 
     swd = "."; path = "";
@@ -727,7 +727,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "" && extension == "");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir);
 
     swd = ""; path = ".";
@@ -735,7 +735,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "" && extension == "");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir);
 
     swd = "@"; path = "topdir/seconddir/myFileName.ext";
@@ -743,7 +743,7 @@ void testPathname() {
     directory = fileName = extension = "junk";
     Pathname::deconstructPathnameUsingSpecifiedWorkingDirectory(swd, path, directory, fileName, extension);
     SimTK_TEST(directory == dir && fileName == "myFileName" && extension == ".ext");
-    pathname = Pathname::findAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
+    pathname = Pathname::getAbsolutePathnameUsingSpecifiedWorkingDirectory(swd, path);
     SimTK_TEST(pathname == dir + "myFileName.ext");
 #endif
 


### PR DESCRIPTION
I made a few follow-on updates to @carmichaelong's PR #307:
- renamed *find*AbsolutePathnameUsingSpecifiedWorkingDirectory() to *get*... for consistency with the other method names; fixed test program to match
- fixed doxygen comments so that numbered list formats properly
- added missing method getAbsolute*Directory*PathnameUsingSpecifiedWorkingDirectory()
- updated copyright and authorship; added Carmichael to the contributors table
- updated changelog to mention new pathname methods
- some minor additions to comments
- fixed addDirectoryOffset() method so that the result always uses the platform-appropriate slashes

Carmichael, please review (other interested parties also welcome).