### PR TITLE
Minor modifications to get simbody-3.5 to compile with Visual Studio 2015.

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/Timing.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Timing.h
@@ -58,17 +58,6 @@ librt realtime library (-lrt). **/
 #include <ctime>
 
 #if defined(_MSC_VER)
-    /* On Windows, the timespec struct is not defined. However, note that the 
-    timespec struct is also defined in the pthread.h header on Windows, so the 
-    guard symbols must match here to avoid a duplicate declaration. */
-    #ifndef HAVE_STRUCT_TIMESPEC
-    #define HAVE_STRUCT_TIMESPEC 1
-    struct timespec {
-            long tv_sec;  // TODO: this should be time_t but must fix in pthreads too
-            long tv_nsec;
-    };
-    #endif /* HAVE_STRUCT_TIMESPEC */
-
     /* Posix nanosleep() sleeps the indicated number of nanoseconds and returns
     0, or if it is interrupted early it returns how much time was left in 
     rem and returns EINTR. Ours is not interruptable so will always succeed and

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -168,7 +168,23 @@ or any other Index type to an argument expecting a certain Index type. **/
     #pragma warning(disable:4251) /*no DLL interface for type of member of exported class*/
     #pragma warning(disable:4275) /*no DLL interface for base class of exported class*/
     #pragma warning(disable:4345) /*warning about PODs being default-initialized*/
+
+     /* Until VS2015 struct timespec was missing from <ctime> so is faked here
+     if needed. However, note that it is also defined in the pthread.h header on
+     Windows, so the guard symbol must match here to avoid a duplicate declaration.
+     TODO: there is a potential problem here since VS2015's struct timespec
+     doesn't appear to match pthread's definition. */
+    #ifndef HAVE_STRUCT_TIMESPEC
+    #define HAVE_STRUCT_TIMESPEC 1
+    #if _MSC_VER < 1900
+    struct timespec {
+        long tv_sec;  // TODO: this should be time_t but must fix in pthreads too
+        long tv_nsec;
+    };
     #endif
+    #endif /* HAVE_STRUCT_TIMESPEC */
+    #endif
+
     #if defined(SimTK_SimTKCOMMON_BUILDING_SHARED_LIBRARY)
         #define SimTK_SimTKCOMMON_EXPORT __declspec(dllexport)
         /* Keep MS VC++ quiet when it tries to instantiate incomplete template classes in a DLL. */

--- a/SimTKmath/include/simmath/Differentiator.h
+++ b/SimTKmath/include/simmath/Differentiator.h
@@ -176,8 +176,16 @@ protected:
 
 private:
     // suppress copy constructor and copy assignment
+
+    // This is a workaround for a Visual Studio 2015 bug where
+    // the old-style C++03 deletion method didn't work.
+#if defined(_MSC_VER) && (_MSC_VER >= 1900)
+    Function(const Function&) = delete;
+    Function& operator=(const Function&) = delete;
+#else
     Function(const Function&);
     Function& operator=(const Function&);
+#endif
 
 friend class Differentiator;
 };


### PR DESCRIPTION
The main issue is that Microsoft added a definition of "struct timespec" to time.h which conflicted with the one we were defining.

There is a potential problem with timespec-related functions in our fake pthread implemention since the new Microsoft definition isn't identical to the one in the pthread library. I'm not sure that we are using those anywhere however.

Same as master branch PR #394 except attempts to preserve C++03 compatibility.