### PR TITLE
Switch back to build with VS2013

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,11 +13,9 @@ shallow_clone: true
 
 platform: x64
 
-os: Visual Studio 2015
-
 init:
   # Put MSBuild on the path.
-  - SET PATH=C:\Program Files (x86)\MSBuild\14.0\bin\;%PATH%
+  - SET PATH=C:\Program Files (x86)\MSBuild\12.0\bin\;%PATH%
 
 build_script:
   # Must create separate build dir, otherwise can't read test files
@@ -25,7 +23,7 @@ build_script:
   - mkdir build
   - cd build
   # Treat all warnings as errors.
-  - cmake .. -G"Visual Studio 14 2015 Win64" -DBUILD_VISUALIZER=OFF -DCMAKE_INSTALL_PREFIX=C:\simbody
+  - cmake .. -G"Visual Studio 12 2013 Win64" -DBUILD_VISUALIZER=OFF -DCMAKE_INSTALL_PREFIX=C:\simbody
   # See http://msdn.microsoft.com/en-us/library/ms164311.aspx for
   # command-line options to MSBuild.
   - MSBuild Simbody.sln /target:ALL_BUILD /p:Configuration=Release /maxcpucount:4 /verbosity:quiet


### PR DESCRIPTION
Added some more constructors to NullOnCopyUniquePtr rather than inheriting them, so we can continue to build with VS2013.

This should allow the new smart pointer from PR #417 to continue to work,  but with VS2013.

/cc @aymanhab @klshrinidhi @chrisdembia 