### PR TITLE
Add DEPRECATED_14 macro

### DIFF
--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
@@ -165,6 +165,11 @@ private:
 
 namespace Exception {
 
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4996) // don't warn about sprintf, etc.
+#endif
+
 class RealizeTopologyMustBeCalledFirst : public Base {
 public:
     RealizeTopologyMustBeCalledFirst(const char* fn, int ln,
@@ -279,6 +284,9 @@ public:
     virtual ~RealizeCheckFailed() throw() { }
 };
 
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 } // namespace Exception
 

--- a/SimTKcommon/Simulation/src/Event.cpp
+++ b/SimTKcommon/Simulation/src/Event.cpp
@@ -73,11 +73,9 @@ std::string Event::eventTriggerString(Trigger e) {
 
     // should have accounted for everything by now
     if (e != NoEventTrigger) {
-        char buf[128];
-        std::sprintf(buf, "0x%x", (unsigned)e);
         if (s.size()) s += " + ";
         s += "UNRECOGNIZED EVENT TRIGGER GARBAGE ";
-        s += buf;
+        s += String((unsigned)e, "0x%x");
     }
     return s;
 }

--- a/SimTKcommon/include/SimTKcommon/internal/ClonePtr.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ClonePtr.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors:                                                              *
  *                                                                            *
@@ -148,12 +148,17 @@ public:
     the container is non-null (that is, not empty). **/
     operator bool() const { return !empty(); }
 
-    /** Return a writable pointer to the contained object if any, or null. 
-    You can use the "address of" operator\&() instead if you prefer. **/
-    T* updPtr() { return p; }
-    /** Return a const pointer to the contained object if any, or null.  
-    You can use the "address of" operator\&() instead if you prefer. **/
-    const T* getPtr()  const  { return p; }
+    /** Return a const pointer to the contained object if any, or nullptr. Note 
+    that this is different than `%get()` for the standard smart pointers which 
+    return a writable pointer. Use upd() here for that purpose. 
+    @see upd(), getRef() **/
+    const T* get()  const  { return p; }
+
+    /** Return a writable pointer to the contained object if any, or nullptr. 
+    Note that you need write access to this container in order to get write 
+    access to the object it contains.
+    @see get(), updRef() **/
+    T* upd() { return p; }
 
     /** Return a writable reference to the contained object. Don't call this if
     this container is empty. There is also an implicit conversion to reference
@@ -202,7 +207,11 @@ public:
         other.reset(p);
         reset(otherp);
     }
-     
+
+    DEPRECATED_14("use get() instead")
+    const T* getPtr()  const  { return get(); }
+    DEPRECATED_14("use upd() instead")
+    T* updPtr() { return upd(); }
 private:
     // Warning: ClonePtr must be exactly the same size as type T*. That way
     // one can reinterpret_cast a T* to a ClonePtr<T> when needed.

--- a/SimTKcommon/include/SimTKcommon/internal/ClonePtr.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ClonePtr.h
@@ -208,8 +208,12 @@ public:
         reset(otherp);
     }
 
+    /** <b>(Deprecated)</b> Same as `get()`. Use get() instead; it is more like 
+    the API for `std::unique_ptr`. **/
     DEPRECATED_14("use get() instead")
     const T* getPtr()  const  { return get(); }
+    /** <b>(Deprecated)</b> Same as `upd()`. Use upd() instead; it is a better 
+    match for `get()` modeled after the API for `std::unique_ptr`. **/
     DEPRECATED_14("use upd() instead")
     T* updPtr() { return upd(); }
 private:

--- a/SimTKcommon/include/SimTKcommon/internal/Exception.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Exception.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors:                                                              *
  *                                                                            *
@@ -24,11 +24,6 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// Keeps MS VC++ 8 quiet about sprintf, strcpy, etc.
-#ifdef _MSC_VER
-#pragma warning(disable:4996)
-#endif
-
 #include "SimTKcommon/internal/common.h"
 
 #include <string>
@@ -40,6 +35,12 @@
 namespace SimTK {
 
 namespace Exception {
+
+    // Keeps MS VC++ quiet about sprintf, strcpy, etc.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
     
 // SimTK::Exception::Base    
 class Base : public std::exception {
@@ -302,6 +303,10 @@ public:
     }    
     virtual ~Cant() throw() { }
 };
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 } // namespace Exception
 } // namespace SimTK

--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors:                                                              *
  *                                                                            *
@@ -24,12 +24,6 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// Keeps MS VC++ 8 quiet about sprintf, strcpy, etc.
-#ifdef _MSC_VER
-#pragma warning(disable:4996)
-#endif
-
-
 #include "SimTKcommon/internal/common.h"
 #include "SimTKcommon/internal/ExceptionMacros.h"
 
@@ -38,6 +32,12 @@
 #include <limits>
 #include <complex>
 #include <sstream>
