### PR TITLE
Add ResetOnCopy<T> and ReinitOnCopy<T> mixins

### DIFF
--- a/SimTKcommon/BigMatrix/include/SimTKcommon/internal/MatrixBase.h
+++ b/SimTKcommon/BigMatrix/include/SimTKcommon/internal/MatrixBase.h
@@ -100,7 +100,6 @@ public:
     typedef EPrecision Precision;     // complex removed from StdNumber
     typedef EScalarNormSq  ScalarNormSq;      // type of scalar^2
 
-    typedef MatrixBase<E>                T;
     typedef MatrixBase<ENeg>             TNeg;
     typedef MatrixBase<EWithoutNegator>  TWithoutNegator;
     typedef MatrixBase<EReal>            TReal;

--- a/SimTKcommon/BigMatrix/include/SimTKcommon/internal/Matrix_.h
+++ b/SimTKcommon/BigMatrix/include/SimTKcommon/internal/Matrix_.h
@@ -60,7 +60,6 @@ template <class ELT> class Matrix_ : public MatrixBase<ELT> {
     typedef MatrixBase<ENeg>    BaseNeg;
     typedef MatrixBase<EHerm>   BaseHerm;
 
-    typedef Matrix_<ELT>        T;
     typedef MatrixView_<ELT>    TView;
     typedef Matrix_<ENeg>       TNeg;
 

--- a/SimTKcommon/include/SimTKcommon/basics.h
+++ b/SimTKcommon/include/SimTKcommon/basics.h
@@ -45,6 +45,8 @@
 #include "SimTKcommon/internal/CloneOnWritePtr.h"
 #include "SimTKcommon/internal/ReferencePtr.h"
 #include "SimTKcommon/internal/NullOnCopyUniquePtr.h"
+#include "SimTKcommon/internal/ResetOnCopy.h"
+#include "SimTKcommon/internal/ReinitOnCopy.h"
 #include "SimTKcommon/internal/String.h"
 #include "SimTKcommon/internal/Serialize.h"
 #include "SimTKcommon/internal/Fortran.h"

--- a/SimTKcommon/include/SimTKcommon/internal/ReinitOnCopy.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ReinitOnCopy.h
@@ -1,0 +1,287 @@
+#ifndef SimTK_SimTKCOMMON_REINIT_ON_COPY_H_
+#define SimTK_SimTKCOMMON_REINIT_ON_COPY_H_
+
+/* -------------------------------------------------------------------------- *
+ *                       Simbody(tm): SimTKcommon                             *
+ * -------------------------------------------------------------------------- *
+ * This is part of the SimTK biosimulation toolkit originating from           *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
+ *                                                                            *
+ * Portions copyright (c) 2015 Stanford University and the Authors.           *
+ * Authors: Michael Sherman                                                   *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "SimTKcommon/internal/common.h"
+#include <cassert>
+#include <utility>
+#include <memory>
+#include <cstddef>
+#include <type_traits>
+
+namespace SimTK {
+
+//==============================================================================
+//                            REINIT ON COPY
+//==============================================================================
+
+// Only show the unspecialized helper class in Doxygen.
+
+/** This helper class is used only by ReinitOnCopy and is specialized as 
+necessary to support a variety of template types `T`. **/
+template <class T, bool IsScalarType>
+class ReinitOnCopyHelper {};
+
+/** Ensures that a data member of type `T` is automatically reinitialized to a 
+given initial value upon copy construction or copy assignment.\ This allows the
+compiler-generated defaults for these to be used.
+
+The template type `T` here is required to be `CopyAssignable` and 
+`CopyConstructible`. There is space overhead here for one extra copy of `T`
+used to hold the initial value. The default constructor is suppressed here; if 
+you just need the data member reset to zero 
+or to its default-constructed value, use class `ResetOnCopy<T>` instead. That 
+class has zero overhead and accepts a wider range of template arguments.
+
+Here are some usage examples:
+@code
+class Thing {
+    // Able to use default constructors and assignments
+
+    ReinitOnCopy<int>         m_which{-1};          // reinit to -1 on copy
+    ReinitOnCopy<string>      m_name{"unknown"};    // back to "unknown" on copy
+    ReinitOnCopy<const char*> m_desc{"none given"}; // similar
+
+    // An example where ResetOnCopy is better.
+    ResetOnCopy<unsigned>     m_count1;     // reset to 0 on copy; no overhead
+    ReinitOnCopy<unsigned>    m_count2;     // error; no default construction
+    ReinitOnCopy<unsigned>    m_count3{0};  // ok, but has space overhead
+
+    // An example where ResetOnCopy is necessary (T doesn't allow copying).
+    ResetOnCopy<std::unique_ptr<Something>> m_myThing;
+};
+@endcode
+
+Other than copy behavior, an object of type `ReinitOnCopy<T>` behaves just like 
+the underlying object of type `T`. It will implicitly convert to `T` when 
+needed, and inherit constructors, assignment, and other methods from `T`. Move 
+construction and move assignment behave as they would for `T`, and an assignment
+from an object of type `T` to an object of type `ReinitOnCopy<T>` will invoke 
+`T`'s ordinary copy assignment operator if there is one, and fail to compile if
+an attempt is made to use a non-existent assignment operator.
+
+@see ResetOnCopy if you only need to reinitialize to the default value.
+**/
+template <class T> 
+class ReinitOnCopy 
+:   public ReinitOnCopyHelper<T, 
+            std::is_scalar<typename std::remove_all_extents<T>::type>::value> {
+    using Super = ReinitOnCopyHelper<T, 
+            std::is_scalar<typename std::remove_all_extents<T>::type>::value>;
+public:
+    using Super::Super;
+    using Super::operator=;
+   
+    /** Default constructor is deleted; use ResetOnCopy instead. **/
+    ReinitOnCopy() = delete;
+
+    /** Construct or implicitly convert from an object of type `T`.\ This sets
+    both the current and remembered initial value to the given `value`. **/ 
+    ReinitOnCopy(const T& value) : Super(value) {}
+
+    /** Copy constructor sets the value and remembered initial value to the
+    initial value in the source, using type `T`'s copy constructor. The 
+    current value of the source is ignored. **/
+    ReinitOnCopy(const ReinitOnCopy& source) : Super(source) {}
+
+    /** Move constructor is simply a pass-through to the move constructor of
+    the contained object for both the current and initial values. **/
+    ReinitOnCopy(ReinitOnCopy&& source) : Super(std::move(source)) {} // default
+
+    /** Copy assignment reinitializes this object to its original condition; the
+    source argument is ignored. **/
+    ReinitOnCopy& operator=(const ReinitOnCopy& ignored) 
+    {   Super::operator=(ignored); return *this; }
+
+    /** Move assignment uses type `T`'s move assignment for the current value
+    but does not change the remembered initial value here. **/
+    ReinitOnCopy& operator=(ReinitOnCopy&& source) 
+    {   Super::operator=(std::move(source)); return *this; }
+
+    /** Assignment from an object of type `T` uses `T`'s copy assignment
+    operator; affects only the current value but does not change the remembered
+    initial value. **/
+    ReinitOnCopy& operator=(const T& value) 
+    {   Super::operator=(value); return *this; }
+
+    /** (Advanced) Return a const reference to the stored initial value. **/
+    const T& getReinitValue() const {return Super::getReinitValue();}
+
+    /** (Advanced) Return a writable reference to the stored initial 
+    value.\ Use of this should be rare and restricted to constructors. **/
+    T& updReinitValue() {return Super::updReinitValue();}
+};
+
+//==============================================================================
+//                          REINIT ON COPY HELPERS
+//==============================================================================
+
+
+/** @cond **/ // hide helpers from doxygen
+/** ReinitOnCopy helper class for built-in types (integral or floating point). 
+These types are value initialized, so will be reset to zero. **/
+template <class T>
+class ReinitOnCopyHelper<T,true> {
+
+    // TODO: should be possible to specialize this for arrays.
+    static_assert(!std::is_array<T>::value, 
+        "ReinitOnCopy<T> does not allow T to be an array. Use an array "
+        "of ReinitOnCopy<E> instead, where E is the element type.");
+public:
+    // These three are just the defaults but for debugging it is helpful to
+    // have them explicitly present to step into.
+
+    // Default construction (note that members are "value initialized").
+    ReinitOnCopyHelper() {}
+
+    // Constructor from `T` sets the value and remembered initial value to the
+    // given value, using type `T`'s copy constructor.
+    explicit ReinitOnCopyHelper(const T& value) 
+    :   m_value(value), m_reinitValue(value) {}
+
+    // Copy constructor sets the value and remembered initial value to the
+    // initial value in the source, using type `T`'s copy constructor. The 
+    // current value of the source is ignored.
+    ReinitOnCopyHelper(const ReinitOnCopyHelper& source)
+    :   ReinitOnCopyHelper(source.m_reinitValue) {}
+
+    // Default move construction.
+    ReinitOnCopyHelper(ReinitOnCopyHelper&& source) 
+    :   m_value(std::move(source.m_value)), 
+        m_reinitValue(std::move(source.m_reinitValue)) {}
+
+    // Move assignment moves the *value* from source to `this` but does not
+    // move the recorded initial value which may differ.
+    ReinitOnCopyHelper& operator=(ReinitOnCopyHelper&& source) 
+    {   m_value = std::move(source.m_value); return *this; }
+
+    // Copy assignment resets the current value to the remembered initial value
+    // using type `T`'s copy assignment operator. The source is ignored.
+    ReinitOnCopyHelper& operator=(const ReinitOnCopyHelper&) 
+    {   m_value = m_reinitValue; return *this; }
+
+    // Allow assignment from an object of type T; affects only the current
+    // value. Uses type `T`'s copy assignment operator.
+    ReinitOnCopyHelper& operator=(const T& value) 
+    {   m_value = value; return *this; }
+
+    // Implicit conversion to a const reference to the contained object of
+    // type `T`.
+    operator const T&() const {return m_value;}
+
+    // Implicit conversion to a writable reference to the contained object of
+    // type `T`.
+    operator T&() {return m_value;}
+
+    // Return a const reference to the stored initial value.
+    const T& getReinitValue() const {return m_reinitValue;}
+
+    // Return a writable reference to the stored initial value. Use of this 
+    // should be restricted to constructors.
+    T& updReinitValue() {return m_reinitValue;}
+
+private:
+    T           m_value{};          // note "value initialization"; i.e. zero
+    const T     m_reinitValue{}; 
+};
+
+
+/** ReinitOnCopy helper class specialization for any type `T` that is not a
+built-in ("scalar") type and that is `CopyConstructible` and `CopyAssignable`.
+Those operators are used to reinitialize the object to a stored initial value
+when copy constructor or copy assignment is performed. **/
+template <class T>
+class ReinitOnCopyHelper<T,false> : public T {
+
+    // TODO: should be possible to specialize this for arrays.
+    static_assert(!std::is_array<T>::value, 
+        "ReinitOnCopy<T> does not allow T to be an array. Use an array "
+        "of ReinitOnCopy<E> instead, where E is the element type.");
+
+    static_assert(   std::is_copy_constructible<T>::value
+                  && std::is_copy_assignable<T>::value,
+        "ReinitOnCopy<T> requires type T to have a copy constructor and copy "
+        "assignment operator. Use ResetOnCopy<T> instead to reinitialize to "
+        "the default value.");
+
+public:
+    using T::T;
+    using T::operator=;
+
+    // Default construction (T and the stored initial value are default 
+    // constructed).
+    ReinitOnCopyHelper() : T(), m_reinitValue() {}
+
+    // Move construction moves both the value and initial value from the 
+    // source object. This is the same as default move construction.
+    ReinitOnCopyHelper(ReinitOnCopyHelper&& source) 
+    :   T(std::move(source)), m_reinitValue(std::move(source.m_reinitValue)) {}
+
+    // Constructor from `T` sets the value and remembered initial value to the
+    // given value, using type `T`'s copy constructor.
+    explicit ReinitOnCopyHelper(const T& value) 
+    :   T(value), m_reinitValue(value) {}
+
+    // Copy constructor sets the value and remembered initial value to the
+    // initial value in the source, using type `T`'s copy constructor. The 
+    // current value of the source is ignored.
+    ReinitOnCopyHelper(const ReinitOnCopyHelper& source)
+    :   ReinitOnCopyHelper(source.m_reinitValue) {}
+
+    // Move assignment moves the *value* from source to `this` but does not
+    // move the recorded initial value which may differ.
+    ReinitOnCopyHelper& operator=(ReinitOnCopyHelper&& source) 
+    {   T::operator=(std::move(source)); return *this; }
+
+    // Copy assignment resets the current value to the remembered initial value
+    // using type `T`'s copy assignment operator. The source is ignored.
+    ReinitOnCopyHelper& operator=(const ReinitOnCopyHelper&) 
+    {   T::operator=(m_reinitValue); return *this; }
+
+    // Allow assignment from an object of type T; affects only the current
+    // value. Uses type `T`'s copy assignment operator.
+    ReinitOnCopyHelper& operator=(const T& value) 
+    {   T::operator=(value); return *this; }
+
+    // Return a const reference to the stored initial value.
+    const T& getReinitValue() const {return m_reinitValue;}
+
+    // Return a writable reference to the stored initial value. Use of this 
+    // should be restricted to constructors.
+    T& updReinitValue() {return m_reinitValue;}
+
+private:
+    // The remembered initial value is set to the already-constructed
+    // base value in case we used one of the base constructors. This uses
+    // the base class copy constructor.
+    const T m_reinitValue = {static_cast<const T&>(*this)}; 
+};
+
+/** @endcond **/
+
+} // namespace SimTK
+
+#endif // SimTK_SimTKCOMMON_REINIT_ON_COPY_H_
+

