### PR TITLE
Improve Simbody's smart pointers for consistency and compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 3.6 (in development)
 --------------------
 * Added C++11 features to the `SimTK::Array_` container including `std::initializer_list` construction, move construction, move assignment, and `emplace` methods.
+* Prevented copy construction of Array_<T> from Array_<T2> unless T2 is *implicitly*
+  convertible to T. Previously this was allowed if there was any conversion possible
+  even if it was explicit. Array_ was being too relaxed about this, causing hidden 
+  copies to occur. 
+* Added CloneOnWritePtr smart pointer (acts like ClonePtr but with deferred cloning).
+* Updated ClonePtr and ReferencePtr APIs to follow C++11 standard smart pointer
+  terminology. This required deprecating some existing methods and operators, so
+  you can expect to get annoying warnings until you switch to the new API. 
+* Possible BREAKING CHANGE: ClonePtr's operator==() previously delegated
+  to the managed object; not it just operates on the managed pointer as is done 
+  in other smart pointers. Consequently now only a clone() method is required for a type
+  to be contained in a ClonePtr; previously it had to support comparison also.
 * Make doxygen run silently so errors will be easier to see.
 * Added new methods to `Pathname` class for interpreting pathnames against a specified working directory instead
 of the current working directory (thanks to Carmichael Ong). See [Issue #264](https://github.com/simbody/simbody/issues/264) and [PR #307](https://github.com/simbody/simbody/pull/307). 

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1978,6 +1978,7 @@ PREDEFINED             = SimTK_SIMBODY_EXPORT= \
                          SimTK_SimTKCOMMON_EXPORT= \
                          SimTK_SIMMATH_EXPORT= \
                          SimTK_FORCE_INLINE= \
+                         NOEXCEPT_11=noexcept \
                          OVERRIDE_11=override \
                          FINAL_11=final \
                          __cplusplus

--- a/SimTKcommon/include/SimTKcommon/internal/CloneOnWritePtr.h
+++ b/SimTKcommon/include/SimTKcommon/internal/CloneOnWritePtr.h
@@ -24,8 +24,11 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+#include "SimTKcommon/internal/common.h"
+
 #include <memory>
 #include <iosfwd>
+#include <cassert>
 
 namespace SimTK {
 
@@ -40,9 +43,10 @@ SimTK::ClonePtr when the object is written. Like SimTK::ClonePtr,
 %CloneOnWritePtr supports copy and assigment operations, by insisting that the 
 contained object have a `clone()` method that returns a pointer to a 
 heap-allocated deep copy of the *concrete* object. The API is modeled as closely
-as possible to the C++11 `std::shared_ptr` and `std::unique_ptr`. The get() 
-method is modified to return a const pointer to avoid accidental copying, with 
-upd() (update) added to return a writable pointer.
+as possible to the C++11 `std::shared_ptr` and `std::unique_ptr`. However,
+it always uses a default deleter. Also, the get() method is modified to return 
+a const pointer to avoid accidental copying, with upd() (update) added to 
+return a writable pointer.
 
 This class is entirely inline and has no computational or space overhead
 beyond the cost of dealing with the reference count, except when a copy has
@@ -64,12 +68,12 @@ public:
     /** Default constructor stores a `nullptr` and sets use count to zero. No
     heap allocation is performed. The empty() method will return true when
     called on a default-constructed %CloneOnWritePtr. **/
-    CloneOnWritePtr() {init();}
+    CloneOnWritePtr() NOEXCEPT_11 {init();}
 
     /** Constructor from `nullptr` is the same as the default constructor.
     This is an implicit conversion that allows `nullptr` to be used to
     initialize a %CloneOnWritePtr. **/
-    CloneOnWritePtr(std::nullptr_t) : CloneOnWritePtr() {}
+    CloneOnWritePtr(std::nullptr_t) NOEXCEPT_11 : CloneOnWritePtr() {}
 
     /** Given a pointer to a writable heap-allocated object, take over 
     ownership of that object. The use count will be one unless the pointer
@@ -95,25 +99,25 @@ public:
     source or destination are written to subsequently a deep copy is made and
     the objects become disconnected. If the source container is empty this one
     will be as though default constructed. **/
-    CloneOnWritePtr(const CloneOnWritePtr& src) : CloneOnWritePtr() 
+    CloneOnWritePtr(const CloneOnWritePtr& src) NOEXCEPT_11 : CloneOnWritePtr() 
     {   shareWith(src); }
 
     /** Copy construction from a compatible %CloneOnWritePtr. Type `U*` must
     be implicitly convertible to type `T*`. **/
     template <class U>
-    CloneOnWritePtr(const CloneOnWritePtr<U>& src) : CloneOnWritePtr() 
+    CloneOnWritePtr(const CloneOnWritePtr<U>& src) NOEXCEPT_11 : CloneOnWritePtr() 
     {   shareWith<U>(src); }
 
     /** Move constructor is very fast and leaves the source empty. The use
     count is unchanged. If the source was empty this one will be as though
     default constructed. **/
-    CloneOnWritePtr(CloneOnWritePtr&& src) : CloneOnWritePtr() 
+    CloneOnWritePtr(CloneOnWritePtr&& src) NOEXCEPT_11 : CloneOnWritePtr() 
     {   moveFrom(std::move(src)); }
 
     /** Move construction from a compatible %CloneOnWritePtr. Type `U*` must
     be implicitly convertible to type `T*`. **/
     template <class U>
-    CloneOnWritePtr(CloneOnWritePtr<U>&& src) : CloneOnWritePtr()
+    CloneOnWritePtr(CloneOnWritePtr<U>&& src) NOEXCEPT_11 : CloneOnWritePtr()
     {   moveFrom<U>(std::move(src)); }
     /**@}**/
 
@@ -126,7 +130,7 @@ public:
     If the source container is empty this one will be empty after the 
     assignment. Nothing happens if the source and destination were already
     managing the same object. **/
-    CloneOnWritePtr& operator=(const CloneOnWritePtr& src) { 
+    CloneOnWritePtr& operator=(const CloneOnWritePtr& src) NOEXCEPT_11 { 
         if (src.p != p) 
         {   reset(); shareWith(src); }
         return *this;
@@ -135,7 +139,7 @@ public:
     /** Copy assignment from a compatible %CloneOnWritePtr. Type `U*` must
     be implicitly convertible to type `T*`. **/
     template <class U>
-    CloneOnWritePtr& operator=(const CloneOnWritePtr<U>& src) { 
+    CloneOnWritePtr& operator=(const CloneOnWritePtr<U>& src) NOEXCEPT_11 { 
         if (static_cast<T*>(src.p) != p) 
         {   reset(); shareWith<U>(src); }
         return *this;
@@ -147,7 +151,7 @@ public:
     happens if the source and destination are the same containers. If they are
     different but are sharing the same object then the use count is reduced
     by one. **/
-    CloneOnWritePtr& operator=(CloneOnWritePtr&& src) { 
+    CloneOnWritePtr& operator=(CloneOnWritePtr&& src) NOEXCEPT_11 { 
         if (&src != this) 
         {   reset(); moveFrom(std::move(src)); }
         return *this;
@@ -156,7 +160,7 @@ public:
     /** Move assignment from a compatible %CloneOnWritePtr. Type U* must
     be implicitly convertible to type T*. **/
     template <class U>
-    CloneOnWritePtr& operator=(CloneOnWritePtr<U>&& src) {
+    CloneOnWritePtr& operator=(CloneOnWritePtr<U>&& src) NOEXCEPT_11 {
         // Can't be the same container since the type is different.
         reset(); moveFrom<U>(std::move(src));
         return *this;
@@ -174,7 +178,7 @@ public:
     source object and takes over ownership of the source object. The use count
     of the currently-held object is decremented and the object is deleted if 
     this was the last reference to it. **/ 
-    CloneOnWritePtr& operator=(T* x)               
+    CloneOnWritePtr& operator=(T* x) NOEXCEPT_11
     {   reset(x); return *this; }
     /**@}**/
     
@@ -182,7 +186,7 @@ public:
     /**@{**/    
     /** Destructor decrements the reference count and deletes the object
     if the count goes to zero. @see reset() **/
-    ~CloneOnWritePtr() {reset();}
+    ~CloneOnWritePtr() NOEXCEPT_11 {reset();}
     /**@}**/
 
     /** @name                     Accessors **/
@@ -193,7 +197,7 @@ public:
     `%get()` for the standard smart pointers which return a writable pointer. 
     Use upd() here for that purpose. 
     @see upd(), getRef() **/
-    const T* get() const {return p;}
+    const T* get() const NOEXCEPT_11 {return p;}
 
     /** Clone if necessary to ensure the contained object is not shared, then 
     return a writable pointer to the contained (and now unshared) object if any,
@@ -253,7 +257,7 @@ public:
     object (if any), and deleting it if this was the last use. The container
     is restored to its default-constructed state. 
     @see empty() **/
-    void reset() {
+    void reset() NOEXCEPT_11 {
         if (empty()) return;
         if (decr()==0) {delete p; delete count;} 
         init();
@@ -264,7 +268,7 @@ public:
     first if necessary. Nothing happens if the supplied pointer is the same
     as the one already being managed. Otherwise, on return the use count will be
     one if the supplied pointer was non-null or else zero. **/
-    void reset(T* x) {
+    void reset(T* x) { // could throw when allocating count
         if (x != p) {
             reset();
             if (x) {p=x; count=new long(1);}
@@ -275,7 +279,7 @@ public:
     ownership changing hands but no copying performed. This is very fast;
     no heap activity occurs. Both containers must have been instantiated with 
     the identical type. **/
-    void swap(CloneOnWritePtr& other) {
+    void swap(CloneOnWritePtr& other) NOEXCEPT_11 {
         std::swap(p, other.p);
         std::swap(count, other.count);
     }
@@ -284,21 +288,21 @@ public:
     sharing the referenced object. There is never more than
     one holding an object for writing. If the pointer is null the use 
     count is zero. **/
-    long use_count() const {return count ? *count : 0;}
+    long use_count() const NOEXCEPT_11 {return count ? *count : 0;}
 
     /** Is this the only user of the referenced object? Note that this means
     there is exactly one; if the managed pointer is null `unique()` returns 
     `false`. **/
-    bool unique() const {return use_count()==1;}
+    bool unique() const NOEXCEPT_11 {return use_count()==1;}
    
     /** Return true if this container is empty, which is the state the container
     is in immediately after default construction and various other 
     operations. **/
-    bool empty() const {return !p;} // count should be null also
+    bool empty() const NOEXCEPT_11 {return !p;} // count should be null also
 
     /** This is a conversion to type bool that returns true if
     the container is non-null (that is, not empty). **/
-    explicit operator bool() const {return !empty();}
+    explicit operator bool() const NOEXCEPT_11 {return !empty();}
 
     /** (Advanced) Remove the contained object from management by this 
     container and transfer ownership to the caller. Clone if necessary to 
@@ -307,7 +311,7 @@ public:
     container empty. A writable pointer to the object is returned. No object 
     destruction occurs. 
     @see detach() **/
-    T* release() {
+    T* release() { // could throw during detach()
         detach(); // now use count is 1 or 0
         T* save = p; delete count; init();
         return save;
@@ -322,7 +326,7 @@ public:
     will see the shared use count reduced by one. If this is empty() or 
     unique() already then nothing happens. Note that you have to have write
     access to this container in order to detach it. **/
-    void detach() {
+    void detach() { // can throw during clone()
         if (use_count() > 1) 
         {   decr(); p=p->clone(); count=new long(1); }
     }
@@ -338,191 +342,182 @@ template <class U> friend class CloneOnWritePtr;
 
     // Set an empty pointer to share with the given object. Type U* must be
     // implicitly convertible to type T*.
-    template <class U> void shareWith(const CloneOnWritePtr<U>& src) {
+    template <class U> void shareWith(const CloneOnWritePtr<U>& src) NOEXCEPT_11 {
         assert(!(p||count)); 
         if (!src.empty()) {p=src.p; count=src.count; incr();}
     }
 
     // Steal the object and count from the source to initialize this *empty* 
     // pointer, leaving the source empty.
-    template <class U> void moveFrom(CloneOnWritePtr<U>&& src) {
+    template <class U> void moveFrom(CloneOnWritePtr<U>&& src) NOEXCEPT_11 {
         assert(!(p||count)); 
         p=src.p; count=src.count; src.init();
     }
 
     // Increment/decrement use count and return the result.
-    long incr() const {assert(count && *count>=0); return ++(*count);}
-    long decr() const {assert(count && *count>=1); return --(*count);}
+    long incr() const NOEXCEPT_11 {assert(count && *count>=0); return ++(*count);}
+    long decr() const NOEXCEPT_11 {assert(count && *count>=1); return --(*count);}
 
-    void init() {p=nullptr; count=nullptr;}
+    void init() NOEXCEPT_11 {p=nullptr; count=nullptr;}
 
     // Can't use std::shared_ptr here due to lack of release() method.
     T*      p;          // this may be null
     long*   count;      // if p is null so is count
 };    
-    
-} // namespace SimTK
-
 
 
 //==============================================================================
-//                          std:: namespace
+//                       SimTK namespace-scope functions
 //==============================================================================
-namespace std {
-/** This is a specialization of the STL std::swap() algorithm which uses the
+// These namespace-scope functions will be resolved by the compiler using
+// "Koenig lookup" which examines the arguments' namespaces first.
+// See Herb Sutter's discussion here: http://www.gotw.ca/publications/mill08.htm.
+
+/** This is an overload of the STL std::swap() algorithm which uses the
 cheap built-in swap() member of the CloneOnWritePtr class. (This function
-is defined in the `std` namespace.) 
-@relates SimTK::CloneOnWritePtr **/
+is defined in the `SimTK` namespace.) 
+@relates CloneOnWritePtr **/
 template <class T> inline void
-swap(SimTK::CloneOnWritePtr<T>& p1, SimTK::CloneOnWritePtr<T>& p2) {
+swap(CloneOnWritePtr<T>& p1, CloneOnWritePtr<T>& p2) {
     p1.swap(p2);
 }
-} // namespace std
 
-
-
-//==============================================================================
-//                          global namespace
-//==============================================================================
 /** Output the system-dependent representation of the pointer contained
-in a SimTK::CloneOnWritePtr object. This is equivalent to `os << p.get();`.
-This operator is defined in the global namespace.
-@relates SimTK::CloneOnWritePtr **/
+in a CloneOnWritePtr object. This is equivalent to `os << p.get();`.
+@relates CloneOnWritePtr **/
 template <class charT, class traits, class T>
 inline std::basic_ostream<charT,traits>& 
 operator<<(std::basic_ostream<charT,traits>& os, 
-           const SimTK::CloneOnWritePtr<T>&  p) 
-{   os << p.get(); }
+           const CloneOnWritePtr<T>&  p) 
+{   os << p.get(); return os; }
 
 /** Compare for equality the managed pointers contained in two compatible
-SimTK::CloneOnWritePtr containers. Returns `true` if the pointers refer to
+CloneOnWritePtr containers. Returns `true` if the pointers refer to
 the same object or if both are null. It must be possible for one of the
 pointer types `T*` and `U*` to be implicitly converted to the other.
-This operator is defined in the global namespace.
-@relates SimTK::CloneOnWritePtr **/
+@relates CloneOnWritePtr **/
 template <class T, class U>
-inline bool operator==(const SimTK::CloneOnWritePtr<T>& lhs,
-                       const SimTK::CloneOnWritePtr<U>& rhs)
+inline bool operator==(const CloneOnWritePtr<T>& lhs,
+                       const CloneOnWritePtr<U>& rhs)
 {   return lhs.get() == rhs.get(); }
 
 /** Comparison against `nullptr`; same as `lhs.empty()`. 
-This operator is defined in the global namespace.
-@relates SimTK::CloneOnWritePtr **/
+@relates CloneOnWritePtr **/
 template <class T>
-inline bool operator==(const SimTK::CloneOnWritePtr<T>& lhs, std::nullptr_t)
+inline bool operator==(const CloneOnWritePtr<T>& lhs, std::nullptr_t)
 {   return lhs.empty(); }
 
 /** Comparison against `nullptr`; same as `rhs.empty()`. 
-This operator is defined in the global namespace.
-@relates SimTK::CloneOnWritePtr **/
+@relates CloneOnWritePtr **/
 template <class T>
-inline bool operator==(std::nullptr_t, const SimTK::CloneOnWritePtr<T>& rhs)
+inline bool operator==(std::nullptr_t, const CloneOnWritePtr<T>& rhs)
 {   return rhs.empty(); }
 
-/** Less-than operator for two compatible SimTK::CloneOnWritePtr containers, 
+/** Less-than operator for two compatible CloneOnWritePtr containers, 
 comparing the *pointers*, not the *objects* they point to. Returns `true` if the
 lhs pointer tests less than the rhs pointer. A null pointer tests less than any
 non-null pointer. It must be possible for one of the pointer types `T*` and 
-`U*` to be implicitly converted to the other. This operator is defined in the 
-global namespace. @relates SimTK::CloneOnWritePtr **/
+`U*` to be implicitly converted to the other.
+@relates CloneOnWritePtr **/
 template <class T, class U>
-inline bool operator<(const SimTK::CloneOnWritePtr<T>& lhs,
-                      const SimTK::CloneOnWritePtr<U>& rhs)
+inline bool operator<(const CloneOnWritePtr<T>& lhs,
+                      const CloneOnWritePtr<U>& rhs)
 {   return lhs.get() < rhs.get(); }
 
 /** Less-than comparison against a `nullptr`. A null pointer tests less than any
 non-null pointer and equal to another null pointer, so this method always 
-returns `false`. This operator is defined in the global namespace.
-@relates SimTK::CloneOnWritePtr **/
+returns `false`.
+@relates CloneOnWritePtr **/
 template <class T>
-inline bool operator<(const SimTK::CloneOnWritePtr<T>& lhs, std::nullptr_t)
+inline bool operator<(const CloneOnWritePtr<T>& lhs, std::nullptr_t)
 {   return false; }
 
 /** Less-than comparison of a `nullptr` against this container. A null
 pointer tests less than any non-null pointer and equal to another null pointer,
-so this method returns `true` unless the container is empty. This operator is 
-defined in the global namespace. @relates SimTK::CloneOnWritePtr **/
+so this method returns `true` unless the container is empty. 
+@relates CloneOnWritePtr **/
 template <class T>
-inline bool operator<(std::nullptr_t, const SimTK::CloneOnWritePtr<T>& rhs)
+inline bool operator<(std::nullptr_t, const CloneOnWritePtr<T>& rhs)
 {   return !rhs.empty(); }
 
 
 // These functions are derived from operator== and operator<.
 
-/** Pointer inequality test defined as `!(lhs==rhs)`. This operator is defined 
-in the global namespace. @relates SimTK::CloneOnWritePtr **/
+/** Pointer inequality test defined as `!(lhs==rhs)`.
+@relates CloneOnWritePtr **/
 template <class T, class U>
-inline bool operator!=(const SimTK::CloneOnWritePtr<T>& lhs,
-                       const SimTK::CloneOnWritePtr<U>& rhs)
+inline bool operator!=(const CloneOnWritePtr<T>& lhs,
+                       const CloneOnWritePtr<U>& rhs)
 {   return !(lhs==rhs); }
-/** `nullptr` inequality test defined as `!(lhs==nullptr)`. This operator is 
-defined in the global namespace. @relates SimTK::CloneOnWritePtr **/
+/** `nullptr` inequality test defined as `!(lhs==nullptr)`.
+@relates CloneOnWritePtr **/
 template <class T>
-inline bool operator!=(const SimTK::CloneOnWritePtr<T>& lhs, std::nullptr_t)
+inline bool operator!=(const CloneOnWritePtr<T>& lhs, std::nullptr_t)
 {   return !(lhs==nullptr); }
-/** `nullptr` inequality test defined as `!(nullptr==rhs)`. This operator is 
-defined in the global namespace. @relates SimTK::CloneOnWritePtr **/
+/** `nullptr` inequality test defined as `!(nullptr==rhs)`.
+@relates CloneOnWritePtr **/
 template <class T>
-inline bool operator!=(std::nullptr_t, const SimTK::CloneOnWritePtr<T>& rhs)
+inline bool operator!=(std::nullptr_t, const CloneOnWritePtr<T>& rhs)
 {   return !(nullptr==rhs); }
 
-/** Pointer greater-than test defined as `rhs < lhs`. This operator is defined 
-in the global namespace. @relates SimTK::CloneOnWritePtr **/
+/** Pointer greater-than test defined as `rhs < lhs`.
+@relates CloneOnWritePtr **/
 template <class T, class U>
-inline bool operator>(const SimTK::CloneOnWritePtr<T>& lhs,
-                      const SimTK::CloneOnWritePtr<U>& rhs)
+inline bool operator>(const CloneOnWritePtr<T>& lhs,
+                      const CloneOnWritePtr<U>& rhs)
 {   return rhs < lhs; }
-/** `nullptr` greater-than test defined as `nullptr < lhs`. This operator is 
-defined in the global namespace. @relates SimTK::CloneOnWritePtr **/
+/** `nullptr` greater-than test defined as `nullptr < lhs`.
+@relates CloneOnWritePtr **/
 template <class T>
-inline bool operator>(const SimTK::CloneOnWritePtr<T>& lhs, std::nullptr_t)
+inline bool operator>(const CloneOnWritePtr<T>& lhs, std::nullptr_t)
 {   return nullptr < lhs; }
 
-/** `nullptr` greater-than test defined as `rhs < nullptr`. This operator is 
-defined in the global namespace. @relates SimTK::CloneOnWritePtr **/
+/** `nullptr` greater-than test defined as `rhs < nullptr`.
+@relates CloneOnWritePtr **/
 template <class T>
-inline bool operator>(std::nullptr_t, const SimTK::CloneOnWritePtr<T>& rhs)
+inline bool operator>(std::nullptr_t, const CloneOnWritePtr<T>& rhs)
 {   return rhs < nullptr; }
 
 
-/** Pointer greater-or-equal test defined as `!(lhs < rhs)`. This operator is 
-defined in the global namespace. @relates SimTK::CloneOnWritePtr **/
+/** Pointer greater-or-equal test defined as `!(lhs < rhs)`.
+@relates CloneOnWritePtr **/
 template <class T, class U>
-inline bool operator>=(const SimTK::CloneOnWritePtr<T>& lhs,
-                       const SimTK::CloneOnWritePtr<U>& rhs)
+inline bool operator>=(const CloneOnWritePtr<T>& lhs,
+                       const CloneOnWritePtr<U>& rhs)
 {   return !(lhs < rhs); }
-/** `nullptr` greater-or-equal test defined as `!(lhs < nullptr)`. This operator
-is defined in the global namespace. @relates SimTK::CloneOnWritePtr **/
+/** `nullptr` greater-or-equal test defined as `!(lhs < nullptr)`.
+@relates CloneOnWritePtr **/
 template <class T>
-inline bool operator>=(const SimTK::CloneOnWritePtr<T>& lhs, std::nullptr_t)
+inline bool operator>=(const CloneOnWritePtr<T>& lhs, std::nullptr_t)
 {   return !(lhs < nullptr); }
 
-/** `nullptr` greater-or-equal test defined as `!(nullptr < rhs)`. This operator
-is defined in the global namespace. @relates SimTK::CloneOnWritePtr **/
+/** `nullptr` greater-or-equal test defined as `!(nullptr < rhs)`.
+@relates CloneOnWritePtr **/
 template <class T>
-inline bool operator>=(std::nullptr_t, const SimTK::CloneOnWritePtr<T>& rhs)
+inline bool operator>=(std::nullptr_t, const CloneOnWritePtr<T>& rhs)
 {   return !(nullptr < rhs); }
 
 
 /** Pointer less-or-equal test defined as `!(rhs < lhs)` (note reversed
-arguments). This operator is defined in the global namespace.
-@relates SimTK::CloneOnWritePtr **/
+arguments).
+@relates CloneOnWritePtr **/
 template <class T, class U>
-inline bool operator<=(const SimTK::CloneOnWritePtr<T>& lhs,
-                       const SimTK::CloneOnWritePtr<U>& rhs)
+inline bool operator<=(const CloneOnWritePtr<T>& lhs,
+                       const CloneOnWritePtr<U>& rhs)
 {   return !(rhs < lhs); }
 /** `nullptr` less-or-equal test defined as `!(nullptr < lhs)` (note reversed
-arguments). This operator is defined in the global namespace.
-@relates SimTK::CloneOnWritePtr **/
+arguments).
+@relates CloneOnWritePtr **/
 template <class T>
-inline bool operator<=(const SimTK::CloneOnWritePtr<T>& lhs, std::nullptr_t)
+inline bool operator<=(const CloneOnWritePtr<T>& lhs, std::nullptr_t)
 {   return !(nullptr < lhs); }
 /** `nullptr` less-or-equal test defined as `!(rhs < nullptr)` (note reversed
-arguments). This operator is defined in the global namespace.
-@relates SimTK::CloneOnWritePtr **/
+arguments).
+@relates CloneOnWritePtr **/
 template <class T>
-inline bool operator<=(std::nullptr_t, const SimTK::CloneOnWritePtr<T>& rhs)
+inline bool operator<=(std::nullptr_t, const CloneOnWritePtr<T>& rhs)
 {   return !(rhs < nullptr); }
 
+} // namespace SimTK
 
 #endif // SimTK_SimTKCOMMON_CLONE_ON_WRITE_PTR_H_

--- a/SimTKcommon/include/SimTKcommon/internal/ClonePtr.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ClonePtr.h
@@ -29,6 +29,7 @@
 #include <memory>
 #include <iosfwd>
 #include <cassert>
+#include <utility>
 
 namespace SimTK {
 
@@ -63,7 +64,7 @@ public:
     /** Default constructor stores a `nullptr`. No heap allocation is performed.
     The empty() method will return true when called on a default-constructed 
     %ClonePtr. **/
-    ClonePtr() NOEXCEPT_11 {p=nullptr;}
+    ClonePtr() NOEXCEPT_11 : p(nullptr) {}
 
     /** Constructor from `nullptr` is the same as the default constructor.
     This is an implicit conversion that allows `nullptr` to be used to
@@ -108,8 +109,7 @@ public:
     source to the new %ClonePtr. If the source was empty this one will be empty 
     also. No heap activity occurs. **/
     template <class U>
-    ClonePtr(ClonePtr<U>&& src) NOEXCEPT_11 : p(src.release()) {
-    }
+    ClonePtr(ClonePtr<U>&& src) NOEXCEPT_11 : p(src.release()) {}
     /**@}**/
 
     /** @name                   Assignment **/

--- a/SimTKcommon/include/SimTKcommon/internal/ClonePtr.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ClonePtr.h
@@ -293,11 +293,15 @@ public:
     /** <b>(Deprecated)</b> Same as `get()`. Use get() instead; it is more like 
     the API for `std::unique_ptr`. **/
     DEPRECATED_14("use get() instead")
-    const T* getPtr()  const  { return get(); }
+    const T* getPtr() const NOEXCEPT_11 {return get();}
     /** <b>(Deprecated)</b> Same as `upd()`. Use upd() instead; it is a better 
     match for `get()` modeled after the API for `std::unique_ptr`. **/
     DEPRECATED_14("use upd() instead")
-    T* updPtr() { return upd(); }    
+    T* updPtr() NOEXCEPT_11 {return upd();}  
+    /** <b>(Deprecated)</b> Use reset() instead. **/
+    DEPRECATED_14("use reset() instead")
+    void clear() NOEXCEPT_11 {reset();}
+
     /**@}**/
 
 private:

--- a/SimTKcommon/include/SimTKcommon/internal/ClonePtr.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ClonePtr.h
@@ -24,188 +24,270 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+#include "SimTKcommon/internal/common.h"
+
+#include <memory>
+#include <iosfwd>
+#include <cassert>
+
 namespace SimTK {
 
-/** Wrap a pointer to an abstract base class in a way that makes it behave like
-a concrete class. This is similar to std::unique_ptr in that it does not permit
-shared ownership of the object. However, unlike std::unique_ptr, %ClonePtr
-supports copy and assigment operations, by insisting that the contained object
-have a clone() method that returns a pointer to a heap-allocated deep copy of 
-the <em>concrete</em> object.
+/** Smart pointer with deep copy semantics. This is similar to `std::unique_ptr` 
+in that it does not permit shared ownership of the contained object. However, 
+unlike `std::unique_ptr`, %ClonePtr supports copy and assignment operations, by 
+insisting that the contained object have a clone() method that returns a pointer
+to a heap-allocated deep copy of the *concrete* object. The API is modeled as 
+closely as possible on the C++11 `std::unique_ptr` API. However, it always uses
+a default deleter. Also, in keeping with Simbody's careful distinction between 
+writable and const access, and for compatibility with CloneOnWritePtr, the get() 
+method is modified to return only a const pointer, with upd() (update) added to 
+return a writable pointer.
 
-We define operator==() and operator<() here that delegate to the contained 
-object; if you want to use those the contained type must support that
-operator.
+This class is entirely inline and has no computational or space overhead except
+when cloning is required; it contains just a single pointer and does no 
+reference counting. 
 
-This class is entirely inline and has no computational or space overhead; it
-contains just a single pointer and does no reference counting. 
+@tparam T   The type of the contained object, which *must* have a `clone()` 
+            method. May be an abstract or concrete type.
 
-@see ReferencePtr **/ 
+@see CloneOnWritePtr, ReferencePtr **/ 
 template <class T> class ClonePtr {
 public:
-    typedef T  element_type;
-    typedef T* pointer;
-    typedef T& reference;
+    typedef T  element_type; ///< Type of the contained object.
+    typedef T* pointer;      ///< Type of a pointer to the contained object.
+    typedef T& reference;    ///< Type of a reference to the contained object.
+    
+    /** @name                    Constructors **/
+    /**@{**/
 
-    /** Default constructor creates an empty object. **/
-    ClonePtr() : p(0) { }
+    /** Default constructor stores a `nullptr`. No heap allocation is performed.
+    The empty() method will return true when called on a default-constructed 
+    %ClonePtr. **/
+    ClonePtr() NOEXCEPT_11 {p=nullptr;}
+
+    /** Constructor from `nullptr` is the same as the default constructor.
+    This is an implicit conversion that allows `nullptr` to be used to
+    initialize a %ClonePtr. **/
+    ClonePtr(std::nullptr_t) NOEXCEPT_11 : ClonePtr() {}
+
     /** Given a pointer to a writable heap-allocated object, take over 
-    ownership of that object. **/
-    explicit ClonePtr(T*  obj) : p(obj) { }
-    /** Given a pointer to a writable heap-allocated object, take over 
-    ownership of that object and set the original pointer to null. **/
-    explicit ClonePtr(T** obj) : p(*obj) { *obj=0; }
-    /** Given a pointer to a read-only object, create a new heap-allocated 
-    copy of that object via its clone() method and make this %ClonePtr
-    object the owner of the copy. Ownership of the original object is not
-    affected. If the supplied pointer is null, the resulting %ClonePtr
-    object is empty. **/
-    explicit ClonePtr(const T* obj) : p(cloneOrNull(obj)) { }
+    ownership of that object. The `clone()` method is *not* invoked. **/
+    explicit ClonePtr(T* x) NOEXCEPT_11 : p(x) {}
+
+    /** Given a pointer to a read-only object, create a new heap-allocated copy 
+    of that object via its `clone()` method and make this %ClonePtr the owner of
+    the copy. Ownership of the original object is not affected. If the supplied 
+    pointer is null, the resulting %ClonePtr will be empty. **/
+    explicit ClonePtr(const T* x) : ClonePtr(cloneOrNull(x)) {}
+
     /** Given a read-only reference to an object, create a new heap-allocated 
-    copy of that object via its clone() method and make this %ClonePtr
+    copy of that object via its `clone()` method and make this %ClonePtr
     object the owner of the copy. Ownership of the original object is not
     affected. **/
-    explicit ClonePtr(const T& obj) : p(obj.clone()) { }
+    explicit ClonePtr(const T& x) : ClonePtr(&x) {}
+
     /** Copy constructor is deep; the new %ClonePtr object contains a new
-    copy of the object in the source, created via the source object's clone()
+    copy of the object in the source, created via the source object's `clone()`
     method. If the source container is empty this one will be empty also. **/
-    ClonePtr(const ClonePtr& c) : p(cloneOrNull(c.p)) { }
-    /** Copy assignment replaces the currently-held object by a heap-allocated
-    copy of the object held in the source container. The copy is created using 
-    the source object's clone() method. The currently-held object is deleted. 
-    If the source container is empty this one will be empty after the 
-    assignment. **/
-    ClonePtr& operator=(const ClonePtr& c) 
-    {   reset(cloneOrNull(c.p)); return *this; }
+    ClonePtr(const ClonePtr& src) : p(cloneOrNull(src.p)) {}
+
+    /** Deep copy construction from a compatible %ClonePtr. Type `U*` must be 
+    implicitly convertible to type `T*`. The new %ClonePtr object contains a new
+    copy of the object in the source, created via the source object's `clone()`
+    method. If the source container is empty this one will be empty also. **/
+    template <class U>
+    ClonePtr(const ClonePtr<U>& src) : p(cloneOrNull(src.p)) {} 
+
+    /** Move constructor is very fast and leaves the source empty. Ownership
+    is transferred from the source to the new %ClonePtr. If the source was empty
+    this one will be empty also. No heap activity occurs. **/
+    ClonePtr(ClonePtr&& src) NOEXCEPT_11 : p(src.release()) {} 
+
+    /** Move construction from a compatible %ClonePtr. Type `U*` must be 
+    implicitly convertible to type `T*`. Ownership is transferred from the 
+    source to the new %ClonePtr. If the source was empty this one will be empty 
+    also. No heap activity occurs. **/
+    template <class U>
+    ClonePtr(ClonePtr<U>&& src) NOEXCEPT_11 : p(src.release()) {
+    }
+    /**@}**/
+
+    /** @name                   Assignment **/
+    /**@{**/
+
+    /** Copy assignment replaces the currently-held object by a copy of the 
+    object held in the source container, created using the source object's 
+    `clone()` method. The currently-held object (if any) is deleted. If the 
+    source container is empty this one will be empty also after the assignment. 
+    Nothing happens if the source and destination are the same container. **/
+    ClonePtr& operator=(const ClonePtr& src) {
+        if (&src != this) { 
+            assert((p != src.p) || !p); // can't be same ptr unless null
+            reset(cloneOrNull(src.p));
+        }
+        return *this;
+    }
+
+    /** Copy assignment from a compatible %ClonePtr. Type `U*` must be 
+    implicitly convertible to type `T*`. The currently-held object is replaced
+    by a copy of the object held in the source container, created using the 
+    source object's `clone()` method. The currently-held object (if any) is 
+    deleted. If the source container is empty this one will be empty also after 
+    the assignment.**/
+    template <class U>
+    ClonePtr& operator=(const ClonePtr<U>& src) {
+        // The source can't be the same container as this one since they are
+        // different types. The managed pointers should never be the same either 
+        // since ClonePtrs represent unique ownership. (OK if both nullptr.)
+        assert((p != static_cast<const T*>(src.p)) || !p);
+
+        reset(cloneOrNull(src.p));
+        return *this;
+    }
+
+    /** Move assignment replaces the currently-held object by the source object, 
+    leaving the source empty. The currently-held object (if any) is deleted. 
+    The `clone()` method is *not* invoked. Nothing happens if the source and 
+    destination are the same containers. **/
+    ClonePtr& operator=(ClonePtr&& src) NOEXCEPT_11 { 
+        if (&src != this) {   
+            assert((p != src.p) || !p); // can't be same ptr unless null
+            reset(src.p); src.p = nullptr; 
+        }
+        return *this;
+    }
+
+    /** Move assignment from a compatible %ClonePtr replaces the currently-held 
+    object by the source object, leaving the source empty. Type U* must be 
+    implicitly convertible to type T*. The currently-held object (if any) is 
+    deleted. The `clone()` method is *not* invoked. **/
+    template <class U>
+    ClonePtr& operator=(ClonePtr<U>&& src) NOEXCEPT_11 {
+        // The source can't be the same container as this one since they are
+        // different types. The managed pointers should never be the same either 
+        // since ClonePtrs represent unique ownership. (OK if both nullptr.)
+        assert((p != static_cast<const T*>(src.p)) || !p);
+        reset(src.p); src.p = nullptr;
+        return *this;
+    }
+
     /** This form of assignment replaces the currently-held object by a 
-    heap-allocated copy of the source object. The copy is created using the 
-    source object's clone() method. The currently-held object is deleted. **/    
-    ClonePtr& operator=(const T& t)          
-    {   reset(t.clone()); return *this; }
-    /** This form of assignment replaces the currently-held object by the given
-    source object and takes over ownership of the source object. The 
-    currently-held object is deleted. **/ 
-    ClonePtr& operator=(T* tp)               
-    {   reset(tp); return *this; }
+    heap-allocated copy of the source object, created using its `clone()`
+    method. The currently-held object (if any) is deleted.  **/    
+    ClonePtr& operator=(const T& x)          
+    {   reset(cloneOrNull(&x)); return *this; }
+
+    /** This form of assignment replaces the currently-held object by 
+    the given source object and takes over ownership of the source object. The  
+    currently-held object (if any) is deleted. **/ 
+    ClonePtr& operator=(T* x) NOEXCEPT_11               
+    {   reset(x); return *this; }
+    /**@}**/
     
-    /** Destructor deletes the referenced object. **/
-    ~ClonePtr() { delete p; }
+    /** @name                    Destructor **/
+    /**@{**/    
+    /** Destructor deletes the contained object. 
+    @see reset() **/
+    ~ClonePtr() NOEXCEPT_11 {reset();}
+    /**@}**/
 
-    /** Compare the contained objects for equality using the contained 
-    objects' operator==() operator. If both containers are empty or both
-    refer to the same object they will test equal; if only one is empty they 
-    will test not equal. Otherwise the objects are compared. **/
-    bool operator==(const ClonePtr& other) const {
-        if (p == other.p) return true; // same object or both empty
-        if (empty() || other.empty()) return false;
-        return getRef()==other.getRef();
-    }
-    /** Compare the contained objects for inequality using operator==(). **/
-    bool operator!=(const ClonePtr& other) const {return !((*this)==other);}
+    /** @name                     Accessors **/
+    /**@{**/
 
-    /** Provide an ordering for use in sorted containers using the contained 
-    objects' operator<(). If both containers are empty or both
-    refer to the same object they will test equal; if only one is empty that 
-    one is considered less than the other one. Otherwise the objects are 
-    compared using T::operator<(). **/
-    bool operator<(const ClonePtr& other) const {
-        if (p == other.p)  return false;    // same object or both empty
-        if (empty())       return true;     //  empty < !empty
-        if (other.empty()) return false;    // !empty > empty
-        return getRef() < other.getRef();
-    }
-    
-    /** Dereference a const pointer to the contained object. This will fail if 
-    the container is empty. **/
-    const T* operator->() const { return &getRef(); }
-    /** Dereference a writable pointer to the contained object. This will fail 
-    if the container is empty. **/
-    T*       operator->()       { return &updRef(); }
-
-    /** This "dereference" operator returns a const reference to the contained 
-    object. This will fail if the container is empty. **/
-    const T& operator*() const { return getRef(); }
-    /** This "dereference" operator returns a writable reference to the 
-    contained object. This will fail if the container is empty. **/
-    T&       operator*()       { return updRef(); }
-
-    /** This "address of" operator returns a const pointer to the contained 
-    object (or null if none). **/
-    const T* operator&() const { return p; }
-    /** This "address of" operator returns a writable pointer to the contained 
-    object (or null if none). **/
-    T*       operator&()       { return p; }
-    
-    /** This is an implicit conversion from %ClonePtr\<T> to a const 
-    reference to the contained object. This will fail if the container is
-    empty. **/
-    operator const T&() const { return getRef(); }
-    /** This is an implicit conversion from %ClonePtr\<T> to a writable 
-    reference to the contained object. **/
-    operator T&()             { return updRef(); } 
-
-    /** This is an implicit conversion to type bool that returns true if
-    the container is non-null (that is, not empty). **/
-    operator bool() const { return !empty(); }
-
-    /** Return a const pointer to the contained object if any, or nullptr. Note 
-    that this is different than `%get()` for the standard smart pointers which 
-    return a writable pointer. Use upd() here for that purpose. 
+    /** Return a const pointer to the contained object if any, or `nullptr`.
+    Note that this is different than `%get()` for the standard smart pointers 
+    like `std::unique_ptr` which return a writable pointer. Use upd() here for 
+    that purpose. 
     @see upd(), getRef() **/
-    const T* get()  const  { return p; }
+    const T* get() const NOEXCEPT_11 {return p;}
 
-    /** Return a writable pointer to the contained object if any, or nullptr. 
+    /** Return a writable pointer to the contained object if any, or `nullptr`. 
     Note that you need write access to this container in order to get write 
     access to the object it contains.
     @see get(), updRef() **/
-    T* upd() { return p; }
+    T* upd() NOEXCEPT_11 {return p;}
 
-    /** Return a writable reference to the contained object. Don't call this if
-    this container is empty. There is also an implicit conversion to reference
-    that allows %ClonePtr\<T> to be used as though it were a T\&. **/
-    T& updRef() { 
-        SimTK_ERRCHK(p!=0, "ClonePtr::updRef()", 
-                    "An attempt was made to dereference a null pointer."); 
-        return *p; 
-    }
-    /** Return a const reference to the contained object. Don't call this if
-    this container is empty. There is also an implicit conversion to reference
-    that allows %ClonePtr\<T> to be used as though it were a T\&. **/
+    /** Return a const reference to the contained object. Don't call this if 
+    this container is empty. 
+    @see get() **/
     const T& getRef() const { 
-        SimTK_ERRCHK(p!=0, "ClonePtr::getRef()", 
+        SimTK_ERRCHK(!empty(), "ClonePtr::getRef()", 
                     "An attempt was made to dereference a null pointer."); 
-        return *p; 
-    }    
+        return *get(); 
+    } 
 
-    /** Return true if this container is empty. **/
-    bool     empty() const    { return p==0; }
-    /** Make this container empty, deleting the currently contained object if
-    there is one. **/
-    void     clear()          { delete p; p=0; }
-    /** Extract the object from this container, leaving the container empty
-    and transferring ownership to the caller. A pointer to the object is
-    returned. No destruction occurs. **/
-    T*       release()        { T* x=p; p=0; return x; }
+    /** Return a writable reference to the contained object. Don't call this if 
+    this container is empty. @see upd() **/
+    T& updRef() { 
+        SimTK_ERRCHK(!empty(), "ClonePtr::updRef()", 
+                    "An attempt was made to dereference a null pointer.");
+        return *upd(); 
+    }
+
+    /** Dereference a const pointer to the contained object. This will fail if 
+    the container is empty. **/
+    const T* operator->() const { return &getRef(); }
+
+    /** Dereference a writable pointer to the contained object. This will fail 
+    if the container is empty. **/
+    T* operator->() { return &updRef(); }
+
+    /** This "dereference" operator returns a const reference to the contained 
+    object. This will fail if the container is empty. **/
+    const T& operator*() const {return getRef();}
+
+    /** Return a writable reference to the contained object. This will fail if 
+    the container is empty. **/
+    T& operator*() {return updRef();}
+    /**@}**/
+
+    /** @name                      Utility Methods **/
+    /**@{**/
+
+    /** Make this container empty if it isn't already, destructing the contained 
+    object if there is one. The container is restored to its default-constructed
+    state. 
+    @see empty() **/
+    void reset() NOEXCEPT_11 {
+        delete p; 
+        p = nullptr;
+    }
+
     /** Replace the contents of this container with the supplied heap-allocated
     object, taking over ownership of that object and deleting the current one
     first if necessary. Nothing happens if the supplied pointer is the same
-    as the one already stored. **/
-    void     reset(T* tp)     { if (tp!=p) {delete p; p=tp;} }
-    /** Replace the contents of this container with the supplied heap-allocated
-    object, taking over ownership of that object, deleting the current one
-    first if necessary, and setting the caller's supplied pointer to null. 
-    If the supplied pointer is the same as the one we're already storing, then
-    we just set the caller's pointer to null and return. **/
-    void reset(T** tpp) { 
-        if (*tpp!=p) {delete p; p=*tpp;} 
-        *tpp=0; 
+    as the one already being managed. **/
+    void reset(T* x) NOEXCEPT_11 {
+        if (x != p) {
+            delete p;
+            p = x;
+        }
     }
-    /** Swap the contents of this %ClonePtr with another one, with ownership
-    changing hands but no copying performed. **/
-    void swap(ClonePtr& other) {
-        T* otherp = other.release();
-        other.reset(p);
-        reset(otherp);
+
+    /** Swap the contents of this %ClonePtr with another one, with 
+    ownership changing hands but no copying performed. This is very fast;
+    no heap activity occurs. Both containers must have been instantiated with 
+    the identical type. **/
+    void swap(ClonePtr& other) NOEXCEPT_11 {
+        std::swap(p, other.p);
+    }
+   
+    /** Return true if this container is empty, which is the state the container
+    is in immediately after default construction and various other 
+    operations. **/
+    bool empty() const NOEXCEPT_11 {return !p;} // count should be null also
+
+    /** This is a conversion to type bool that returns true if the container is 
+    non-null (that is, not empty). **/
+    explicit operator bool() const NOEXCEPT_11 {return !empty();}
+
+    /** Remove the contained object from management by this container and 
+    transfer ownership to the caller. A writable pointer to the object is 
+    returned. No object destruction occurs. This %ClonePtr is left empty. **/
+    T* release() NOEXCEPT_11 {
+        T* save = p;
+        p = nullptr;
+        return save;
     }
 
     /** <b>(Deprecated)</b> Same as `get()`. Use get() instead; it is more like 
@@ -215,30 +297,174 @@ public:
     /** <b>(Deprecated)</b> Same as `upd()`. Use upd() instead; it is a better 
     match for `get()` modeled after the API for `std::unique_ptr`. **/
     DEPRECATED_14("use upd() instead")
-    T* updPtr() { return upd(); }
-private:
-    // Warning: ClonePtr must be exactly the same size as type T*. That way
-    // one can reinterpret_cast a T* to a ClonePtr<T> when needed.
-    T*    p;  
+    T* updPtr() { return upd(); }    
+    /**@}**/
 
-    // If src is non-null, clone it; otherwise return null.
+private:
+template <class U> friend class ClonePtr;
+
+    // If src is non-null, clone it; otherwise return nullptr.
     static T* cloneOrNull(const T* src) {
         return src ? src->clone() : nullptr;
     }
 
-};    
-    
-} // namespace SimTK
+    T*      p;          // this may be null
+};
 
-namespace std {
-/** This is a specialization of the STL std::swap() algorithm which uses the
-cheap built-in swap() member of the ClonePtr class. 
-@relates SimTK::ClonePtr **/
+
+
+//==============================================================================
+//                       SimTK namespace-scope functions
+//==============================================================================
+// These namespace-scope functions will be resolved by the compiler using
+// "Koenig lookup" which examines the arguments' namespaces first.
+// See Herb Sutter's discussion here: http://www.gotw.ca/publications/mill08.htm.
+
+/** This is an overload of the STL std::swap() algorithm which uses the
+cheap built-in swap() member of the ClonePtr class. (This function
+is defined in the `SimTK` namespace.)
+@relates ClonePtr **/
 template <class T> inline void
-swap(SimTK::ClonePtr<T>& p1, SimTK::ClonePtr<T>& p2) {
+swap(ClonePtr<T>& p1, ClonePtr<T>& p2) NOEXCEPT_11 {
     p1.swap(p2);
 }
 
-} // namespace std
+/** Output the system-dependent representation of the pointer contained
+in a ClonePtr object. This is equivalent to `os << p.get();`.
+@relates ClonePtr **/
+template <class charT, class traits, class T>
+inline std::basic_ostream<charT,traits>& 
+operator<<(std::basic_ostream<charT,traits>& os, 
+           const ClonePtr<T>&  p) 
+{   os << p.get(); return os; }
+
+/** Compare for equality the managed pointers contained in two compatible
+ClonePtr containers. Returns `true` if the pointers refer to
+the same object or if both are null. It must be possible for one of the
+pointer types `T*` and `U*` to be implicitly converted to the other.
+@relates ClonePtr **/
+template <class T, class U>
+inline bool operator==(const ClonePtr<T>& lhs,
+                       const ClonePtr<U>& rhs)
+{   return lhs.get() == rhs.get(); }
+
+/** Comparison against `nullptr`; same as `lhs.empty()`. 
+@relates ClonePtr **/
+template <class T>
+inline bool operator==(const ClonePtr<T>& lhs, std::nullptr_t)
+{   return lhs.empty(); }
+
+/** Comparison against `nullptr`; same as `rhs.empty()`. 
+@relates ClonePtr **/
+template <class T>
+inline bool operator==(std::nullptr_t, const ClonePtr<T>& rhs)
+{   return rhs.empty(); }
+
+/** Less-than operator for two compatible ClonePtr containers, 
+comparing the *pointers*, not the *objects* they point to. Returns `true` if the
+lhs pointer tests less than the rhs pointer. A null pointer tests less than any
+non-null pointer. It must be possible for one of the pointer types `T*` and 
+`U*` to be implicitly converted to the other.
+@relates ClonePtr **/
+template <class T, class U>
+inline bool operator<(const ClonePtr<T>& lhs,
+                      const ClonePtr<U>& rhs)
+{   return lhs.get() < rhs.get(); }
+
+/** Less-than comparison against a `nullptr`. A null pointer tests less than any
+non-null pointer and equal to another null pointer, so this method always 
+returns `false`.
+@relates ClonePtr **/
+template <class T>
+inline bool operator<(const ClonePtr<T>& lhs, std::nullptr_t)
+{   return false; }
+
+/** Less-than comparison of a `nullptr` against this container. A null
+pointer tests less than any non-null pointer and equal to another null pointer,
+so this method returns `true` unless the container is empty.
+@relates ClonePtr **/
+template <class T>
+inline bool operator<(std::nullptr_t, const ClonePtr<T>& rhs)
+{   return !rhs.empty(); }
+
+
+// These functions are derived from operator== and operator<.
+
+/** Pointer inequality test defined as `!(lhs==rhs)`.
+@relates ClonePtr **/
+template <class T, class U>
+inline bool operator!=(const ClonePtr<T>& lhs,
+                       const ClonePtr<U>& rhs)
+{   return !(lhs==rhs); }
+/** `nullptr` inequality test defined as `!(lhs==nullptr)`.
+@relates ClonePtr **/
+template <class T>
+inline bool operator!=(const ClonePtr<T>& lhs, std::nullptr_t)
+{   return !(lhs==nullptr); }
+/** `nullptr` inequality test defined as `!(nullptr==rhs)`.
+@relates ClonePtr **/
+template <class T>
+inline bool operator!=(std::nullptr_t, const ClonePtr<T>& rhs)
+{   return !(nullptr==rhs); }
+
+/** Pointer greater-than test defined as `rhs < lhs`.
+@relates ClonePtr **/
+template <class T, class U>
+inline bool operator>(const ClonePtr<T>& lhs,
+                      const ClonePtr<U>& rhs)
+{   return rhs < lhs; }
+/** `nullptr` greater-than test defined as `nullptr < lhs`.
+@relates ClonePtr **/
+template <class T>
+inline bool operator>(const ClonePtr<T>& lhs, std::nullptr_t)
+{   return nullptr < lhs; }
+
+/** `nullptr` greater-than test defined as `rhs < nullptr`.
+@relates ClonePtr **/
+template <class T>
+inline bool operator>(std::nullptr_t, const ClonePtr<T>& rhs)
+{   return rhs < nullptr; }
+
+
+/** Pointer greater-or-equal test defined as `!(lhs < rhs)`.
+@relates ClonePtr **/
+template <class T, class U>
+inline bool operator>=(const ClonePtr<T>& lhs,
+                       const ClonePtr<U>& rhs)
+{   return !(lhs < rhs); }
+/** `nullptr` greater-or-equal test defined as `!(lhs < nullptr)`.
+@relates ClonePtr **/
+template <class T>
+inline bool operator>=(const ClonePtr<T>& lhs, std::nullptr_t)
+{   return !(lhs < nullptr); }
+
+/** `nullptr` greater-or-equal test defined as `!(nullptr < rhs)`.
+@relates ClonePtr **/
+template <class T>
+inline bool operator>=(std::nullptr_t, const ClonePtr<T>& rhs)
+{   return !(nullptr < rhs); }
+
+
+/** Pointer less-or-equal test defined as `!(rhs < lhs)` (note reversed
+arguments).
+@relates ClonePtr **/
+template <class T, class U>
+inline bool operator<=(const ClonePtr<T>& lhs,
+                       const ClonePtr<U>& rhs)
+{   return !(rhs < lhs); }
+/** `nullptr` less-or-equal test defined as `!(nullptr < lhs)` (note reversed
+arguments).
+@relates ClonePtr **/
+template <class T>
+inline bool operator<=(const ClonePtr<T>& lhs, std::nullptr_t)
+{   return !(nullptr < lhs); }
+/** `nullptr` less-or-equal test defined as `!(rhs < nullptr)` (note reversed
+arguments).
+@relates ClonePtr **/
+template <class T>
+inline bool operator<=(std::nullptr_t, const ClonePtr<T>& rhs)
+{   return !(rhs < nullptr); }
+
+} // namespace SimTK
 
 #endif // SimTK_SimTKCOMMON_CLONE_PTR_H_

--- a/SimTKcommon/include/SimTKcommon/internal/ReferencePtr.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ReferencePtr.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2012 Stanford University and the Authors.           *
+ * Portions copyright (c) 2012-15 Stanford University and the Authors.         *
  * Authors: Michael Sherman                                                   *
  * Contributors:                                                              *
  *                                                                            *
@@ -24,6 +24,8 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+#include "SimTKcommon/internal/common.h"
+
 namespace SimTK {
 
 /** This is a smart pointer that implements "cross reference" semantics where
@@ -33,13 +35,17 @@ you to use compiler-generated copy constructors and copy assignment operators
 for classes which would otherwise have to implement their own in order to
 properly initialize these pointer data members, which must not be copied.
 
-The contained pointer is initialized to null (0) on construction, and it is 
+The contained pointer is initialized to `nullptr` on construction, and it is 
 reinitialized to null upon copy construction or copy assignment. That's 
 because we are assuming this is part of copying the entire data structure and 
 copying the old pointer would create a reference into the old data structure 
 rather than the new copy. This pointer does not own the target to which it 
 points, and there is no reference counting so it will become stale if the 
 target is deleted.
+
+The pointer *is* moved intact for move construction or move assignment. That
+allows `std::vector<ReferencePtr<T>>` or `SimTK::Array_<ReferencePtr<T>>` to
+behave properly when their contents have to be moved for expansion.
 
 Whether you can write through the pointer is controlled by whether type T
 is a const type. For example %ReferencePtr\<int> is equivalent to an int*, while
@@ -48,100 +54,291 @@ is a const type. For example %ReferencePtr\<int> is equivalent to an int*, while
 This class is entirely inline and has no computational or space overhead; it
 contains just a single pointer. 
 
-@see ClonePtr **/ 
+@see ClonePtr, CloneOnWritePtr **/ 
 template <class T> class ReferencePtr {
 public:
-    typedef T  element_type;
-    typedef T* pointer;
-    typedef T& reference;
+    typedef T  element_type; ///< Type of the contained object.
+    typedef T* pointer;      ///< Type of a pointer to the contained object.
+    typedef T& reference;    ///< Type of a reference to the contained object.
 
+    /** @name                    Constructors **/
+    /**@{**/
     /** Default constructor creates an empty object. **/
-    ReferencePtr() : p(0) { }
+    ReferencePtr() NOEXCEPT_11 : p(nullptr) {}
+
+    /** Constructor from `nullptr` is the same as the default constructor.
+    This is an implicit conversion that allows `nullptr` to be used to
+    initialize a %ReferencePtr. **/
+    ReferencePtr(std::nullptr_t) NOEXCEPT_11 : ReferencePtr() {}
+
     /** Construct from a given pointer stores the pointer. **/
-    explicit ReferencePtr(T* tp) : p(tp) { }
+    explicit ReferencePtr(T* tp) NOEXCEPT_11 : p(tp) {}
+
     /** Construct from a reference stores the address of the supplied 
     object. **/
-    explicit ReferencePtr(T& t) : p(&t) { }
+    explicit ReferencePtr(T& t) NOEXCEPT_11 : p(&t) {}
+
     /** Copy constructor unconditionally sets the pointer to null; see class
     comments for why. **/
-    ReferencePtr(const ReferencePtr&) : p(0) { }
-    /** Copy assignment sets the pointer to null (except for a self-assign); 
+    ReferencePtr(const ReferencePtr&) NOEXCEPT_11 : p(nullptr) {}
+
+    /** Move constructor copies the pointer from the source and leaves the
+    source empty. **/
+    ReferencePtr(ReferencePtr&& src) NOEXCEPT_11 {p=src.p; src.clear();}
+
+    /** <b>(Deprecated)</b> Use %ReferencePtr(nullptr) or just %ReferencePtr()
+    instead. For backwards compatibility, this allows initialization 
+    by "0" rather than `nullptr`. **/
+    DEPRECATED_14("use ReferencePtr(nullptr) instead")
+    ReferencePtr(int mustBeZero) NOEXCEPT_11 : ReferencePtr()
+    {   assert(mustBeZero==0); }
+    /**@}**/
+
+    /** @name                   Assignment **/
+    /**@{**/
+
+    /** Copy assignment sets the pointer to nullptr (except for a self-assign); 
     see class comments for why.  **/
-    ReferencePtr& operator=(const ReferencePtr& r) 
-    {   if (&r != this) clear(); return *this; }
+    ReferencePtr& operator=(const ReferencePtr& src) NOEXCEPT_11
+    {   if (&src != this) clear(); return *this; }
+
+    /** Move assignment copies the pointer from the source and leaves the
+    source empty. Nothing happens for self-assign. **/
+    ReferencePtr& operator=(ReferencePtr&& src) NOEXCEPT_11 {
+        if (&src != this) 
+        {   reset(src.p); src.clear(); }
+        return *this; 
+    }
+
     /** This form of assignment replaces the currently-referenced object by a 
     reference to the source object; no destruction occurs. **/    
-    ReferencePtr& operator=(T& t)          
+    ReferencePtr& operator=(T& t) NOEXCEPT_11    
     {  reset(&t); return *this; }
+
     /** This form of assignment replaces the current pointer with the given
     one; no destruction occurs. **/
-    ReferencePtr& operator=(T* tp)               
+    ReferencePtr& operator=(T* tp) NOEXCEPT_11               
     {   reset(tp); return *this; }
     
+    /** @name                    Destructor **/
+    /**@{**/
     /** Destructor does nothing. **/
-    ~ReferencePtr() {clear();} // just being tidy
+    ~ReferencePtr() NOEXCEPT_11 {clear();} // just being tidy
+    /**@}**/
 
-    /** Return the contained pointer. This will fail if the container is 
-    empty. **/
-    T* operator->() const { return &getRef(); }
-
-    /** The "dereference" operator returns a reference to the target object. 
-    This will fail if the container is empty. **/
-    T& operator*() const { return getRef(); }
-
-    /** This is an implicit conversion from %ReferencePtr\<T> to T*. **/
-    operator T*() const { return p; }
-
-    /** This is an implicit conversion to type bool that returns true if
-    the container is non-null (that is, not empty). **/
-    operator bool() const { return !empty(); }
+    /** @name                     Accessors **/
+    /**@{**/
 
     /** Return the contained pointer, or null if the container is empty. **/
-    T* get()  const  { return p; }
+    T* get() const NOEXCEPT_11 {return p;}
 
     /** Return a reference to the target object. Fails if the pointer is
     null. **/
     T& getRef() const { 
-        SimTK_ERRCHK(p!=0, "ReferencePtr::getRef()", 
+        SimTK_ERRCHK(p!=nullptr, "ReferencePtr::getRef()", 
                     "An attempt was made to dereference a null pointer."); 
         return *p; 
     }
 
+    /** Return the contained pointer. This will fail if the container is 
+    empty. **/
+    T* operator->() const {return &getRef();}
+
+    /** The "dereference" operator returns a reference to the target object. 
+    This will fail if the container is empty. **/
+    T& operator*() const {return getRef();}
+
+    /** This is an implicit conversion from %ReferencePtr\<T> to T*. **/
+    operator T*() const NOEXCEPT_11 {return p;}
+    /**@}**/
+
+    /** @name                      Utility Methods **/
+    /**@{**/
+
     /** Return true if this container is empty. **/
-    bool     empty() const    { return p==0; }
+    bool empty() const NOEXCEPT_11 {return !p;}
+
+    /** This is a conversion to type bool that returns true if
+    the container is non-null (that is, not empty). **/
+    operator bool() const NOEXCEPT_11 {return !empty();}
+
     /** Make this container empty; no destruction occurs. **/
-    void     clear()          { p=0; }
+    void clear() NOEXCEPT_11 {p=nullptr;}
+
     /** Extract the pointer from this container, leaving the container empty. 
     The pointer is returned. **/
-    T*       release()        { T* x=p; p=0; return x; }
+    T* release() NOEXCEPT_11 {T* x=p; p=nullptr; return x;}
+
     /** Replace the stored pointer with a different one; no destruction
     occurs. **/
-    void     reset(T* tp)     { p=tp;}
+    void reset(T* tp) NOEXCEPT_11 {p=tp;}
 
     /** Swap the contents of this %ReferencePtr with another one. **/
-    void swap(ReferencePtr& other) {
+    void swap(ReferencePtr& other) NOEXCEPT_11 {
         T* otherp = other.release();
         other.reset(p);
         reset(otherp);
     }
-     
-private:
-    // Warning: ReferencePtr must be exactly the same size as type T*. That way
-    // one can reinterpret_cast a T* to a ReferencePtr<T> when needed.
-    T*    p;  
-};    
-    
-} // namespace SimTK
+    /**@}**/
 
-namespace std {
-/** This is a specialization of the STL std::swap() algorithm which uses the
-cheap built-in swap() member of the ReferencePtr class. 
+private:
+    T*    p;        // can be nullptr
+};    
+
+
+
+//==============================================================================
+//                       SimTK namespace-scope functions
+//==============================================================================
+// These namespace-scope functions will be resolved by the compiler using
+// "Koenig lookup" which examines the arguments' namespaces first.
+// See Herb Sutter's discussion here: http://www.gotw.ca/publications/mill08.htm.
+
+/** This is an overload of the STL std::swap() algorithm which uses the
+cheap built-in swap() member of the ReferencePtr class. (This function
+is defined in the `SimTK` namespace.)
 @relates SimTK::ReferencePtr **/
 template <class T> inline void
-swap(SimTK::ReferencePtr<T>& p1, SimTK::ReferencePtr<T>& p2) {
+swap(ReferencePtr<T>& p1, ReferencePtr<T>& p2) NOEXCEPT_11 {
     p1.swap(p2);
 }
 
-} // namespace std
+/** Output the system-dependent representation of the pointer contained
+in a ReferencePtr object. This is equivalent to `os << p.get();`.
+@relates ReferencePtr **/
+template <class charT, class traits, class T>
+inline std::basic_ostream<charT,traits>& 
+operator<<(std::basic_ostream<charT,traits>& os, 
+           const ReferencePtr<T>&  p) 
+{   os << p.get(); return os; }
+
+/** Compare for equality the managed pointers contained in two compatible
+ReferencePtr containers. Returns `true` if the pointers refer to
+the same object or if both are null. It must be possible for one of the
+pointer types `T*` and `U*` to be implicitly converted to the other.
+@relates ReferencePtr **/
+template <class T, class U>
+inline bool operator==(const ReferencePtr<T>& lhs,
+                       const ReferencePtr<U>& rhs)
+{   return lhs.get() == rhs.get(); }
+
+/** Comparison against `nullptr`; same as `lhs.empty()`. 
+@relates ReferencePtr **/
+template <class T>
+inline bool operator==(const ReferencePtr<T>& lhs, std::nullptr_t)
+{   return lhs.empty(); }
+
+/** Comparison against `nullptr`; same as `rhs.empty()`. 
+@relates ReferencePtr **/
+template <class T>
+inline bool operator==(std::nullptr_t, const ReferencePtr<T>& rhs)
+{   return rhs.empty(); }
+
+/** Less-than operator for two compatible ReferencePtr containers, 
+comparing the *pointers*, not the *objects* they point to. Returns `true` if the
+lhs pointer tests less than the rhs pointer. A null pointer tests less than any
+non-null pointer. It must be possible for one of the pointer types `T*` and 
+`U*` to be implicitly converted to the other.
+@relates ReferencePtr **/
+template <class T, class U>
+inline bool operator<(const ReferencePtr<T>& lhs,
+                      const ReferencePtr<U>& rhs)
+{   return lhs.get() < rhs.get(); }
+
+/** Less-than comparison against a `nullptr`. A null pointer tests less than any
+non-null pointer and equal to another null pointer, so this method always 
+returns `false`.
+@relates ReferencePtr **/
+template <class T>
+inline bool operator<(const ReferencePtr<T>& lhs, std::nullptr_t)
+{   return false; }
+
+/** Less-than comparison of a `nullptr` against this container. A null
+pointer tests less than any non-null pointer and equal to another null pointer,
+so this method returns `true` unless the container is empty.
+@relates ReferencePtr **/
+template <class T>
+inline bool operator<(std::nullptr_t, const ReferencePtr<T>& rhs)
+{   return !rhs.empty(); }
+
+
+// These functions are derived from operator== and operator<.
+
+/** Pointer inequality test defined as `!(lhs==rhs)`.
+@relates ReferencePtr **/
+template <class T, class U>
+inline bool operator!=(const ReferencePtr<T>& lhs,
+                       const ReferencePtr<U>& rhs)
+{   return !(lhs==rhs); }
+/** `nullptr` inequality test defined as `!(lhs==nullptr)`.
+@relates ReferencePtr **/
+template <class T>
+inline bool operator!=(const ReferencePtr<T>& lhs, std::nullptr_t)
+{   return !(lhs==nullptr); }
+/** `nullptr` inequality test defined as `!(nullptr==rhs)`.
+@relates ReferencePtr **/
+template <class T>
+inline bool operator!=(std::nullptr_t, const ReferencePtr<T>& rhs)
+{   return !(nullptr==rhs); }
+
+/** Pointer greater-than test defined as `rhs < lhs`.
+@relates ReferencePtr **/
+template <class T, class U>
+inline bool operator>(const ReferencePtr<T>& lhs,
+                      const ReferencePtr<U>& rhs)
+{   return rhs < lhs; }
+/** `nullptr` greater-than test defined as `nullptr < lhs`.
+@relates ReferencePtr **/
+template <class T>
+inline bool operator>(const ReferencePtr<T>& lhs, std::nullptr_t)
+{   return nullptr < lhs; }
+
+/** `nullptr` greater-than test defined as `rhs < nullptr`.
+@relates ReferencePtr **/
+template <class T>
+inline bool operator>(std::nullptr_t, const ReferencePtr<T>& rhs)
+{   return rhs < nullptr; }
+
+
+/** Pointer greater-or-equal test defined as `!(lhs < rhs)`.
+@relates ReferencePtr **/
+template <class T, class U>
+inline bool operator>=(const ReferencePtr<T>& lhs,
+                       const ReferencePtr<U>& rhs)
+{   return !(lhs < rhs); }
+/** `nullptr` greater-or-equal test defined as `!(lhs < nullptr)`.
+@relates ReferencePtr **/
+template <class T>
+inline bool operator>=(const ReferencePtr<T>& lhs, std::nullptr_t)
+{   return !(lhs < nullptr); }
+
+/** `nullptr` greater-or-equal test defined as `!(nullptr < rhs)`.
+@relates ReferencePtr **/
+template <class T>
+inline bool operator>=(std::nullptr_t, const ReferencePtr<T>& rhs)
+{   return !(nullptr < rhs); }
+
+
+/** Pointer less-or-equal test defined as `!(rhs < lhs)` (note reversed
+arguments).
+@relates ReferencePtr **/
+template <class T, class U>
+inline bool operator<=(const ReferencePtr<T>& lhs,
+                       const ReferencePtr<U>& rhs)
+{   return !(rhs < lhs); }
+/** `nullptr` less-or-equal test defined as `!(nullptr < lhs)` (note reversed
+arguments).
+@relates ReferencePtr **/
+template <class T>
+inline bool operator<=(const ReferencePtr<T>& lhs, std::nullptr_t)
+{   return !(nullptr < lhs); }
+/** `nullptr` less-or-equal test defined as `!(rhs < nullptr)` (note reversed
+arguments).
+@relates ReferencePtr **/
+template <class T>
+inline bool operator<=(std::nullptr_t, const ReferencePtr<T>& rhs)
+{   return !(rhs < nullptr); }
+
+} // namespace SimTK
 
 #endif // SimTK_SimTKCOMMON_REFERENCE_PTR_H_

--- a/SimTKcommon/include/SimTKcommon/internal/ReferencePtr.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ReferencePtr.h
@@ -25,6 +25,7 @@
  * -------------------------------------------------------------------------- */
 
 #include "SimTKcommon/internal/common.h"
+#include <cassert>
 
 namespace SimTK {
 
@@ -270,11 +271,13 @@ template <class T, class U>
 inline bool operator!=(const ReferencePtr<T>& lhs,
                        const ReferencePtr<U>& rhs)
 {   return !(lhs==rhs); }
+
 /** `nullptr` inequality test defined as `!(lhs==nullptr)`.
 @relates ReferencePtr **/
 template <class T>
 inline bool operator!=(const ReferencePtr<T>& lhs, std::nullptr_t)
 {   return !(lhs==nullptr); }
+
 /** `nullptr` inequality test defined as `!(nullptr==rhs)`.
 @relates ReferencePtr **/
 template <class T>
@@ -338,6 +341,14 @@ arguments).
 template <class T>
 inline bool operator<=(std::nullptr_t, const ReferencePtr<T>& rhs)
 {   return !(rhs < nullptr); }
+
+
+/** <b>(Deprecated)</b> Use `nullptr` instead of `0`.
+@relates ReferencePtr **/
+template <class T>
+DEPRECATED_14("use refptr != nullptr instead")
+inline bool operator!=(const ReferencePtr<T>& lhs, int mustBeZero)
+{   assert(mustBeZero==0); return !(lhs==nullptr); }
 
 } // namespace SimTK
 

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -169,6 +169,7 @@ or any other Index type to an argument expecting a certain Index type. **/
     #pragma warning(disable:4275) /*no DLL interface for base class of exported class*/
     #pragma warning(disable:4345) /*warning about PODs being default-initialized*/
 
+
     /* Until VS2015 struct timespec was missing from <ctime> so is faked here 
     if needed. However, note that it is also defined in the pthread.h header on 
     Windows, so the guard symbol must match here to avoid a duplicate declaration. 
@@ -178,7 +179,7 @@ or any other Index type to an argument expecting a certain Index type. **/
     #define HAVE_STRUCT_TIMESPEC 1
         #if _MSC_VER < 1900
         struct timespec {
-            long tv_sec;  // TODO: this should be time_t but must fix in pthreads too
+            long tv_sec; /*TODO: should be time_t but must fix in pthreads too*/
             long tv_nsec;
         };
         #endif
@@ -260,6 +261,13 @@ cache misses which ultimately reduce performance. */
     #define SimTK_FORCE_INLINE __forceinline
 #else
     #define SimTK_FORCE_INLINE __attribute__((always_inline))
+#endif
+
+/* Microsoft added noexcept in VS2015 */
+#if defined(_MSC_VER) && _MSC_VER < 1900
+    #define NOEXCEPT_11 throw()
+#else
+    #define NOEXCEPT_11 noexcept
 #endif
 
 /* C++14 introduces a standard way to mark deprecated declarations. Before

--- a/Simbody/src/MotionImpl.h
+++ b/Simbody/src/MotionImpl.h
@@ -48,7 +48,7 @@ public:
     // Default copy constructor, copy assignment, and destructor; note that the 
     // pointer to the mobilized body is not copied or deleted.
 
-    bool hasMobilizedBody() const {return m_mobodImpl != 0;}
+    bool hasMobilizedBody() const {return m_mobodImpl != nullptr;}
     const MobilizedBodyImpl& getMobilizedBodyImpl() const 
     {   assert(m_mobodImpl); return *m_mobodImpl; }
     MobilizedBodyIndex getMobilizedBodyIndex() const;


### PR DESCRIPTION
Improve smart pointers for consistency with each other and with C++11's smart pointers.

Added NOEXCEPT_11 define to allow "noexcept" specification to compile with VS2013.

Moved namespace-scope comparison functions and swap() overloads to SimTK namespace.

Fixes issue #328