+
+// Keeps MS VC++ quiet about sprintf, strcpy, etc.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4996)
+#endif
 
 namespace SimTK {
 
@@ -465,5 +465,10 @@ template <class T> inline static
 T convertStringTo(const String& in)
 {   return in.convertTo<T>(); }
 
-}
+} // namespace SimTK
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 #endif // SimTK_SimTKCOMMON_STRING_H_

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-14 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors: Chris Dembia                                                 *
  *                                                                            *
@@ -262,8 +262,24 @@ cache misses which ultimately reduce performance. */
     #define SimTK_FORCE_INLINE __attribute__((always_inline))
 #endif
 
+/* C++14 introduces a standard way to mark deprecated declarations. Before
+that we can use non-standard compiler hacks. */
+#ifndef SWIG
+    #if __cplusplus >= 201402L
+        /* C++14 */
+        #define DEPRECATED_14(MSG) [[deprecated(MSG)]]
+    #elif _MSC_VER
+        /* VC++ just says warning C4996 so add "DEPRECATED" to the message. */
+        #define DEPRECATED_14(MSG) __declspec(deprecated("DEPRECATED: " MSG))
+    #else /* gcc or clang */
+        #define DEPRECATED_14(MSG) __attribute__((deprecated(MSG)))
+    #endif
+#else /* Swigging */
+    #define DEPRECATED_14(MSG)
+#endif
+
 /* These macros are deprecated, leftover from before C++11 was available. 
-Don't use them. */
+Don't use them. Sorry, can't use the DEPRECATED_14 macro here! */
 #define OVERRIDE_11 override
 #define FINAL_11 final
 

--- a/SimTKcommon/src/String.cpp
+++ b/SimTKcommon/src/String.cpp
@@ -37,6 +37,10 @@
 
 using SimTK::String;
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996) // don't warn about sprintf, etc.
+#endif
+
 String::String(float r, const char* fmt) {
     if (!isFinite(r)) {
         if (isNaN(r)) {(*this)="NaN"; return;}

--- a/SimTKmath/LinearAlgebra/src/LapackInterface.cpp
+++ b/SimTKmath/LinearAlgebra/src/LapackInterface.cpp
@@ -34,6 +34,10 @@
 #include "WorkSpace.h"
 #include <cstring>
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996) // don't warn about strcat, sprintf, etc.
+#endif
+
 static const double EPS = .000001;
 namespace SimTK {
 

--- a/SimTKmath/Optimizers/src/CFSQPOptimizer.cpp
+++ b/SimTKmath/Optimizers/src/CFSQPOptimizer.cpp
@@ -24,6 +24,10 @@
 #include "CFSQPOptimizer.h"
 #include <string>
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996) // don't warn about strcat, sprintf, etc.
+#endif
+
 //TODO only works in double precision without some mods
 #if SimTK_DEFAULT_PRECISION == 2
 

--- a/SimTKmath/Optimizers/src/InteriorPointOptimizer.cpp
+++ b/SimTKmath/Optimizers/src/InteriorPointOptimizer.cpp
@@ -26,6 +26,9 @@
 using std::cout;
 using std::endl;
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996) // don't warn about strcat, sprintf, etc.
+#endif
 
 namespace SimTK {
 

--- a/SimTKmath/Optimizers/src/LBFGSBOptimizer.cpp
+++ b/SimTKmath/Optimizers/src/LBFGSBOptimizer.cpp
@@ -28,6 +28,11 @@
 
 using std::cout;
 using std::endl;
+
+#ifdef _MSC_VER
+#pragma warning(disable:4996) // don't warn about strcat, sprintf, etc.
+#endif
+
 namespace SimTK {
 
 Optimizer::OptimizerRep* LBFGSBOptimizer::clone() const {

--- a/SimTKmath/Optimizers/src/lbfgs.cpp
+++ b/SimTKmath/Optimizers/src/lbfgs.cpp
@@ -30,6 +30,10 @@
 #include <iostream> 
 #include <cmath>
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996) // don't warn about strcat, sprintf, etc.
+#endif
+
 #define NUMBER_OF_CORRECTIONS 5   
 
 #if SimTK_DEFAULT_PRECISION==1 // float

--- a/SimTKmath/Optimizers/src/lbfgsb.cpp
+++ b/SimTKmath/Optimizers/src/lbfgsb.cpp
@@ -52,6 +52,10 @@
 #include <ctime>
 #include <cstring>
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996) // don't warn about strcat, sprintf, etc.
+#endif
+
 #define  imin(X, Y)  ((X) < (Y) ? (X) : (Y))
 
 #if SimTK_DEFAULT_PRECISION==1 // float

--- a/SimTKmath/include/simmath/internal/common.h
+++ b/SimTKmath/include/simmath/internal/common.h
@@ -79,8 +79,12 @@ const static double NEGATIVE_INF = -2e19;
 
 namespace SimTK {
 
-
 namespace Exception {
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4996) // don't warn about sprintf, etc.
+#endif
 
 class OptimizerFailed : public Base {
 public:
@@ -173,6 +177,11 @@ public:
         }
 private:
 };
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
 } // namespace Exception
 
 } //  namespace SimTK

