### PR TITLE
Get rid of some warnings detected by VS2015 at warning level 4

### DIFF
--- a/SimTKcommon/BigMatrix/include/SimTKcommon/internal/MatrixCharacteristics.h
+++ b/SimTKcommon/BigMatrix/include/SimTKcommon/internal/MatrixCharacteristics.h
@@ -505,7 +505,8 @@ public:
 
     /// This is an implicit conversion from the Condition enum to a
     /// MatrixCondition object.
-    MatrixCondition(Condition cond, Diagonal diag=UnknownDiagonal) : condition(cond) {}
+    MatrixCondition(Condition cond, Diagonal diag=UnknownDiagonal) 
+    :   condition(cond), diagonal(diag) {}
 
     /// Restore to default-constructed state of "none".
     MatrixCondition& setToNone() {condition=UnknownCondition; diagonal=UnknownDiagonal; return *this;}

--- a/SimTKcommon/Mechanics/include/SimTKcommon/internal/MassProperties.h
+++ b/SimTKcommon/Mechanics/include/SimTKcommon/internal/MassProperties.h
@@ -244,7 +244,7 @@ Inertia_(const RealP& xx, const RealP& yy, const RealP& zz,
 
 /// Construct an Inertia from a symmetric 3x3 matrix. The diagonals must
 /// be nonnegative and satisfy the triangle inequality.
-explicit Inertia_(const SymMat33P& I) : I_OF_F(I) 
+explicit Inertia_(const SymMat33P& inertia) : I_OF_F(inertia)
 {   errChk("Inertia::Inertia(SymMat33)"); }
 
 /// Construct an Inertia matrix from a 3x3 symmetric matrix. In Debug mode
@@ -289,15 +289,15 @@ Inertia_& setInertia(const RealP& xx, const RealP& yy, const RealP& zz,
 
 /// Add in another inertia matrix. Frames and reference point must be the same but
 /// we can't check. (6 flops)
-Inertia_& operator+=(const Inertia_& I) 
-{   I_OF_F += I.I_OF_F; 
+Inertia_& operator+=(const Inertia_& inertia) 
+{   I_OF_F += inertia.I_OF_F; 
     errChk("Inertia::operator+=()");
     return *this; }
 
 /// Subtract off another inertia matrix. Frames and reference point must 
 /// be the same but we can't check. (6 flops)
-Inertia_& operator-=(const Inertia_& I) 
-{   I_OF_F -= I.I_OF_F; 
+Inertia_& operator-=(const Inertia_& inertia) 
+{   I_OF_F -= inertia.I_OF_F; 
     errChk("Inertia::operator-=()");
     return *this; }
 
@@ -719,7 +719,7 @@ explicit UnitInertia_(const Mat33P& m) : InertiaP(m) {}
 /// is no way to check whether this is really a unit inertia -- \e any
 /// inertia matrix may be interpreted as a unit inertia for some shape. So
 /// be sure you know what you're doing before you use this constructor!
-explicit UnitInertia_(const Inertia_<P>& I) : InertiaP(I) {}
+explicit UnitInertia_(const Inertia_<P>& inertia) : InertiaP(inertia) {}
 
 /// Set a UnitInertia matrix to have only principal moments (that is, it
 /// will be diagonal). Returns a reference to "this" like an assignment 
@@ -841,8 +841,8 @@ const Inertia_<P>& asUnitInertia() const
 
 /// Set from a unit inertia matrix. Note that we can't check; every Inertia
 /// matrix can be interpreted as a unit inertia for some shape.
-UnitInertia_& setFromUnitInertia(const Inertia_<P>& I)
-{   Inertia_<P>::operator=(I);
+UnitInertia_& setFromUnitInertia(const Inertia_<P>& inertia)
+{   Inertia_<P>::operator=(inertia);
     return *this; }
 
 /// %Test some conditions that must hold for a valid UnitInertia matrix.

--- a/Simbody/Visualizer/src/VisualizerProtocol.cpp
+++ b/Simbody/Visualizer/src/VisualizerProtocol.cpp
@@ -474,14 +474,14 @@ void VisualizerProtocol::drawPolygonalMesh(const PolygonalMesh& mesh, const Tran
     
     meshes[impl] = (unsigned short)index;    // insert new mesh
     WRITE(outPipe, &DefineMesh, 1);
-    unsigned short numVertices = (unsigned)vertices.size()/3;
-    unsigned short numFaces = (unsigned)faces.size()/3;
+    unsigned short numVertices = (unsigned short)vertices.size()/3;
+    unsigned short numFaces = (unsigned short)faces.size()/3;
     WRITE(outPipe, &numVertices, sizeof(short));
     WRITE(outPipe, &numFaces, sizeof(short));
     WRITE(outPipe, &vertices[0], (unsigned)(vertices.size()*sizeof(float)));
     WRITE(outPipe, &faces[0], (unsigned)(faces.size()*sizeof(short)));
 
-    drawMesh(X_GM, scale, color, (short) representation, index, 0);
+    drawMesh(X_GM, scale, color, (short) representation, (unsigned short)index, 0);
 }
 
 void VisualizerProtocol::
@@ -589,11 +589,11 @@ void VisualizerProtocol::
 addMenu(const String& title, int id, const Array_<pair<String, int> >& items) {
     pthread_mutex_lock(&sceneLock);
     WRITE(outPipe, &DefineMenu, 1);
-    short titleLength = title.size();
+    short titleLength = (short)title.size();
     WRITE(outPipe, &titleLength, sizeof(short));
     WRITE(outPipe, title.c_str(), titleLength);
     WRITE(outPipe, &id, sizeof(int));
-    short numItems = items.size();
+    short numItems = (short)items.size();
     WRITE(outPipe, &numItems, sizeof(short));
     for (int i = 0; i < numItems; i++) {
         int buffer[] = {items[i].second, items[i].first.size()};
@@ -607,7 +607,7 @@ void VisualizerProtocol::
 addSlider(const String& title, int id, Real minVal, Real maxVal, Real value) {
     pthread_mutex_lock(&sceneLock);
     WRITE(outPipe, &DefineSlider, 1);
-    short titleLength = title.size();
+    short titleLength = (short)title.size();
     WRITE(outPipe, &titleLength, sizeof(short));
     WRITE(outPipe, title.c_str(), titleLength);
     WRITE(outPipe, &id, sizeof(int));
@@ -642,7 +642,7 @@ void VisualizerProtocol::setSliderRange(int id, Real newMin, Real newMax) const 
 void VisualizerProtocol::setWindowTitle(const String& title) const {
     pthread_mutex_lock(&sceneLock);
     WRITE(outPipe, &SetWindowTitle, 1);
-    short titleLength = title.size();
+    short titleLength = (short)title.size();
     WRITE(outPipe, &titleLength, sizeof(short));
     WRITE(outPipe, title.c_str(), titleLength);
     pthread_mutex_unlock(&sceneLock);

--- a/Simbody/Visualizer/src/VisualizerProtocol.cpp
+++ b/Simbody/Visualizer/src/VisualizerProtocol.cpp
@@ -474,8 +474,8 @@ void VisualizerProtocol::drawPolygonalMesh(const PolygonalMesh& mesh, const Tran
     
     meshes[impl] = (unsigned short)index;    // insert new mesh
     WRITE(outPipe, &DefineMesh, 1);
-    unsigned short numVertices = (unsigned short)vertices.size()/3;
-    unsigned short numFaces = (unsigned short)faces.size()/3;
+    unsigned short numVertices = (unsigned short)(vertices.size()/3);
+    unsigned short numFaces = (unsigned short)(faces.size()/3);
     WRITE(outPipe, &numVertices, sizeof(short));
     WRITE(outPipe, &numFaces, sizeof(short));
     WRITE(outPipe, &vertices[0], (unsigned)(vertices.size()*sizeof(float)));


### PR DESCRIPTION
This fixes a few warnings, including those mentioned by @chrisdembia in opensim-org/opensim32#19, but there are many more. This is warning free on level 3.