### PR TITLE
Make Array_<T> copy more strict for element type mismatch

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/Array.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Array.h
@@ -40,6 +40,7 @@
 #include <ostream>
 #include <climits>
 #include <typeinfo>
+#include <type_traits>
 #include <initializer_list>
 #include <utility>
 
@@ -1597,10 +1598,13 @@ Array_(const InputIter& first, const InputIter& last1) : Base() {
 /** Construct an Array_<T> from a range [first,last1) of values identified by a 
 pair of ordinary pointers to elements of type T2 (where T2 might be the same as
 T but doesn't have to be). This is templatized so can be used with any source 
-type T2 for which there is a working conversion constructor T(T2), provided
+type T2 which is either T or implicitly convertible to T, provided
 that the number of source elements does not exceed the array's max_size(). **/
 template <class T2>
 Array_(const T2* first, const T2* last1) : Base() {
+    static_assert(std::is_assignable<T&,T2>::value,
+        "Array_<T> construction from T2 requires that "
+        "T2 implicitly converts to T");
     SimTK_ERRCHK((first&&last1)||(first==last1), "Array_<T>(first,last1)", 
         "Pointers must be non-null unless they are both null.");
     SimTK_ERRCHK3(this->isSizeOK(last1-first), "Array_<T>(first,last1)",

--- a/Simbody/src/PGSImpulseSolver.cpp
+++ b/Simbody/src/PGSImpulseSolver.cpp
@@ -71,12 +71,12 @@ Real doRowSum(const Array_<MultiplierIndex>& columns,
 // we switch columns.
 // Vectors must be contiguous, Matrix must be packed and in column order (i.e.
 // columns are contiguous.) So A(r,c) = A[r + c*m].
-void doRowSums(const Array_<MultiplierIndex>& columns,
-               const Array_<MultiplierIndex>& rows,
-               const Matrix&                  A, 
-               const Vector&                  D,
-               const Vector&                  pi,
-               Array_<Real>&                  sums)
+void doRowSums(const Array_<int>& columns, // these are MultiplierIndex ints
+               const Array_<int>& rows,
+               const Matrix&      A, 
+               const Vector&      D,
+               const Vector&      pi,
+               Array_<Real>&      sums)
 {
     assert(pi.hasContiguousData());
     const Real* pip = &pi[0];
@@ -122,7 +122,7 @@ inline Real doUpdate(const MultiplierIndex& row,
 
 // Same but now we're doing multiple row updates and return the sum of the
 // squared errors for those rows.
-Real doUpdates(const Array_<MultiplierIndex>& rows,
+Real doUpdates(const Array_<int>& rows, // These are MultiplierIndex ints
                const Matrix&                  A,
                const Vector&                  D,
                const Vector&                  rhs,
@@ -133,7 +133,7 @@ Real doUpdates(const Array_<MultiplierIndex>& rows,
     const bool hasDiag = (D.size() > 0);
     Real er2 = 0;
     for (unsigned i=0; i<rows.size(); ++i) {
-        const MultiplierIndex row = rows[i];
+        const MultiplierIndex row(rows[i]);
         Real Arr = A(row,row);
         if (hasDiag) Arr += D[row];
         const Real er = rhs[row]-rowSums[i];
@@ -197,8 +197,10 @@ and index set IF identifying the components of the friction vector, ensure
 that ||pi[IF]|| <= mu*||pi[IN]|| by scaling the friction vector if necessary.
 Return true if any change is made. **/
 ImpulseSolver::FricCond 
-boundFriction(Real mu, const Array_<MultiplierIndex>& IN, 
-              const Array_<MultiplierIndex>& IF, Vector& pi) {
+boundFriction(Real mu, 
+              const Array_<int>& IN, // these are MultiplierIndex ints 
+              const Array_<int>& IF, 
+              Vector& pi) {
     assert(mu >= 0);
     Real N2=0, F2=0; // squares of normal and friction force magnitudes
     for (unsigned i=0; i<IN.size(); ++i) N2 += square(pi[IN[i]]);

--- a/Simbody/tests/adhoc/WristMomentArm.cpp
+++ b/Simbody/tests/adhoc/WristMomentArm.cpp
@@ -503,18 +503,18 @@ int main() {
     aux1Hand.push_back(MobilizedBodyIndex(hand)); 
     aux1Wrap.push_back(MobilizedBodyIndex(aux1)); 
     aux1Wrap.push_back(MobilizedBodyIndex(wrap)); 
-    Array_<MobilizerUIndex> whichUs(2, MobilizerUIndex(0));
+    Array_<MobilizerQIndex> whichQs(2, MobilizerQIndex(0));
 
     Constraint::CoordinateCoupler 
     aux1toAux2(matter,
         new Function::Linear(Vector(Vec3(ratios1[0],ratios1[1],0))),
-        aux1aux2, whichUs);
+        aux1aux2, whichQs);
     aux1toAux2.setDisabledByDefault(true);
 
     Constraint::CoordinateCoupler 
     aux1toHand(matter,
         new Function::Linear(Vector(Vec3(ratios2[0],ratios2[1],0))),
-        aux1Hand, whichUs);
+        aux1Hand, whichQs);
     aux1toHand.setDisabledByDefault(true);
 
     // Coupling ratio to the wrap surface's body is hardcoded to
@@ -522,7 +522,7 @@ int main() {
     Constraint::CoordinateCoupler
     aux1toWrap(matter,
         new Function::Linear(Vector(Vec3(1, -.4, 0))),
-        aux1Wrap, whichUs);
+        aux1Wrap, whichQs);
 
     // Enable this to make a point of the hand touch a plane fixed on ground.
     // We'll optionally use this constraint instead of one of the couplers


### PR DESCRIPTION
The Array_ class supports creating an Array_<T> from an Array_<T2>. It was allowing this as long as there is a constructor T(T2) that works, but that is too generous. It should only work if there is an *implicit* conversion like that. The existing behavior was causing some unexpected copying to occur due to inadvertent type mismatches.

This change uses `static_assert` and `std::is_assignable` to prevent compilation in the case that there is no T2 to T implicit conversion.

This PR also fixes two Array_ usage bugs caught by this change.