### PR TITLE
Make `SimTK::Function_` objects cloneable and assignable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 3.6 (in development)
 --------------------
+* Added clone() method to `SimTK::Function_` base class and implemented it for
+  Simbody-defined concrete Function classes. Made concrete Function members
+  non-const to permit assignment, and modified Function_<T>::Step to allow
+  changing its parameters after construction.
 * Added C++11 features to the `SimTK::Array_` container including `std::initializer_list` construction, move construction, move assignment, and `emplace` methods.
 * Prevented copy construction of `Array_<T>` from `Array_<T2>` unless T2 is *implicitly*
   convertible to T. Previously this was allowed if there was any conversion possible

--- a/SimTKmath/Geometry/include/simmath/internal/BicubicSurface.h
+++ b/SimTKmath/Geometry/include/simmath/internal/BicubicSurface.h
@@ -546,7 +546,7 @@ public:
      
     @param[in] XY   the 2-Vector of input arguments X and Y. 
     @return The interpolated value of the function at point (X,Y). **/
-    virtual Real calcValue(const Vector& XY) const {
+    Real calcValue(const Vector& XY) const override {
         SimTK_ERRCHK1(XY.size()==2, "BicubicFunction::calcValue()",
         "The argument Vector XY must have exactly 2 elements but had %d.",
         XY.size());        
@@ -572,8 +572,8 @@ public:
         surface. 
     @return The interpolated value of the selected function partial derivative
     for arguments (X,Y). **/
-    virtual Real calcDerivative(const Array_<int>& derivComponents, 
-                                const Vector& XY) const {
+    Real calcDerivative(const Array_<int>& derivComponents, 
+                        const Vector& XY) const override {
         SimTK_ERRCHK1(XY.size()==2, "BicubicFunction::calcDerivative()",
         "The argument Vector XY must have exactly 2 elements but had %d.",
         XY.size());        
@@ -582,15 +582,24 @@ public:
 
     /** This implements the Function base class pure virtual; here it
     always returns 2 (X and Y). **/
-    virtual int getArgumentSize() const {return 2;}
+    int getArgumentSize() const override {return 2;}
 
     /** This implements the Function base class pure virtual specifying how
     many derivatives can be taken of this function; here it is unlimited.
     However, note that a bicubic surface is continuous up to the second 
     derivative, discontinuous at the third, and zero for any derivatives equal 
     to or higher than the fourth. **/
-    virtual int getMaxDerivativeOrder() const 
+    int getMaxDerivativeOrder() const override 
     {   return std::numeric_limits<int>::max(); }
+
+    BicubicFunction* clone() const override {return new BicubicFunction(*this);}
+
+    /** This provides compatibility with std::vector without requiring any 
+    copying. **/
+    Real calcDerivative(const std::vector<int>& derivComponents, 
+                        const Vector& x) const 
+    {   return calcDerivative(ArrayViewConst_<int>(derivComponents),x); }
+
 private:
     BicubicSurface                      surface;
     mutable BicubicSurface::PatchHint   hint;

--- a/SimTKmath/Geometry/include/simmath/internal/Spline.h
+++ b/SimTKmath/Geometry/include/simmath/internal/Spline.h
@@ -66,7 +66,7 @@ public:
 
     /** Default constructor creates an empty %Spline_ handle; not very 
     useful. **/
-    Spline_() : impl(NULL) {}
+    Spline_() : impl(nullptr) {}
 
     /** Copy constructor is shallow and reference-counted; that is, the new
     %Spline_ refers to the same object as does \a source. **/
@@ -168,6 +168,8 @@ public:
     /** Required by the Function_ interface. **/
     int getMaxDerivativeOrder() const override 
     {   return std::numeric_limits<int>::max(); }
+    /** Required by the Function_ interface. **/
+    Spline_* clone() const override {return new Spline_(*this);}
 
 private:
     class SplineImpl;


### PR DESCRIPTION
Some minor improvements to the `SimTK::Function_<T>` classes:
- Added `clone()` method to `Function_` base class and implemented it for Simbody-defined concrete Function classes.
- Made concrete Function members non-const to permit assignment.
- Modified `Function_<T>::Step` to allow changing its parameters after construction.

@chrisdembia please review.