### PR TITLE
Add `NullOnCopyUniquePtr` and regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 3.6 (in development)
 --------------------
+* Added smart pointer NullOnCopyUniquePtr which is the same as std::unique_ptr
+  except that it adds copy construction and copy assignment that leave the
+  target null. This can be used for owned heap-allocated objects that are
+  "local" in the sense that they should not be copied along with their owner.
+  That allows use of compiler-generated default copy construction and 
+  copy assignment for the owning class. 
 * Added clone() method to `SimTK::Function_` base class and implemented it for
   Simbody-defined concrete Function classes. Made concrete Function members
   non-const to permit assignment, and modified Function_<T>::Step to allow

--- a/SimTKcommon/include/SimTKcommon/basics.h
+++ b/SimTKcommon/include/SimTKcommon/basics.h
@@ -44,6 +44,7 @@
 #include "SimTKcommon/internal/ClonePtr.h"
 #include "SimTKcommon/internal/CloneOnWritePtr.h"
 #include "SimTKcommon/internal/ReferencePtr.h"
+#include "SimTKcommon/internal/NullOnCopyUniquePtr.h"
 #include "SimTKcommon/internal/String.h"
 #include "SimTKcommon/internal/Serialize.h"
 #include "SimTKcommon/internal/Fortran.h"

--- a/SimTKcommon/include/SimTKcommon/internal/NullOnCopyUniquePtr.h
+++ b/SimTKcommon/include/SimTKcommon/internal/NullOnCopyUniquePtr.h
@@ -1,0 +1,136 @@
+#ifndef SimTK_SimTKCOMMON_NULL_ON_COPY_UNIQUE_PTR_H_
+#define SimTK_SimTKCOMMON_NULL_ON_COPY_UNIQUE_PTR_H_
+
+/* -------------------------------------------------------------------------- *
+ *                       Simbody(tm): SimTKcommon                             *
+ * -------------------------------------------------------------------------- *
+ * This is part of the SimTK biosimulation toolkit originating from           *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
+ *                                                                            *
+ * Portions copyright (c) 2015 Stanford University and the Authors.           *
+ * Authors: Michael Sherman                                                   *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "SimTKcommon/internal/common.h"
+#include <cassert>
+#include <utility>
+#include <memory>
+
+namespace SimTK {
+
+/** This is a smart pointer representing unique ownership like `std::unique_ptr`
+but adds "reset" copy construction and copy assignment. Judicious use of this 
+container will allow you to use compiler-generated copy constructors and copy 
+assignment operators for classes which would otherwise have to implement their 
+own in order to properly reset these pointer data members, which must not 
+be copied.
+
+The contained pointer is initialized to `nullptr` on construction, is properly
+deleted on destruction, and the target is reset to to `nullptr` upon copy 
+construction or copy assignment. Generally this is used when the owned object
+has pointers into its owner, so should not be copied along with the owner 
+since those pointers would point to the source object rather than the target.
+
+The pointer *is* moved intact for move construction or move assignment. That
+allows `std::vector<NullOnCopyUniquePtr<T>>` or 
+`SimTK::Array_<NullOnCopyUniquePtr<T>>` to behave properly when their contents 
+have to be moved for expansion (if copied they would end up null!).
+
+This class derives publicly from `std::unique_ptr` and inherits its constructors
+and other methods, so behaves identically except where noted.
+
+@see ReferencePtr, ClonePtr, CloneOnWritePtr **/ 
+template < class T, class D = std::default_delete<T> >
+class NullOnCopyUniquePtr : public std::unique_ptr<T,D> {
+    using Super = std::unique_ptr<T,D>;
+public:
+    using Super::unique_ptr; // inherit most constructors
+
+    /** Default constructor creates a null pointer. **/
+    NullOnCopyUniquePtr() NOEXCEPT_11 : Super() {}
+
+    /** Copy constructor ignores source and creates a null pointer, 
+    same as default construction. See class description for why. **/
+    NullOnCopyUniquePtr(const NullOnCopyUniquePtr&) NOEXCEPT_11
+    :   NullOnCopyUniquePtr() {}
+
+    /** Move constructor transfers ownership (same as std::unique_ptr). **/
+    NullOnCopyUniquePtr(NullOnCopyUniquePtr&& source) NOEXCEPT_11
+    :   Super(std::move(source)) {}
+
+    /** Copy assignment ignores source, leaves target null. See class
+    description for why. **/
+    NullOnCopyUniquePtr& operator=(const NullOnCopyUniquePtr&) NOEXCEPT_11 {
+        Super::reset();
+        return *this;
+    }
+
+    /** Move assignment transfers ownership (same as std::unique_ptr). **/
+    NullOnCopyUniquePtr& operator=(NullOnCopyUniquePtr&& src) NOEXCEPT_11 {
+        Super::operator=(std::move(src));
+        return *this;
+    }
+}; 
+
+
+
+//==============================================================================
+//                       SimTK namespace-scope functions
+//==============================================================================
+// These namespace-scope functions will be resolved by the compiler using
+// "Koenig lookup" which examines the arguments' namespaces first.
+// See Herb Sutter's discussion here: http://www.gotw.ca/publications/mill08.htm.
+
+/** This is an overload of the STL std::swap() algorithm which uses the
+cheap built-in swap() member of the NullOnCopyUniquePtr class. (This function
+is defined in the `SimTK` namespace.)
+@relates SimTK::NullOnCopyUniquePtr **/
+template <class T, class D> inline void
+swap(NullOnCopyUniquePtr<T,D>& p1, NullOnCopyUniquePtr<T,D>& p2) NOEXCEPT_11 {
+    p1.swap(p2);
+}
+
+/** Output the system-dependent representation of the pointer contained
+in a NullOnCopyUniquePtr object. This is equivalent to `os << p.get();`.
+@relates NullOnCopyUniquePtr **/
+template <class charT, class traits, class T, class D>
+inline std::basic_ostream<charT,traits>& 
+operator<<(std::basic_ostream<charT,traits>& os, 
+           const NullOnCopyUniquePtr<T,D>&  p) 
+{   os << p.get(); return os; }
+
+} // namespace SimTK
+
+
+
+//==============================================================================
+//                             hash specialization
+//==============================================================================
+namespace std {
+/** This is a specialization of std::hash<std::unique_ptr<T,D>> so that
+SimTK::NullOnCopyUniquePtr hashes identically. This specialization is in the 
+`std` namespace. 
+@see SimTK::NullOnCopyUniquePtr **/
+template <class T, class D>
+struct hash<SimTK::NullOnCopyUniquePtr<T,D>> 
+:   public hash<std::unique_ptr<T,D>> 
+{
+    using hash<std::unique_ptr<T,D>>::hash; // inherit constructors
+};
+} // namespace std
+
+
+#endif // SimTK_SimTKCOMMON_NULL_ON_COPY_UNIQUE_PTR_H_