--- a/SimTKcommon/include/SimTKcommon/internal/ReinitOnCopy.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ReinitOnCopy.h
@@ -90,11 +90,23 @@ an attempt is made to use a non-existent assignment operator.
 @see ResetOnCopy if you only need to reinitialize to the default value.
 **/
 template <class T> 
-class ReinitOnCopy 
-:   public ReinitOnCopyHelper<T, 
-            std::is_scalar<typename std::remove_all_extents<T>::type>::value> {
-    using Super = ReinitOnCopyHelper<T, 
-            std::is_scalar<typename std::remove_all_extents<T>::type>::value>;
+class ReinitOnCopy : public ReinitOnCopyHelper<T, std::is_scalar<T>::value> {
+    using Super = ReinitOnCopyHelper<T, std::is_scalar<T>::value>;
+    
+    // TODO: should be possible to specialize this for arrays.
+    static_assert(!std::is_array<T>::value, 
+        "ReinitOnCopy<T> does not allow T to be an array. Use an array "
+        "of ReinitOnCopy<E> instead, where E is the element type.");
+
+    static_assert(   std::is_copy_constructible<T>::value
+                  && std::is_copy_assignable<T>::value,
+        "ReinitOnCopy<T> requires type T to have an accessible copy "
+        "constructor and copy assignment operator. Use ResetOnCopy<T> instead "
+        "to reinitialize using only default construction.");
+
+    static_assert(std::is_destructible<T>::value,
+        "ReinitOnCopy<T> requires type T to have an accessible destructor.");
+
 public:
     using Super::Super;
     using Super::operator=;
@@ -168,11 +180,6 @@ public:
 These types are value initialized, so will be reset to zero. **/
 template <class T>
 class ReinitOnCopyHelper<T,true> {
-
-    // TODO: should be possible to specialize this for arrays.
-    static_assert(!std::is_array<T>::value, 
-        "ReinitOnCopy<T> does not allow T to be an array. Use an array "
-        "of ReinitOnCopy<E> instead, where E is the element type.");
 public:
     // These three are just the defaults but for debugging it is helpful to
     // have them explicitly present to step into.
@@ -241,18 +248,6 @@ Those operators are used to reinitialize the object to a stored initial value
 when copy constructor or copy assignment is performed. **/
 template <class T>
 class ReinitOnCopyHelper<T,false> : public T {
-
-    // TODO: should be possible to specialize this for arrays.
-    static_assert(!std::is_array<T>::value, 
-        "ReinitOnCopy<T> does not allow T to be an array. Use an array "
-        "of ReinitOnCopy<E> instead, where E is the element type.");
-
-    static_assert(   std::is_copy_constructible<T>::value
-                  && std::is_copy_assignable<T>::value,
-        "ReinitOnCopy<T> requires type T to have a copy constructor and copy "
-        "assignment operator. Use ResetOnCopy<T> instead to reinitialize to "
-        "the default value.");
-
 public:
     using T::T;
     using T::operator=;

--- a/SimTKcommon/include/SimTKcommon/internal/ReinitOnCopy.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ReinitOnCopy.h
@@ -114,21 +114,23 @@ public:
     /** Copy constructor sets the value and remembered initial value to the
     initial value in the source, using type `T`'s copy constructor. The 
     current value of the source is ignored. **/
-    ReinitOnCopy(const ReinitOnCopy& source) : Super(source) {}
+    ReinitOnCopy(const ReinitOnCopy& source) 
+    :   Super(static_cast<const Super&>(source)) {}
 
     /** Move constructor is simply a pass-through to the move constructor of
     the contained object for both the current and initial values. **/
-    ReinitOnCopy(ReinitOnCopy&& source) : Super(std::move(source)) {} // default
+    ReinitOnCopy(ReinitOnCopy&& source) 
+    :   Super(static_cast<Super&&>(source)) {} // default
 
     /** Copy assignment reinitializes this object to its original condition; the
     source argument is ignored. **/
     ReinitOnCopy& operator=(const ReinitOnCopy& ignored) 
-    {   Super::operator=(ignored); return *this; }
+    {   Super::operator=(static_cast<const Super&>(ignored)); return *this; }
 
     /** Move assignment uses type `T`'s move assignment for the current value
     but does not change the remembered initial value here. **/
     ReinitOnCopy& operator=(ReinitOnCopy&& source) 
-    {   Super::operator=(std::move(source)); return *this; }
+    {   Super::operator=(static_cast<Super&&>(source)); return *this; }
 
     /** Assignment from an object of type `T` uses `T`'s copy assignment
     operator; affects only the current value but does not change the remembered

--- a/SimTKcommon/include/SimTKcommon/internal/ResetOnCopy.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ResetOnCopy.h
@@ -121,17 +121,18 @@ public:
 
     /** Move constructor is simply a pass-through to the move constructor of
     the contained object so behaves normally. **/
-    ResetOnCopy(ResetOnCopy&& source) : Super(std::move(source)) {} // default
+    ResetOnCopy(ResetOnCopy&& source) 
+    :   Super(static_cast<Super&&>(source)) {} // default
 
     /** Copy assignment reinitializes this object to its default-constructed
     condition; the source argument is ignored. **/
     ResetOnCopy& operator=(const ResetOnCopy& ignored) 
-    {   Super::operator=(ignored); return *this; }
+    {   Super::operator=(static_cast<const Super&>(ignored)); return *this; }
 
     /** Move assignment is simply a pass-through to the move assignment of the
     contained object so behaves normally. **/
     ResetOnCopy& operator=(ResetOnCopy&& source) 
-    {   Super::operator=(std::move(source)); return *this; }
+    {   Super::operator=(static_cast<Super&&>(source)); return *this; }
 
     /** Assignment from an object of type `T` uses `T`'s copy assignment
     operator if there is a suitable copy assignment operator available. **/

--- a/SimTKcommon/include/SimTKcommon/internal/ResetOnCopy.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ResetOnCopy.h
@@ -1,0 +1,267 @@
+#ifndef SimTK_SimTKCOMMON_RESET_ON_COPY_H_
+#define SimTK_SimTKCOMMON_RESET_ON_COPY_H_
+
+/* -------------------------------------------------------------------------- *
+ *                       Simbody(tm): SimTKcommon                             *
+ * -------------------------------------------------------------------------- *
+ * This is part of the SimTK biosimulation toolkit originating from           *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
+ *                                                                            *
+ * Portions copyright (c) 2015 Stanford University and the Authors.           *
+ * Authors: Michael Sherman                                                   *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "SimTKcommon/internal/common.h"
+#include <cassert>
+#include <utility>
+#include <memory>
+#include <cstddef>
+#include <type_traits>
+
+namespace SimTK {
+
+//==============================================================================
+//                             RESET ON COPY
+//==============================================================================
+
+// Only show the unspecialized helper class in Doxygen.
+
+/** This helper class is used only by ResetOnCopy and is specialized as 
+necessary to support a variety of template types `T`. **/
+template <class T, bool IsScalarType>
+class ResetOnCopyHelper {};
+
+/** Ensures that a data member of type `T` is automatically reset to its default
+value upon copy construction or copy assignment.\ This allows the
+compiler-generated defaults for these to be used.
+
+Here are some usage examples:
+@code
+class Thing {
+    // Able to use default constructors and assignments.
+
+    // Note that any initial values shown here disappear when this
+    // is copied; all members will be default-initialized in the copy.
+    ResetOnCopy<int>                     m_defint;
+    ResetOnCopy<char>                    m_charZ = 'z';
+    ResetOnCopy<string>                  m_defstr;
+    ResetOnCopy<string>                  m_strHelloC = "hello";
+    ResetOnCopy<string>                  m_strGoodbyeS = "goodbye"s;
+    ResetOnCopy<short>                   m_shArr[3] = {9,8,7};
+    ResetOnCopy<SubsystemIndex>          m_subIx{5};
+    ResetOnCopy<std::vector<string>>     m_vstr {"one", "two", "three"};
+    ResetOnCopy<unique_ptr<Array_<int>>> m_up{new Array_<int>({1,2,3})};
+};
+@endcode
+
+
+Other than copy behavior, an object of type `ResetOnCopy<T>` behaves just like 
+the underlying object of type `T`. It will implicitly convert to `T` when 
+needed, and inherit constructors, assignment, and other methods from `T`. Move 
+construction and move assignment behave as they would for `T`, and an assignment
+from an object of type `T` to an object of type `ResetOnCopy<T>` will invoke 
+`T`'s ordinary copy assignment operator if there is one, and fail to compile if
+an attempt is made to use a non-existent assignment operator.
+
+If `T` is a C++ built-in "scalar" type (arithmetic, character, or pointer type)
+it will be reset to `T(0)` or `nullptr` when copy constructed or copy assigned. 
+We don't allow `T` to be an enumerated type here since resetting an enum
+to zero isn't always reasonable; use `ReinitOnCopy<T>` instead and provide
+an initialing enumerator. For class types `T`, copy construction will use the 
+default constructor, and copy assignment will invoke `T::reset()` or, if there 
+is no such method then `T::clear()`. This will add `CopyConstructible` and 
+`CopyAssignable` concepts to move-only classes like `std::unique_ptr`, but those
+operations just reset the object to its default-constructed state.
+
+@see ReinitOnCopy if you want to reset to a non-default value.
+**/
+template <class T> 
+class ResetOnCopy 
+:   public ResetOnCopyHelper<T, 
+            std::is_scalar<typename std::remove_all_extents<T>::type>::value> {
+    using Super = ResetOnCopyHelper<T, 
+            std::is_scalar<typename std::remove_all_extents<T>::type>::value>;
+public:
+    using Super::Super;
+    using Super::operator=;
+  
+    /** Default constructor performs zero-initialization for built-in types;
+    default initialization for class types. **/
+    ResetOnCopy() : Super() {} // same as default
+
+    /** Construct or implicitly convert from an object of type `T` if there
+    is a suitable copy constructor available. **/ 
+    ResetOnCopy(const T& value) : Super(value) {}
+
+    /** Copy constructor behaves identically to the default constructor; the
+    supplied source argument is ignored. **/
+    ResetOnCopy(const ResetOnCopy&) : ResetOnCopy() {}
+
+    /** Move constructor is simply a pass-through to the move constructor of
+    the contained object so behaves normally. **/
+    ResetOnCopy(ResetOnCopy&& source) : Super(std::move(source)) {} // default
+
+    /** Copy assignment reinitializes this object to its default-constructed
+    condition; the source argument is ignored. **/
+    ResetOnCopy& operator=(const ResetOnCopy& ignored) 
+    {   Super::operator=(ignored); return *this; }
+
+    /** Move assignment is simply a pass-through to the move assignment of the
+    contained object so behaves normally. **/
+    ResetOnCopy& operator=(ResetOnCopy&& source) 
+    {   Super::operator=(std::move(source)); return *this; }
+
+    /** Assignment from an object of type `T` uses `T`'s copy assignment
+    operator if there is a suitable copy assignment operator available. **/
+    ResetOnCopy& operator=(const T& value) 
+    {   Super::operator=(value); return *this; }
+};
+
+//==============================================================================
+//                          RESET ON COPY HELPERS
+//==============================================================================
+
+
+/** @cond **/ // hide helpers from doxygen
+/** ResetOnCopy helper class for built-in ("scalar") types (arithmetic, 
+character, and pointer types). We don't want to allow enums here because they
+should always be initialized to one of their values, not necessarily zero.
+These types are value initialized, so will be reset to zero. **/
+template <class T>
+class ResetOnCopyHelper<T,true> {
+
+    // TODO: should be possible to specialize this for arrays.
+    static_assert(!std::is_array<T>::value, 
+        "ResetOnCopy<T> does not allow T to be an array. Use an array "
+        "of ResetOnCopy<E> instead, where E is the element type.");
+
+    static_assert(!std::is_enum<T>::value,
+        "ResetOnCopy<T> does not allow T to be an enum, because resetting to "
+        "zero may be inappropriate. Use ReinitOnCopy<T> instead and "
+        "provide the desired reinitialization enumerator value.");
+
+public:
+    // These three are just the defaults but for debugging it is helpful to
+    // have them explicitly present to step into.
+
+    // Default construction (note that m_value is "value initialized").
+    ResetOnCopyHelper() {}
+
+    // Default move construction.
+    ResetOnCopyHelper(ResetOnCopyHelper&& source) 
+    :   m_value(std::move(source.m_value)) {}
+
+    // Default move assignment.
+    ResetOnCopyHelper& operator=(ResetOnCopyHelper&& source) 
+    {   m_value = std::move(source.m_value); return *this; }
+
+    // Copy constructor isn't needed here since ResetOnCopy doesn't use it.
+    ResetOnCopyHelper(const ResetOnCopyHelper&) = delete;
+
+    /** Constructor from T sets an initial value but this initial value
+    will not be restored on copy. **/
+    ResetOnCopyHelper(const T& value) : m_value(value) {}
+
+    /** Make copy assignment produce the same result as if the target were
+    default constructed; the source is ignored. **/
+    ResetOnCopyHelper& operator=(const ResetOnCopyHelper&) {
+        m_value = T{};
+        return *this;
+    }
+
+    /** Allow assignment from an object of type T. **/
+    ResetOnCopyHelper& operator=(const T& value) {
+        m_value = value;
+        return *this;
+    }
+
+    /** Implicit conversion to a const reference to the contained object of
+    type `T`. **/
+    operator const T&() const {return m_value;}
+
+    /** Implicit conversion to a writable reference to the contained object of
+    type `T`. **/
+    operator T&() {return m_value;}
+
+private:
+    T   m_value{}; // value initialize; i.e., set to zero
+};
+
+
+/** ResetOnCopy helper class specialization for any type `T` that is not a
+built-in ("scalar") type and that has a reset() or clear() method. This will
+add `CopyConstructible` and `CopyAssignable` concepts to move-only classes
+like `std::unique`, but those operations just reset the object to its 
+default-constructed state. **/
+template <class T>
+class ResetOnCopyHelper<T,false> : public T {
+
+    // TODO: should be possible to specialize this for arrays.
+    static_assert(!std::is_array<T>::value, 
+        "ResetOnCopy<T> does not allow T to be an array. Use an array "
+        "of ResetOnCopy<E> instead, where E is the element type.");
+public:
+    using T::T;
+    using T::operator=;
+
+    // These three are just the defaults but for debugging it is helpful to
+    // have them explicitly present to step into.
+
+    // Default construction (T is default constructed).
+    ResetOnCopyHelper() : T() {}
+
+    // Constructor from T sets an initial value but this initial value
+    // will not be restored on copy. Won't compile if T doesn't have a copy
+    // constructor.
+    ResetOnCopyHelper(const T& value) : T(value) {}
+
+    // Default move construction.
+    ResetOnCopyHelper(ResetOnCopyHelper&& source) : T(std::move(source)) {}
+
+    // Default move assignment.
+    ResetOnCopyHelper& operator=(ResetOnCopyHelper&& source) {
+        T::operator=(std::move(source));
+        return *this;
+    }
+
+    // Copy constructor isn't needed here since ResetOnCopy doesn't use it.
+    ResetOnCopyHelper(const ResetOnCopyHelper&) = delete;
+
+    /** Copy assignment just invokes `this->reset()` or `this->clear()` and 
+    ignores the source. **/
+    ResetOnCopyHelper& operator=(const ResetOnCopyHelper&) {
+        resetOrClear<T>(0); // int(0) favors reset() over clear()
+        return *this;
+    }
+
+private:
+    // Thanks to Shrinidhi Kowshika Lakshmikanth for this lovely code that 
+    // figures out whether to call clear() or reset(). This depends on SFINAE to
+    // avoid generating any code that would depend on a non-existent method.
+    // reset() is preferred if both methods are available.
+
+    template<class TT, class = decltype(std::declval<TT>().reset())>
+    void resetOrClear(int) {TT::reset();}
+
+    template<class TT, class = decltype(std::declval<TT>().clear())>
+    void resetOrClear(float) {TT::clear();}
+
+};
+/** @endcond **/
+
+} // namespace SimTK
+
+#endif // SimTK_SimTKCOMMON_RESET_ON_COPY_H_

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -447,7 +447,8 @@ public:                                     \
     operator int() const {return ix;}               \
     bool isValid() const {return ix>=0;}            \
     bool isValidExtended() const {return ix>=-1;}   \
-    void invalidate(){ix=SimTK::InvalidIndex;}      \
+    void invalidate(){clear();}                     \
+    void clear(){ix=SimTK::InvalidIndex;}           \
     \
     bool operator==(int  i) const {assert(isValidExtended() && isValidExtended(i)); return ix==i;}    \
     bool operator==(short s) const{assert(isValidExtended() && isValidExtended(s)); return ix==(int)s;}  \
@@ -624,6 +625,35 @@ struct Segment {
     int length;
     int offset;
 };  
+
+// These next four methods supply the missing relational operators for any
+// types L and R where L==R and L<R have been defined. This is like the
+// operators in the std::rel_ops namespace, except that those require both
+// types to be the same.
+
+template<class L, class R> inline
+bool operator!=(const L& left, const R& right)
+{	// test for inequality, in terms of equality
+    return !(left == right);
+}
+
+template<class L, class R> inline
+bool operator>(const L& left, const R& right)
+{	// test if left > right, in terms of operator<
+    return right < left;
+}
+
+template<class L, class R> inline
+bool operator<=(const L& left, const R& right)
+{	// test if left <= right, in terms of operator<
+    return !(right < left);
+}
+
+template<class L, class R> inline
+bool operator>=(const L& left, const R& right)
+{	// test if left >= right, in terms of operator<
+    return !(left < right);
+}
 
 
 /** This is a special type used for causing invocation of a particular

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -633,25 +633,25 @@ struct Segment {
 
 template<class L, class R> inline
 bool operator!=(const L& left, const R& right)
-{	// test for inequality, in terms of equality
+{   // test for inequality, in terms of equality
     return !(left == right);
 }
 
 template<class L, class R> inline
 bool operator>(const L& left, const R& right)
-{	// test if left > right, in terms of operator<
+{   // test if left > right, in terms of operator<
     return right < left;
 }
 
 template<class L, class R> inline
 bool operator<=(const L& left, const R& right)
-{	// test if left <= right, in terms of operator<
+{   // test if left <= right, in terms of operator<
     return !(right < left);
 }
 
 template<class L, class R> inline
 bool operator>=(const L& left, const R& right)
-{	// test if left >= right, in terms of operator<
+{   // test if left >= right, in terms of operator<
     return !(left < right);
 }
 

--- a/SimTKcommon/tests/TestCloneOnWritePtr.cpp
+++ b/SimTKcommon/tests/TestCloneOnWritePtr.cpp
@@ -36,7 +36,9 @@ called SimTK::NullOnCopyUniquePtr. */
 
 using namespace SimTK;
 using std::cout; using std::endl; using std::string; using std::unique_ptr;
-using namespace std::literals;
+
+// C++14
+// using namespace std::literals;
 
 class Base {
 public:
@@ -436,7 +438,7 @@ public:
     ResetOnCopy<char>                   charZ = 'z';
     ResetOnCopy<string>                 defstr;
     ResetOnCopy<string>                 strHelloC = "hello";    // char* literal
-    ResetOnCopy<string>                 strGoodbyeS = "goodbye"s; // string literal
+    //ResetOnCopy<string>                 strGoodbyeS = "goodbye"s; // string literal C++14
     ResetOnCopy<short>                  shArr[3] = {9,8,7};
     ResetOnCopy<SubsystemIndex>         subIx{5};
     ResetOnCopy<std::vector<string>>    vstr {"one", "two", "three"};
@@ -446,7 +448,7 @@ public:
         SimTK_TEST(defint == 0 && charZ == 'z');
         SimTK_TEST(defstr.empty());
         SimTK_TEST(strHelloC == "hello");
-        SimTK_TEST(strGoodbyeS == "goodbye");
+        //SimTK_TEST(strGoodbyeS == "goodbye");
         SimTK_TEST(shArr[0]==9 && shArr[1]==8 && shArr[2]==7);
         SimTK_TEST(subIx == 5);
         SimTK_TEST(vstr.size() == 3);
@@ -459,7 +461,7 @@ public:
         SimTK_TEST(defint == 0 && charZ == '\0');
         SimTK_TEST(defstr.empty());
         SimTK_TEST(strHelloC.empty());
-        SimTK_TEST(strGoodbyeS.empty());
+        //SimTK_TEST(strGoodbyeS.empty());
         SimTK_TEST(shArr[0]==0 && shArr[1]==0 && shArr[2]==0);
         SimTK_TEST(!subIx.isValid());
         SimTK_TEST(vstr.empty());
@@ -555,7 +557,7 @@ public:
 
     ReinitOnCopy<char>                   charZ = 'z';
     ReinitOnCopy<string>                 strHelloC = "hello";    // char* literal
-    ReinitOnCopy<string>                 strGoodbyeS = "goodbye"s; // string literal
+    // ReinitOnCopy<string>                 strGoodbyeS = "goodbye"s; // string literal C++14
     ReinitOnCopy<short>                  shArr[3] = {9,8,7};
     ReinitOnCopy<SubsystemIndex>         subIx{5};
     ReinitOnCopy<std::vector<string>>    vstr {"one", "two", "three"};
@@ -564,7 +566,7 @@ public:
     void checkHasInitialValues() const {
         SimTK_TEST(charZ == 'z');
         SimTK_TEST(strHelloC == "hello");
-        SimTK_TEST(strGoodbyeS == "goodbye");
+        //SimTK_TEST(strGoodbyeS == "goodbye");
         SimTK_TEST(shArr[0]==9 && shArr[1]==8 && shArr[2]==7);
         SimTK_TEST(subIx == 5);
         SimTK_TEST(vstr.size() == 3);
@@ -575,7 +577,7 @@ public:
     void changeAll() {
         charZ = 'y';
         strHelloC = "something";
-        strGoodbyeS = "a string"s;
+        //strGoodbyeS = "a string"s;
         // shArr[0] = shArr[1] = shArr[2] = -123 won't work: two of those are
         // copy assignments so get reinitialized instead.
         shArr[0] = -123; shArr[1] = -123; shArr[2] = -123;
@@ -587,7 +589,7 @@ public:
     void checkHasChanged() const {
         SimTK_TEST(charZ == 'y');
         SimTK_TEST(strHelloC == "something");
-        SimTK_TEST(strGoodbyeS == "a string");
+        //SimTK_TEST(strGoodbyeS == "a string");
         SimTK_TEST(shArr[0]==-123 && shArr[1]==-123 && shArr[2]==-123);
         SimTK_TEST(!subIx.isValid());
         SimTK_TEST(vstr.size() == 2);

--- a/SimTKcommon/tests/TestCloneOnWritePtr.cpp
+++ b/SimTKcommon/tests/TestCloneOnWritePtr.cpp
@@ -500,6 +500,7 @@ void testResetOnCopy() {
 
     // Using std::string here failed on OSX clang 3.6 due to bad std::string
     // move assignment operator (didn't check for self-move).
+    // std::vector seemed to be more widely broken.
     //ResetOnCopy<string> mystr("hello");
     //SimTK_TEST(mystr == "hello");
 
@@ -509,8 +510,8 @@ void testResetOnCopy() {
     //mystr = mystr; // copy assignment should clear
     //SimTK_TEST(mystr.empty());
 
-    // Using std::vector instead hoping for correctly-implemented moves.
-    ResetOnCopy<std::vector<int>> myvec{1,2,3};
+    // Using Array_ instead to guarantee correctly-implemented moves.
+    ResetOnCopy<Array_<int>> myvec{1,2,3};
     SimTK_TEST(myvec.size()==3 && myvec[2]==3);
     // remember location of third element to check for unexpected reallocation
     int* const addr2 = &myvec[2];

--- a/SimTKcommon/tests/TestCloneOnWritePtr.cpp
+++ b/SimTKcommon/tests/TestCloneOnWritePtr.cpp
@@ -648,17 +648,14 @@ void testReinitOnCopy() {
     ReinitOnCopy<string> mystr2(mystr1); // reinit
     SimTK_TEST(mystr2 == "unknown" && mystr2.getReinitValue() == "unknown");
 
-    ReinitOnCopy<char*> mychar1 = "charstr";
+    ReinitOnCopy<const char*> mychar1 = "charstr";
     SimTK_TEST(string(mychar1) == "charstr");
     mychar1 = "here is a new string";
     SimTK_TEST(string(mychar1) == "here is a new string");
 
-    // Weird -- mychar converts to char* implicitly, then this is a construction
-    // from value rather than copy construction, so mychar2 doesn't inherit
-    // mychar1's initial value.
-    ReinitOnCopy<const char*> mychar2(mychar1);
-    SimTK_TEST(string(mychar2) == "here is a new string" 
-               && string(mychar2.getReinitValue()) == "here is a new string");
+    ReinitOnCopy<const char*> mychar2(mychar1); // copy construction; reinit
+    SimTK_TEST(string(mychar2) == "charstr" 
+               && string(mychar2.getReinitValue()) == "charstr");
 
     ReinitOnCopy<std::vector<char>> vc = {'a','b','c'};
     SimTK_TEST(vc.size()==3 && vc.getReinitValue().size()==3);


### PR DESCRIPTION
Add ResetOnCopy<T> and ReinitOnCopy<T> mixins. These are used on data members to provide resetting to default values on copy construction or copy assignment, or reinitialization to specified values.
These can be used on built-in types, pointers, containers, smart pointers, Simbody resource index objects, and almost anything else. (I don't know how to make them work with C array types though.)

Also:
- Added a clear() method to unique index types.
- Added templates that define all relational operators when given only operator==() and operator<().