### PR TITLE
Remove cmake dev warning about OSX RPATH (cmp0042).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,10 @@
 cmake_minimum_required(VERSION 2.8.8)
 
 if(COMMAND cmake_policy)
-        cmake_policy(SET CMP0003 NEW)
-        cmake_policy(SET CMP0005 NEW)
+    cmake_policy(SET CMP0003 NEW)
+    cmake_policy(SET CMP0005 NEW)
+    # MACOSX_RPATH enabled by default.
+    cmake_policy(SET CMP0042 NEW)
 endif(COMMAND cmake_policy)
 
 PROJECT(Simbody)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,8 +15,10 @@ cmake_minimum_required(VERSION 2.8.8)
 if(COMMAND cmake_policy)
     cmake_policy(SET CMP0003 NEW)
     cmake_policy(SET CMP0005 NEW)
-    # MACOSX_RPATH enabled by default.
-    cmake_policy(SET CMP0042 NEW)
+    if(NOT (${CMAKE_VERSION} VERSION_LESS 3.0))
+        # MACOSX_RPATH enabled by default; policy introduced with cmake 3.0.
+        cmake_policy(SET CMP0042 NEW)
+    endif()
 endif(COMMAND cmake_policy)
 
 PROJECT(Simbody)


### PR DESCRIPTION
This PR removes the following cmake warning on osx:

```
CMake Warning (dev):

  Policy CMP0042 is not set: MACOSX_RPATH is enabled by default.  Run "cmake

  --help-policy CMP0042" for policy details.  Use the cmake_policy command to

  set the policy and suppress this warning.



  MACOSX_RPATH is not specified for the following targets:



   SimTKcommon

   SimTKmath

   SimTKsimbody



This warning is for project developers.  Use -Wno-dev to suppress it.

```

Before this PR gets merged, I want to see if travis gives an error about policy 0042 in cmake prior to v3.0, since it wasn't defined before v3.0.