--- a/SimTKcommon/tests/TestCloneOnWritePtr.cpp
+++ b/SimTKcommon/tests/TestCloneOnWritePtr.cpp
@@ -22,7 +22,8 @@
  * -------------------------------------------------------------------------- */
 
 /* Test for proper functioning of the copy-on-write smart pointer class
-SimTK::CloneOnWritePtr. */
+SimTK::CloneOnWritePtr, and the null-on-copy variant of std::unique_ptr 
+called SimTK::NullOnCopyUniquePtr. */
 
 #include "SimTKcommon.h"
 
@@ -343,11 +344,95 @@ void testForLeaks() {
     SimTK_TEST(Base::getNumAlive() == 0);
 }
 
+//#define TRACE(fmt, ...) printf(fmt, __VA_ARGS__)
+#define TRACE(fmt, ...)
+class Thing {
+public:
+    explicit Thing(int i) : t(i) {TRACE("construct T @0x%llx\n", 
+                                      (unsigned long long)this);}
+    ~Thing() { TRACE("destruct T @0x%llx\n", (unsigned long long)this); }
+    Thing(const Thing& s) : t(s.t) { TRACE("copy construct T\n"); }
+    Thing(Thing&& s) : t(std::move(s.t)) { TRACE("move construct T\n"); }
+    Thing& operator=(const Thing& s) {
+        t = s.t; TRACE("copy assign T\n");
+        return *this;
+    }
+    Thing& operator=(Thing&& s) {
+        t = s.t; TRACE("move assign T\n");
+        return *this;
+    }
+    int getVal() const {return t;}
+private:
+    int t;
+};
+
+std::ostream& operator<<(std::ostream& o, const Thing& t) {
+    return o << t.getVal();
+}
+
+void testNullOnCopyUniquePtr() {
+    std::unique_ptr<Thing> u(new Thing(-3));
+    NullOnCopyUniquePtr<Thing> pu(std::move(u));
+    SimTK_TEST(pu->getVal() == -3 && !u);
+    u = std::move(pu); // should move it back
+    SimTK_TEST(u->getVal() == -3 && !pu);
+    NullOnCopyUniquePtr<Thing> au;
+    au = std::move(u); 
+    SimTK_TEST(au->getVal() == -3 && !u);
+
+    // Test swap.
+    NullOnCopyUniquePtr<Thing> p(new Thing(3));
+    NullOnCopyUniquePtr<Thing> q(new Thing(33));
+    SimTK_TEST(p->getVal()==3 && q->getVal()==33);
+    const Thing* pp = p.get(); const Thing* qp = q.get();
+    swap(p,q);
+    SimTK_TEST(q->getVal()==3 && p->getVal()==33);
+    SimTK_TEST(q.get() == pp && p.get() == qp);
+
+    NullOnCopyUniquePtr<Thing> np;
+    NullOnCopyUniquePtr<Thing> npn(nullptr);
+    SimTK_TEST(!np && !npn && np==nullptr && npn==nullptr);
+    SimTK_TEST(nullptr==np && nullptr==npn);
+    SimTK_TEST(np <= nullptr && np >= nullptr);
+    SimTK_TEST(!(np > nullptr || np < nullptr));
+    SimTK_TEST(np != q);
+
+    NullOnCopyUniquePtr<Thing> cp = p; // copy constructor
+    SimTK_TEST(!cp && p.get() == qp);
+
+    NullOnCopyUniquePtr<Thing> ap;
+    ap = p; // copy assignment
+    SimTK_TEST(!ap && p.get() == qp);
+
+    NullOnCopyUniquePtr<Thing> mp = std::move(p); // move constructor
+    SimTK_TEST(mp->getVal()==33 && mp.get()==qp && !p);
+    ap = std::move(mp); // move assignment
+    SimTK_TEST(ap->getVal()==33 && ap.get()==qp && !mp);
+
+    ap = nullptr; // null assignment inherited from std::unique_ptr
+    SimTK_TEST(!ap);
+
+    // Hash should be the same for pointer, unique_ptr, and our class.
+    size_t hval = std::hash<Thing*>()(q.get());
+    size_t hvalu = std::hash<std::unique_ptr<Thing>>()
+                                    (static_cast<std::unique_ptr<Thing>&>(q));
+    SimTK_TEST(hvalu == hval);
+
+    size_t hvaln = std::hash<NullOnCopyUniquePtr<Thing>>()(q);
+    SimTK_TEST(hvaln == hvalu);
+
+    std::hash<NullOnCopyUniquePtr<Thing>> myhash;
+    size_t hvaln2 = myhash(q);
+    SimTK_TEST(hvaln2 == hvaln);
+}
+
 int main() {
     SimTK_START_TEST("TestCloneOnWritePtr");
         SimTK_SUBTEST(testEmpty);
         SimTK_SUBTEST(testAllocate);
         SimTK_SUBTEST(testForLeaks);
+
+        SimTK_SUBTEST(testNullOnCopyUniquePtr);
     SimTK_END_TEST();
 }
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,8 @@ shallow_clone: true
 
 platform: x64
 