--- a/SimTKmath/src/About.cpp
+++ b/SimTKmath/src/About.cpp
@@ -33,6 +33,10 @@
 #include <cstring>
 #include <cctype>
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996) // don't warn about strcat, sprintf, etc.
+#endif
+
 #define STR(var) #var
 #define MAKE_VERSION_STRING(maj,min,build)  STR(maj.min.build)
 #define MAKE_COPYRIGHT_STRING(y,a) \

--- a/SimTKmath/src/MultibodyGraphMaker.cpp
+++ b/SimTKmath/src/MultibodyGraphMaker.cpp
@@ -36,6 +36,10 @@
 
 using std::cout; using std::endl;
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996) // don't warn about strcat, sprintf, etc.
+#endif
+
 namespace SimTK {
 
 //------------------------------------------------------------------------------

--- a/Simbody/Visualizer/simbody-visualizer/glut32/glut.h
+++ b/Simbody/Visualizer/simbody-visualizer/glut32/glut.h
@@ -9,6 +9,7 @@
 
 #if defined(_WIN32)
 #if defined(_MSC_VER)
+    #pragma warning(push)
     #pragma warning(disable:4996)/*"unsafe" strcpy(), etc.*/
 #endif
 
@@ -725,6 +726,12 @@ GLUTAPI int APIENTRY glutGameModeGet(GLenum mode);
 #ifdef GLUT_DEFINED__CRTIMP
 # undef GLUT_DEFINED__CRTIMP
 # undef _CRTIMP
+#endif
+
+#if defined(_WIN32)
+#if defined(_MSC_VER)
+    #pragma warning(pop)
+#endif
 #endif
 
 #endif                  /* __glut_h__ */

--- a/Simbody/Visualizer/src/VisualizerProtocol.cpp
+++ b/Simbody/Visualizer/src/VisualizerProtocol.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2010-14 Stanford University and the Authors.        *
+ * Portions copyright (c) 2010-15 Stanford University and the Authors.        *
  * Authors: Peter Eastman, Michael Sherman                                    *
  * Contributors:                                                              *
  *                                                                            *
@@ -41,16 +41,22 @@ using namespace std;
     #include <io.h>
     #include <process.h>
     #define READ _read
+    #define WRITEFUNC _write
 #else
     #include <unistd.h>
     #define READ read
+    #define WRITEFUNC write
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(disable:4996) // don't warn about strcat, sprintf, etc.
 #endif
 
 // gcc 4.4.3 complains bitterly if you don't check the return
 // status from the write() system call. This avoids those 
 // warnings and maybe, someday, will catch an error.
 #define WRITE(pipeno, buf, len) \
-   {int status=write((pipeno), (buf), (len)); \
+   {int status=WRITEFUNC((pipeno), (buf), (len)); \
     SimTK_ERRCHK4_ALWAYS(status!=-1, "VisualizerProtocol",  \
     "An attempt to write() %d bytes to pipe %d failed with errno=%d (%s).", \
     (len),(pipeno),errno,strerror(errno));}

--- a/Simbody/src/About.cpp
+++ b/Simbody/src/About.cpp
@@ -32,6 +32,10 @@
 #include <cstring>
 #include <cctype>
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996) // don't warn about strcat, sprintf, etc.
+#endif
+
 #define STR(var) #var
 #define MAKE_VERSION_STRING(maj,min,build)  STR(maj.min.build)
 #define MAKE_COPYRIGHT_STRING(y,a) \

--- a/Simbody/tests/adhoc/CoarseRNA.cpp
+++ b/Simbody/tests/adhoc/CoarseRNA.cpp
@@ -33,6 +33,10 @@
 #include <vector>
 #include <ctime>
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996) // don't warn about strerror, sprintf, etc.
+#endif
+
 using namespace std;
 using namespace SimTK;
 

--- a/Simbody/tests/adhoc/TestMultibodyPerformance.cpp
+++ b/Simbody/tests/adhoc/TestMultibodyPerformance.cpp
@@ -29,6 +29,10 @@ using std::cout;
 using std::endl;
 using std::string;
 
+#ifdef _MSC_VER
+#pragma warning(disable:4996) // don't warn about strerror, sprintf, etc.
+#endif
+
 using namespace SimTK;
 
 /**


### PR DESCRIPTION
This PR adds a `DEPRECATED_14("message")` macro to be used until we can require C++14 everywhere. For now it expands to the standard `[[deprecated("message")]]` when compiled with C++14 but otherwise expands into non-standard compiler-specific hacks that work the same way.

This required turning off general suppression of "deprecated" warnings in VC++, replacing with local deprecation where necessary. That may affect users of Simbody (possibly including OpenSim), if they are using functions that VC++ deems (incorrectly) to have been deprecated, such as `sprintf()`, `getenv()`, and `ctime()`, and were counting on Simbody to silence those warnings.

I also used the new macro to deprecate `ClonePtr::getPtr()` and `updPtr()` in favor of more C++11-like `get()` and `upd()`.