+os: Visual Studio 2015
+
 init:
   # Put MSBuild on the path.
   - SET PATH=C:\Program Files (x86)\MSBuild\14.0\bin\;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ platform: x64
 
 init:
   # Put MSBuild on the path.
-  - SET PATH=C:\Program Files (x86)\MSBuild\12.0\bin\;%PATH%
+  - SET PATH=C:\Program Files (x86)\MSBuild\14.0\bin\;%PATH%
 
 build_script:
   # Must create separate build dir, otherwise can't read test files
@@ -23,7 +23,7 @@ build_script:
   - mkdir build
   - cd build
   # Treat all warnings as errors.
-  - cmake .. -G"Visual Studio 12 Win64" -DBUILD_VISUALIZER=OFF -DCMAKE_INSTALL_PREFIX=C:\simbody
+  - cmake .. -G"Visual Studio 14 Win64" -DBUILD_VISUALIZER=OFF -DCMAKE_INSTALL_PREFIX=C:\simbody
   # See http://msdn.microsoft.com/en-us/library/ms164311.aspx for
   # command-line options to MSBuild.
   - MSBuild Simbody.sln /target:ALL_BUILD /p:Configuration=Release /maxcpucount:4 /verbosity:quiet

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ build_script:
   - mkdir build
   - cd build
   # Treat all warnings as errors.
-  - cmake .. -G"Visual Studio 14 Win64" -DBUILD_VISUALIZER=OFF -DCMAKE_INSTALL_PREFIX=C:\simbody
+  - cmake .. -G"Visual Studio 14 2015 Win64" -DBUILD_VISUALIZER=OFF -DCMAKE_INSTALL_PREFIX=C:\simbody
   # See http://msdn.microsoft.com/en-us/library/ms164311.aspx for
   # command-line options to MSBuild.
   - MSBuild Simbody.sln /target:ALL_BUILD /p:Configuration=Release /maxcpucount:4 /verbosity:quiet


### PR DESCRIPTION
Added smart pointer `SimTK::NullOnCopyUniquePtr` which is the same as `std::unique_ptr` except that it adds copy construction and copy assignment that leave the  target null. This can be used for owned heap-allocated objects that are "local" in the sense that they should not be copied along with their owner. That allows use of compiler-generated default copy construction and copy assignment for the owning class. 