### PR TITLE
Allow kinematics evaluation separate from position and velocity stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ to ParallelExecutor, mutex state lock.
 * Added move constructor and move assignment to State (very fast).
 * Added "stage version" counters for time, q, u, and z that are incremented
   whenever one of these changes.
+* Separated time-independent position and kinematics calculations so that 
+  they are not invalidated by a time change. These can also be initiated
+  explicitly with new methods `realizePositionKinematics()` and
+  `realizeVelocityKinematics()`. They are invalidated by a change to q or
+  to u, respectively. 
 * (There are more that haven't been added yet)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ of the current working directory (thanks to Carmichael Ong). See [Issue #264](ht
 * Added the ability to parallelize forces, robustness/performance improvements
 to ParallelExecutor, mutex state lock.
 [PR #414](https://github.com/simbody/simbody/pull/414).
+* Added move constructor and move assignment to State (very fast).
+* Added "stage version" counters for time, q, u, and z that are incremented
+  whenever one of these changes.
 * (There are more that haven't been added yet)
 
 

--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
@@ -34,6 +34,16 @@
 #include <cstdarg>
 
 namespace SimTK {
+ 
+/** This is the type to use for Stage and state variable version numbers that
+get incremented whenever a state value changes. Whenever time or any state 
+variable is modified, we increment the stage version for any stage that gets
+invalidated. We also increment a separate version number for the state variable
+that changes, so that cache entries can have finer-grained dependencies than
+just on whole stages. -1 means "unintialized". 0 is never used as 
+a %StageVersion, but is allowed as a cache value which is guaranteed never to 
+look valid. **/
+typedef long long StageVersion;
 
 /** This class is basically a glorified enumerated type, type-safe and range
 checked but permitting convenient (if limited) arithmetic. Constants look like 
@@ -254,7 +264,8 @@ public:
 class CacheEntryOutOfDate : public Base {
 public:
     CacheEntryOutOfDate(const char* fn, int ln,
-        Stage currentStage, Stage dependsOn, int dependsOnVersion, int lastCalculatedVersion) 
+        Stage currentStage, Stage dependsOn, 
+        StageVersion dependsOnVersion, StageVersion lastCalculatedVersion) 
     :   Base(fn,ln)
     {
         setMessage("State Cache entry was out of date at Stage " + currentStage.getName() 

--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
@@ -40,7 +40,7 @@ get incremented whenever a state value changes. Whenever time or any state
 variable is modified, we increment the stage version for any stage that gets
 invalidated. We also increment a separate version number for the state variable
 that changes, so that cache entries can have finer-grained dependencies than
-just on whole stages. -1 means "unintialized". 0 is never used as 
+just on whole stages. -1 means "uninitialized". 0 is never used as 
 a %StageVersion, but is allowed as a cache value which is guaranteed never to 
 look valid. **/
 typedef long long StageVersion;

--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/State.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/State.h
@@ -155,6 +155,11 @@ SimTK_DEFINE_UNIQUE_INDEX_TYPE(SystemMultiplierIndex);
 /// @see SystemMultiplierIndex
 SimTK_DEFINE_UNIQUE_INDEX_TYPE(MultiplierIndex);
 
+class StateImpl;
+class PerSubsystemInfo;
+class DiscreteVarInfo;
+class CacheEntryInfo;
+
 /** This object is intended to contain all state information for a 
 SimTK::System, except topological information which is stored in the %System 
 itself. 
@@ -1133,6 +1138,21 @@ returned with writable access). Will be 1 or greater if z has been
 allocated. **/
 inline StageVersion getZStageVersion() const;
 
+/** (Advanced) Return a reference to the cache entry information for a 
+particular cache entry. No validity checking is performed. **/
+SimTK_FORCE_INLINE const CacheEntryInfo& 
+getCacheEntryInfo(SubsystemIndex, CacheEntryIndex) const;
+
+/** (Advanced) Return a reference to the discrete variable information for a 
+particular discrete variable. **/
+SimTK_FORCE_INLINE const DiscreteVarInfo& 
+getDiscreteVarInfo(SubsystemIndex, DiscreteVariableIndex) const;
+
+/** (Advanced) Return a reference to the per-subsystem information in the
+state. **/
+SimTK_FORCE_INLINE const PerSubsystemInfo& 
+getPerSubsystemInfo(SubsystemIndex) const;
+
 /** (Advanced) This is called at the beginning of every integration step to set
 the values of auto-update discrete variables from the values stored in their 
 associated cache entries. **/
@@ -1145,7 +1165,7 @@ inline String cacheToString() const;
 // The implementation class and associated inline methods are defined in a
 // separate header file included below.
                                 private:
-class StateImpl* impl;
+StateImpl* impl;
 
 const StateImpl& getImpl() const {assert(impl); return *impl;}
 StateImpl&       updImpl()       {assert(impl); return *impl;}

--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/State.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/State.h
@@ -1089,6 +1089,10 @@ inline Vector& updUErr() const; // Stage::Velocity-1        "
 inline Vector& updUDotErr()     const; // Stage::Acceleration-1 (not a view)
 inline Vector& updMultipliers() const; // Stage::Acceleration-1 (not a view)
 
+/** @name                 Advanced/Obscure/Debugging
+Don't call these methods unless you know what you're doing. **/
+/**@{**/
+
 /** (Advanced) Record the current version numbers of each valid System-level 
 stage. This can be used to unambiguously determine what stages have been 
 changed by some opaque operation, even if that operation realized the stages 
@@ -1158,8 +1162,11 @@ the values of auto-update discrete variables from the values stored in their
 associated cache entries. **/
 inline void autoUpdateDiscreteVariables();
 
+/** (Debugging) Not suitable for serialization. **/
 inline String toString() const;
+/** (Debugging) Not suitable for serialization. **/
 inline String cacheToString() const;
+/**@}**/
 
 //------------------------------------------------------------------------------
 // The implementation class and associated inline methods are defined in a

--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/StateImpl.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/StateImpl.h
@@ -199,10 +199,11 @@ public:
     // determine whether the value is current; see isCurrent...() methods above.
     // If a cache entry has a computed-by stage, you have to invalidate that
     // stage in its subsystem also if you want to ensure it is invalid.
+    // The value version is not affected here; that only changes when the
+    // cache entry is explicitly marked valid.
     void invalidate() {
         m_dependsOnVersionWhenLastComputed = StageVersion(0);
         m_extraVersionWhenLastComputed.fill(StageVersion(0));
-        ++m_valueVersion; // not zero; we don't want to repeat one
     }
 
     // Call one of these markAsComputed() methods last when realizing this cache
@@ -256,13 +257,12 @@ public:
     // entry but we're not checking here).
     void swapValue(Real updTime, DiscreteVarInfo& dv) 
     {   dv.swapValue(updTime, m_value); }
+
     const AbstractValue& getValue() const {assert(m_value); return *m_value;}
 
-    AbstractValue& updValue() {
-        assert(m_value);
-        ++m_valueVersion;
-        return *m_value;
-    }
+    // Returning the value for write access doesn't affect the version; that
+    // happens only if the cache entries gets marked valid explicitly.
+    AbstractValue& updValue() {assert(m_value); return *m_value;}
 
     const Stage&          getDependsOnStage()  const {return m_dependsOnStage;}
     const Stage&          getComputedByStage() const {return m_computedByStage;}

--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/SubsystemGuts.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/SubsystemGuts.h
@@ -94,17 +94,19 @@ DiscreteVariableIndex allocateAutoUpdateDiscreteVariable
    (State& s, Stage invalidates, AbstractValue* v, Stage updateDependsOn) const
 {   return s.allocateAutoUpdateDiscreteVariable
                (getMySubsystemIndex(),invalidates,v,updateDependsOn); }
-CacheEntryIndex allocateCacheEntry
-   (const State& s, Stage dependsOn, Stage computedBy, AbstractValue* v) const 
-{   return s.allocateCacheEntry
-               (getMySubsystemIndex(), dependsOn, computedBy, v); }
 
 CacheEntryIndex allocateCacheEntry
-    (const State& state, Stage g, AbstractValue* v) const 
-{   return allocateCacheEntry(state, g, g, v); }
+   (const State& s, Stage dependsOn, Stage computedBy, AbstractValue* v,
+    unsigned numExtras=0) const 
+{   return s.allocateCacheEntry
+               (getMySubsystemIndex(), dependsOn, computedBy, v, numExtras); }
+CacheEntryIndex allocateCacheEntry
+   (const State& state, Stage g, AbstractValue* v, unsigned numExtras=0) const 
+{   return allocateCacheEntry(state, g, g, v, numExtras); }
 CacheEntryIndex allocateLazyCacheEntry   
-    (const State& state, Stage earliest, AbstractValue* v) const 
-{   return allocateCacheEntry(state, earliest, Stage::Infinity, v); }
+   (const State& state, Stage earliest, AbstractValue* v, 
+    unsigned numExtras=0) const 
+{   return allocateCacheEntry(state, earliest, Stage::Infinity, v, numExtras); }
 
 QErrIndex allocateQErr(const State& s, int nqerr) const 
 {   return s.allocateQErr(getMySubsystemIndex(), nqerr); }
@@ -265,8 +267,22 @@ void markDiscreteVarUpdateValueRealized
 
 bool isCacheValueRealized(const State& s, CacheEntryIndex cx) const 
 {   return s.isCacheValueRealized(getMySubsystemIndex(), cx); }
+bool isCacheValueRealizedWithExtras
+   (const State& s, CacheEntryIndex cx,
+    unsigned numExtras, const StageVersion* extraVersions,
+    StageVersion& cacheValueVersion) const 
+{   return s.isCacheValueRealizedWithExtras(getMySubsystemIndex(), cx,
+                                            numExtras, extraVersions,
+                                            cacheValueVersion); }
+
 void markCacheValueRealized(const State& s, CacheEntryIndex cx) const 
 {   s.markCacheValueRealized(getMySubsystemIndex(), cx); }
+void markCacheValueRealizedWithExtras
+   (const State& s, CacheEntryIndex cx,
+    unsigned numExtras, const StageVersion* extraVersions) const 
+{   s.markCacheValueRealizedWithExtras(getMySubsystemIndex(), cx,
+                                       numExtras, extraVersions); }
+
 void markCacheValueNotRealized(const State& s, CacheEntryIndex cx) const 
 {   s.markCacheValueNotRealized(getMySubsystemIndex(), cx); }
 /**@}**/

--- a/SimTKcommon/Simulation/src/State.cpp
+++ b/SimTKcommon/Simulation/src/State.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors: Peter Eastman                                                *
  *                                                                            *
@@ -28,6 +28,7 @@
 
 #include <cassert>
 #include <algorithm>
+#include <utility>
 #include <ostream>
 #include <set>
 #include <mutex>
@@ -55,6 +56,12 @@ State::~State() {
 State::State(const State& state) {
     impl = new StateImpl(*state.impl);
 }
+  
+// move constructor
+State::State(State&& source) {
+    impl = source.impl;
+    source.impl = nullptr;
+}
     
 // copy assignment
 State& State::operator=(const State& src) {
@@ -72,6 +79,11 @@ State& State::operator=(const State& src) {
     return *this;
 }
 
+// move assignment
+State& State::operator=(State&& source) {
+    std::swap(impl, source.impl); // just swap the pointers
+    return *this;
+}
 
 // See StateImpl.h for inline method implementations.
 
@@ -309,29 +321,24 @@ void PerSubsystemInfo::copyFrom(const PerSubsystemInfo& src, Stage maxStage) {
 //------------------------------------------------------------------------------
 //                           COPY CONSTRUCTOR
 //------------------------------------------------------------------------------
-StateImpl::StateImpl(const StateImpl& src)
-:   currentSystemStage(Stage::Empty)
-{
-    initializeStageVersions();
-    
+StateImpl::StateImpl(const StateImpl& src) {
     // Make sure that no copied cache entry could accidentally think
     // it was up to date. We'll change some of these below if appropriate.
     // (We're skipping the Empty stage 0.)
-    for (int i=1; i <= src.currentSystemStage; ++i)
-        systemStageVersions[i] = src.systemStageVersions[i]+1;
+    invalidateCopiedStageVersions(src);
 
     subsystems = src.subsystems;
     if (src.currentSystemStage >= Stage::Topology) {
         advanceSystemToStage(Stage::Topology);
         systemStageVersions[Stage::Topology] = 
             src.systemStageVersions[Stage::Topology];
-        t = src.t;
+        t = src.t; // not validating time version or Stage::Time
         if (src.currentSystemStage >= Stage::Model) {
             advanceSystemToStage(Stage::Model);
             systemStageVersions[Stage::Model] = 
                 src.systemStageVersions[Stage::Model];
             // careful -- don't allow reallocation
-            y = src.y;
+            y = src.y; // not validating state versions or later stages
             uWeights = src.uWeights;
             zWeights = src.zWeights;
         }
@@ -358,21 +365,22 @@ StateImpl& StateImpl::operator=(const StateImpl& src) {
     // Make sure that no copied cache entry could accidentally think
     // it was up to date. We'll change some of these below if appropriate.
     // (We're skipping the Empty stage 0.)
-    for (int i=1; i <= src.currentSystemStage; ++i)
-        systemStageVersions[i] = src.systemStageVersions[i]+1;
+    invalidateCopiedStageVersions(src);
+
+    t = NaN;
 
     subsystems = src.subsystems;
     if (src.currentSystemStage >= Stage::Topology) {
         advanceSystemToStage(Stage::Topology);
         systemStageVersions[Stage::Topology] = 
             src.systemStageVersions[Stage::Topology];
-        t = src.t;
+        t = src.t; // not validating time version or Stage::Time
         if (src.currentSystemStage >= Stage::Model) {
             advanceSystemToStage(Stage::Model);
             systemStageVersions[Stage::Model] = 
                 src.systemStageVersions[Stage::Model];
             // careful -- don't allow reallocation
-            y = src.y;
+            y = src.y; // not validating state versions or later stages
             uWeights = src.uWeights;
             zWeights = src.zWeights;
         }
@@ -439,6 +447,8 @@ void StateImpl::invalidateJustSystemStage(Stage stg) {
         q.clear(); u.clear(); z.clear(); // y views
         // Finally nuke the actual y data.
         y.unlockShape(); y.clear(); 
+        noteYChange(); // bump the q,u,z version numbers
+
         uWeights.unlockShape(); uWeights.clear();
         zWeights.unlockShape(); zWeights.clear();
 
@@ -450,12 +460,13 @@ void StateImpl::invalidateJustSystemStage(Stage stg) {
         // We're invalidating the topology stage. Time is considered
         // a topology stage variable so needs to be invalidated here.
         t = NaN;
+        noteTimeChange(); // bump the version number
     }
 
     // Raise the version number for every stage that we're invalidating and
     // set the current System Stage one lower than the one being invalidated.
     for (int i=currentSystemStage; i >= stg; --i)
-        systemStageVersions[i]++;
+        ++systemStageVersions[i];
     currentSystemStage = stg.prev();
 }
 
@@ -474,7 +485,9 @@ void StateImpl::advanceSystemToStage(Stage stg) const {
     if (stg == Stage::Topology) {
         // As the final "Topology" step, initialize time to 0 (it's NaN 
         // before this).
-        const_cast<StateImpl*>(this)->t = 0;
+        StateImpl* wThis = const_cast<StateImpl*>(this);
+        wThis->t = 0;
+        ++wThis->tVersion;
     }
     else if (stg == Stage::Model) {
         // We know the shared state pool sizes now. Allocate the
@@ -513,6 +526,9 @@ void StateImpl::advanceSystemToStage(Stage stg) const {
         wThis->q.viewAssign(wThis->y(0,nq));
         wThis->u.viewAssign(wThis->y(nq,nu));
         wThis->z.viewAssign(wThis->y(nq+nu,nz));
+
+        // Update modification versions since these are changing.
+        ++wThis->qVersion; ++wThis->uVersion; ++wThis->zVersion;
 
         qdot.viewAssign(ydot(0,     nq));
         udot.viewAssign(ydot(nq,    nu));
@@ -705,8 +721,8 @@ void StateImpl::autoUpdateDiscreteVariables() {
             const CacheEntryIndex cx = dinfo.getAutoUpdateEntry();
             if (!cx.isValid()) continue; // not an auto-update variable
             CacheEntryInfo& cinfo = ss.cacheInfo[cx];
-            if (cinfo.isCurrent(getSubsystemStage(subx), 
-                                getSubsystemStageVersions(subx)))
+            if (cinfo.isCurrentNoExtras(getSubsystemStage(subx), 
+                                        getSubsystemStageVersions(subx)))
                 cinfo.swapValue(getTime(), dinfo);
             cinfo.invalidate();
         }

--- a/SimTKcommon/include/SimTKcommon/Testing.h
+++ b/SimTKcommon/include/SimTKcommon/Testing.h
@@ -562,6 +562,17 @@ private:
         if (threw==2) SimTK_TEST_FAILED1("Expected statement\n%s\n  to throw an std::exception but it threw something else.",#stmt); \
     }while(false)
 
+/// Test that the supplied statement throws an std::exception of some kind, and
+/// show what message got thrown.
+#define SimTK_TEST_MUST_THROW_SHOW(stmt)        \
+    do {int threw=0; try {stmt;}                \
+        catch(const std::exception& e) {threw=1; \
+            std::cout << "(OK) Threw: " << e.what() << std::endl;}  \
+        catch(...){threw=2;}                    \
+        if (threw==0) SimTK_TEST_FAILED1("Expected statement\n----\n%s\n----\n  to throw an exception but it did not.",#stmt); \
+        if (threw==2) SimTK_TEST_FAILED1("Expected statement\n%s\n  to throw an std::exception but it threw something else.",#stmt); \
+    }while(false)
+
 /// Test that the supplied statement throws a particular exception.
 #define SimTK_TEST_MUST_THROW_EXC(stmt,exc)     \
     do {int threw=0; try {stmt;}                \

--- a/SimTKmath/Integrators/src/SemiExplicitEuler2Integrator.cpp
+++ b/SimTKmath/Integrators/src/SemiExplicitEuler2Integrator.cpp
@@ -168,8 +168,7 @@ bool SemiExplicitEuler2IntegratorRep::attemptDAEStep
     advanced.updZ() = m_zBig = getPreviousZ() + h * getPreviousZDot();
     advanced.updU() = getPreviousU() + h * getPreviousUDot();
 
-    //TODO: need to be able to do this without invalidating q's.
-    // Should be able to calculate u_prescribed(newTime, oldQ)
+    // Note that changing time does not invalidate position kinematics.
     advanced.updTime() = t1;
     system.realize(advanced, Stage::Position); // old q, new t=t1
     system.prescribeU(advanced);
@@ -213,7 +212,7 @@ bool SemiExplicitEuler2IntegratorRep::attemptDAEStep
     advanced.updZ() += hHalf * zdotHalf;
     advanced.updU() += hHalf * udotHalf;
 
-    advanced.updTime() = t1;
+    advanced.updTime() = t1; // position kinematics unchanged
     system.realize(advanced, Stage::Position); // old q=qHalf, new t=t1
     system.prescribeU(advanced);
 

--- a/SimTKmath/Integrators/src/SemiExplicitEulerIntegrator.cpp
+++ b/SimTKmath/Integrators/src/SemiExplicitEulerIntegrator.cpp
@@ -150,8 +150,7 @@ bool SemiExplicitEulerIntegratorRep::attemptDAEStep
     advanced.updZ() = getPreviousZ() + h * getPreviousZDot();
     advanced.updU() = getPreviousU() + h * getPreviousUDot();
 
-    //TODO: need to be able to do this without invalidating q's.
-    // Should be able to calculate u_prescribed(newTime, oldQ)
+    // Note that changing time does not invalidate position kinematics.
     advanced.updTime() = t1;
     system.realize(advanced, Stage::Position); // old q, new t
     system.prescribeU(advanced);

--- a/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
+++ b/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2006-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2006-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors: Paul Mitiguy                                                 *
  *                                                                            *
@@ -1174,7 +1174,7 @@ single frame task.
     interest are fixed. These may be in any order and the same body may appear
     more than once if there are multiple task frames on it.
 @param[in]      originAoInB
-    An array of nt frame origin points Ao for the task frames interest (one 
+    An array of nt frame origin points Ao for the task frames of interest (one 
     per task), each corresponding to one of the bodies B from \a onBodyB, given
     as vectors from each body B's origin Bo to its task frame origin Ao, 
     expressed in frame B.
@@ -2470,7 +2470,31 @@ delayed until needed; you can cause those calculations to be performed
 explicitly here if you want. **/
 /**@{**/
 
-    // POSITION STAGE realizations //
+/** Position kinematics is the first part of the Stage::Position realization,
+mapping generalized coordinates q to the spatial (Cartesian) poses of the 
+mobilized bodies. This mapping depends only on instance variables and q; it is
+time-independent, so does not get invalidated by a time change. This 
+computation is normally initiated by a `realize(state,Stage::Position)` 
+call, but you can realize just the kinematics explicitly here. The calculation
+will *not* be repeated when realizing Stage::Position for the same q values. 
+@par Required stage
+  \c Stage::Instance 
+@see invalidatePositionKinematics() **/
+void realizePositionKinematics(const State& state) const;
+
+/** Velocity kinematics is the first part of the Stage::Velocity realization,
+mapping generalized speeds u to the spatial (Cartesian) velocities of the 
+mobilized bodies. This mapping depends only on instance variables, position
+kinematics, and u; it is time-independent, so does not get invalidated by a time
+change. This computation is normally initiated by a 
+`realize(state,Stage::Velocity)` call, but you can realize just the kinematics 
+explicitly here. The calculation will *not* be repeated when realizing 
+Stage::Velocity for the same q and u values. Note that you must already have
+realized position kinematics in order to call this method.
+@par Required stage
+  \c Stage::Position, or \c Stage::Instance and \c PositionKinematics
+@see invalidateVelocityKinematics() **/
+void realizeVelocityKinematics(const State&) const;
 
 /** This method checks whether composite body inertias have already been 
 computed since the last change to a Position stage state variable (q) and if so 
@@ -2478,7 +2502,7 @@ returns immediately at little cost; otherwise, it initiates computation of
 composite body inertias for all of the mobilized bodies. These are not otherwise
 computed unless specifically requested.
 @par Required stage
-  \c Stage::Position 
+  \c Stage::Position
 @see invalidateCompositeBodyInertias() **/
 void realizeCompositeBodyInertias(const State&) const;
 
@@ -2494,18 +2518,65 @@ stage.
 void realizeArticulatedBodyInertias(const State&) const;
 
 
-    // INSTANCE STAGE responses //
+    // INSTANCE STAGE responses and operators //
 
+/** Return a list of the generalized coordinates q that are free, that is,
+not locked or prescribed with a Motion.
+@par Required stage
+  \c Stage::Instance **/
 const Array_<QIndex>& getFreeQIndex(const State& state) const;
+
+/** Return a list of the generalized speeds u that are free, that is,
+not locked or prescribed with a Motion.
+@par Required stage
+  \c Stage::Instance **/
 const Array_<UIndex>& getFreeUIndex(const State& state) const;
+
+/** Return a list of the generalized speeds whose time derivatives udot are
+unknown, that is, not locked or prescribed with a Motion. This is the 
+complement of getKnownUDotIndex().
+@par Required stage
+  \c Stage::Instance **/
 const Array_<UIndex>& getFreeUDotIndex(const State& state) const;
+
+/** Return a list of the generalized speeds whose time derivatives udot are
+known, that is, locked or prescribed with a Motion.  This is the 
+complement of getFreeUDotIndex().
+@par Required stage
+  \c Stage::Instance **/
 const Array_<UIndex>& getKnownUDotIndex(const State& state) const;
+
+/** Given a generalized coordinate (q-space) Vector, select only those 
+elements that are free (in the sense of getFreeQIndex()) and pack them in
+order into `packedFreeQ`, which must already be allocated to the correct
+length, getFreeQIndex().size().
+@par Required stage
+  \c Stage::Instance **/
 void packFreeQ
    (const State& s, const Vector& allQ, Vector& packedFreeQ) const;
+
+/** Given a free-q Vector, unpack it into a q-space Vector which 
+must already be allocated to the correct size. The not-free elements already
+in `unpackedFreeQ` are not touched.
+@par Required stage
+  \c Stage::Instance **/
 void unpackFreeQ
    (const State& s, const Vector& packedFreeQ, Vector& unpackedFreeQ) const;
+
+/** Given a generalized speed (u- or mobility-space) Vector, select only those 
+elements that are free (in the sense of getFreeUIndex()) and pack them in
+order into `packedFreeU`, which must already be allocated to the correct
+length, getFreeUIndex().size().
+@par Required stage
+  \c Stage::Instance **/
 void packFreeU
    (const State& s, const Vector& allU, Vector& packedFreeU) const;
+
+/** Given a free-u Vector, unpack it into a u-space Vector which 
+must already be allocated to the correct size. The not-free elements already
+in `unpackedFreeU` are not touched.
+@par Required stage
+  \c Stage::Instance **/
 void unpackFreeU
    (const State& s, const Vector& packedFreeU, Vector& unpackedFreeU) const;
 
@@ -2628,15 +2699,34 @@ void calcMobilizerReactionForcesUsingFreebodyMethod
    (const State&         state, 
     Vector_<SpatialVec>& forcesAtMInG) const;
 
-/** This is useful for timing computation time for 
+/** (Advanced) Force invalidation of position kinematics, which otherwise 
+remains valid until an instance-stage variable or a generalized coordinate q
+is modified. This is useful for timing computation time for 
+realizePositionKinematics(), which otherwise will not recalculate if called 
+repeatedly. Note that this also invalidates Position stage and 
+above in `state` because position kinematics is assumed to be
+valid after Position stage, regardless of lazy evaluation status. **/
+void invalidatePositionKinematics(const State& state) const;
+
+/** (Advanced) Force invalidation of velocity kinematics, which otherwise 
+remains valid until an instance-stage variable, generalized coordinate q, or
+generalized speed u is modified. This is useful for timing computation time for 
+realizeVelocityKinematics(), which otherwise will not recalculate if called 
+repeatedly. Note that this also invalidates Velocity stage and 
+above in `state` because velocity kinematics is assumed to be
+valid after Velocity stage, regardless of lazy evaluation status. **/
+void invalidateVelocityKinematics(const State& state) const;
+
+/** (Advanced) This is useful for timing computation time for 
 realizeCompositeBodyInertias(), which otherwise will not recalculate them
 if called repeatedly. **/
 void invalidateCompositeBodyInertias(const State& state) const;
 
-/** This is useful for timing computation time for 
-realizeArticulatedBodyInertias(), which otherwise will not recalculate them
-if called repeatedly. Note that this also invalidates Dynamics stage and 
-above in the \a state because articulated body inertias are assumed to be
+/** (Advanced) Force invalidation of articulated body inertias (ABIs), which 
+otherwise remain valid until a position-stage variable is modified. This is 
+useful for timing computation time for realizeArticulatedBodyInertias(), which 
+otherwise will not recalculate if called repeatedly. Note that this also 
+invalidates Dynamics stage and above in `state` because ABIs are assumed to be
 valid after Dynamics stage, regardless of lazy evaluation status. **/
 void invalidateArticulatedBodyInertias(const State& state) const;
 /**@}**/

--- a/Simbody/src/Constraint.cpp
+++ b/Simbody/src/Constraint.cpp
@@ -3143,9 +3143,8 @@ const SpatialVec& ConstraintImpl::getBodyVelocityFromState
 // =============================================================================
 // 63 flops per constrained body
 void ConstraintImpl::calcConstrainedBodyTransformInAncestor      // X_AB
-   (const SBStateDigest& sbs, SBTreePositionCache& tpc) const 
+   (const SBInstanceVars& instanceVars, SBTreePositionCache& tpc) const 
 {
-    const SBInstanceVars& instanceVars  = sbs.getInstanceVars();
     if (instanceVars.constraintIsDisabled[myConstraintIndex]) return;
     if (!myAncestorBodyIsNotGround) return;
     const MobilizedBodyIndex ancestorA = mySubtree.getAncestorMobilizedBodyIndex();
@@ -3172,14 +3171,12 @@ void ConstraintImpl::calcConstrainedBodyTransformInAncestor      // X_AB
 // =============================================================================
 // 51 flops per constrained body
 void ConstraintImpl::calcConstrainedBodyVelocityInAncestor       // V_AB
-   (const SBStateDigest& sbs, SBTreeVelocityCache& tvc) const 
+   (const SBInstanceVars& instanceVars, const SBTreePositionCache& tpc,
+    SBTreeVelocityCache& tvc) const 
 {
-    const SBInstanceVars& instanceVars  = sbs.getInstanceVars();
     if (instanceVars.constraintIsDisabled[myConstraintIndex]) return;
     if (!myAncestorBodyIsNotGround) return;
     const MobilizedBodyIndex ancestorA = mySubtree.getAncestorMobilizedBodyIndex();
-
-    const SBTreePositionCache& tpc = sbs.getTreePositionCache();
 
     // All position kinematics has been calculated, and we also expect 
     // Ground-relative velocity kinematics already to have been calculated in tvc, 

--- a/Simbody/src/ConstraintImpl.h
+++ b/Simbody/src/ConstraintImpl.h
@@ -1166,15 +1166,11 @@ ConstraintIndex getMyConstraintIndex() const {
 
 
 // Calculate the transform X_AB of each ConstrainedBody in its Ancestor frame, 
-// provided Ancestor!=Ground and A!=B. We expect a StateDigest of a State
-// that has been realized through Time stage, and a TreePositionCache in
+// provided Ancestor!=Ground and A!=B. We expect a TreePositionCache in
 // which the mobilizer- and ground-frame position kinematics results have
 // already been calculated. We then fill in the missing ancestor-frame
-// results back into that same TreePositionCache. The TreePositionCache
-// in the StateDigest is ignored; it may or may not be the same as the
-// second argument depending on whether this is part of a realization or
-// part of an operator.
-void calcConstrainedBodyTransformInAncestor(const SBStateDigest&,   // in only
+// results back into that same TreePositionCache.
+void calcConstrainedBodyTransformInAncestor(const SBInstanceVars&,  // in only
                                             SBTreePositionCache&    // in/out
                                             ) const;
 
@@ -1182,7 +1178,8 @@ void calcConstrainedBodyTransformInAncestor(const SBStateDigest&,   // in only
 // Here we expect a StateDigest realized through Position stage, and a 
 // partly-filled-in VelocityCache where we'll put V_AB for the 
 // ConstrainedBodies.
-void calcConstrainedBodyVelocityInAncestor(const SBStateDigest&,    // in only
+void calcConstrainedBodyVelocityInAncestor(const SBInstanceVars&,   // in only
+                                           const SBTreePositionCache&, // "
                                            SBTreeVelocityCache&     // in/out
                                            ) const;
 

--- a/Simbody/src/RigidBodyNodeSpec_Ball.h
+++ b/Simbody/src/RigidBodyNodeSpec_Ball.h
@@ -186,7 +186,7 @@ void calcAcrossJointVelocityJacobianDot(
 // so we have to zero out the last one in that case.
 void calcQDot(const SBStateDigest& sbs, const Real* u, 
                              Real* qdot) const {
-    assert(sbs.getStage() >= Stage::Position);
+    // We have to trust that the tree position cache is valid here.
     assert(u && qdot);
 
     const SBModelVars& mv = sbs.getModelVars();

--- a/Simbody/src/RigidBodyNodeSpec_Ellipsoid.h
+++ b/Simbody/src/RigidBodyNodeSpec_Ellipsoid.h
@@ -286,7 +286,7 @@ void calcAcrossJointVelocityJacobianDot(
 // so we have to zero out the last one in that case.
 void calcQDot(const SBStateDigest& sbs, const Real* u, 
                              Real* qdot) const {
-    assert(sbs.getStage() >= Stage::Position);
+    // We have to trust that the tree position cache is valid here.
     assert(u && qdot);
 
     const SBModelVars& mv = sbs.getModelVars();

--- a/Simbody/src/RigidBodyNodeSpec_Free.h
+++ b/Simbody/src/RigidBodyNodeSpec_Free.h
@@ -221,7 +221,7 @@ void calcAcrossJointVelocityJacobianDot(
 // so we have to zero out the last one in that case.
 void calcQDot(const SBStateDigest& sbs, const Real* u, 
                              Real* qdot) const {
-    assert(sbs.getStage() >= Stage::Position);
+    // We have to trust that the tree position cache is valid here.
     assert(u && qdot);
 
     const SBModelVars& mv = sbs.getModelVars();

--- a/Simbody/src/SimbodyMatterSubsystem.cpp
+++ b/Simbody/src/SimbodyMatterSubsystem.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2006-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2006-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors:                                                              *
  *                                                                            *
@@ -2003,6 +2003,15 @@ void SimbodyMatterSubsystem::addInStationForce(const State& s, MobilizedBodyInde
     bodyForces[body] += SpatialVec((R_GB*stationInB) % forceInG, forceInG);
 }
 
+void SimbodyMatterSubsystem::realizePositionKinematics(const State& s) const {
+    getRep().realizePositionKinematics(s);
+}
+
+
+void SimbodyMatterSubsystem::realizeVelocityKinematics(const State& s) const {
+    getRep().realizeVelocityKinematics(s);
+}
+
 void SimbodyMatterSubsystem::realizeCompositeBodyInertias(const State& s) const {
     getRep().realizeCompositeBodyInertias(s);
 }
@@ -2011,12 +2020,23 @@ void SimbodyMatterSubsystem::realizeArticulatedBodyInertias(const State& s) cons
     getRep().realizeArticulatedBodyInertias(s);
 }
 
+void SimbodyMatterSubsystem::
+invalidatePositionKinematics(const State& s) const {
+    getRep().invalidatePositionKinematics(s);
+}
 
-void SimbodyMatterSubsystem::invalidateCompositeBodyInertias(const State& s) const {
+void SimbodyMatterSubsystem::
+invalidateVelocityKinematics(const State& s) const {
+    getRep().invalidateVelocityKinematics(s);
+}
+
+void SimbodyMatterSubsystem::
+invalidateCompositeBodyInertias(const State& s) const {
     getRep().invalidateCompositeBodyInertias(s);
 }
 
-void SimbodyMatterSubsystem::invalidateArticulatedBodyInertias(const State& s) const {
+void SimbodyMatterSubsystem::
+invalidateArticulatedBodyInertias(const State& s) const {
     getRep().invalidateArticulatedBodyInertias(s);
 }
 

--- a/Simbody/src/SimbodyMatterSubsystemRep.cpp
+++ b/Simbody/src/SimbodyMatterSubsystemRep.cpp
@@ -1415,9 +1415,9 @@ invalidateVelocityKinematics(const State& state) const {
 }
 
 
-    // We've already determined that we haven't reached Stage::Velocity where
-    // the velocity kinematics are guaranteed to be valid. Now do the
-    // fancier checks that won't get inlined.
+// We've already determined that we haven't reached Stage::Velocity where
+// the velocity kinematics are guaranteed to be valid. Now do the
+// fancier checks that won't get inlined.
 void SimbodyMatterSubsystemRep::
 checkValidityOfTreeVelocityCache(const State& state,
                                  const PerSubsystemInfo& subInfo,
@@ -1425,29 +1425,10 @@ checkValidityOfTreeVelocityCache(const State& state,
     const Stage current   = subInfo.getCurrentStage();
     const Stage dependsOn = ce.getDependsOnStage();
     assert(dependsOn == Stage::Instance);
-            
-    // If we're below Instance stage we are hosed.
-    SimTK_ERRCHK2_ALWAYS(current >= dependsOn, 
-    "SimbodyMatterSubsytemRep::getTreeVelocityCache()",
-    "Velocity kinematics can't be obtained until at least Stage::%s "
-    "but state was at Stage::%s.\nEither realize(Stage::Velocity) "
-    "or realize(Stage::Instance), realizePositionKinematics(), and then call "
-    "realizeVelocityKinematics() before asking for velocity "
-    "kinematic information.", 
-        dependsOn.getName().c_str(), current.getName().c_str());
 
-    // Otherwise make sure we agree on the Instance version number.
-    const StageVersion currentVersion = subInfo.getStageVersion(dependsOn);
-    const StageVersion savedVersion = ce.getDependsOnVersionWhenLastComputed();
-
-    SimTK_ERRCHK3_ALWAYS(savedVersion == currentVersion, 
-    "SimbodyMatterSubsytemRep::getTreeVelocityCache()",
-    "Velocity kinematics can't be obtained because it was last "
-    "realized against version %lld of Stage::%s, but that stage "
-    "is currently at version %lld.\nEither realize(Stage::Velocity) "
-    "or call realizeVelocityKinematics() before asking for velocity "
-    "kinematic information.",
-        savedVersion, dependsOn.getName().c_str(), currentVersion);
+    // We don't need to check explicitly whether Instance stage has been
+    // realized because we're going to check that position kinematics has been
+    // realized and that can't happen unless Instance stages was realized first.
 
     StageVersion posKinVersion;
     const bool positionKinematicsRealized =
@@ -1460,8 +1441,8 @@ checkValidityOfTreeVelocityCache(const State& state,
     "call realizeVelocityKinematics() before asking for velocity "
     "kinematic information.");
 
-    // We are happy with the depends-on stage. 
-    // Now check the position kinematics version.
+    // We have determined that position kinematics has been realized. But was
+    // it changed since we last used it? Check the position kinematics version.
     const StageVersion savedPosKinVersion = 
         ce.getExtraDependencyVersionWhenLastComputed(0); // first extra
 

--- a/Simbody/src/SimbodyMatterSubsystemRep.cpp
+++ b/Simbody/src/SimbodyMatterSubsystemRep.cpp
@@ -1378,7 +1378,7 @@ realizeVelocityKinematics(const State& state) const {
             rbNodeLevels[i][j]->realizeVelocity(stateDigest); 
 
     // Ask the constraints to calculate ancestor-relative velocity kinematics 
-    // (still goes in TreePositionCache).
+    // (still goes in TreeVelocityCache).
     for (ConstraintIndex cx(0); cx < constraints.size(); ++cx)
         getConstraint(cx).getImpl()
             .calcConstrainedBodyVelocityInAncestor(iv, tpc, tvc);

--- a/Simbody/src/SimbodyMatterSubsystemRep.cpp
+++ b/Simbody/src/SimbodyMatterSubsystemRep.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors: Derived from IVM code written by Charles Schwieters          *
  *                                                                            *
@@ -381,13 +381,17 @@ int SimbodyMatterSubsystemRep::realizeSubsystemTopologyImpl(State& s) const {
     tc.timeCacheIndex = 
         allocateCacheEntry(s, Stage::Time, new Value<SBTimeCache>());
 
-    // Basic tree position kinematics can be calculated any time after Time
+    // Basic tree position kinematics can be calculated any time after Instance
     // stage and should be filled in first during realizePosition() and then
     // marked valid so later computations during the same realization can
-    // access these quantities.
+    // access these quantities. This has an extra dependency on the q-version
+    // so that it is invalidated whenever a q changes. This can be evaluated
+    // earlier using realizePositionKinematics(). We guarantee this has been
+    // realized by Stage::Position.
     tc.treePositionCacheIndex = 
-        allocateLazyCacheEntry(s, Stage::Time,
-                               new Value<SBTreePositionCache>());
+        allocateCacheEntry(s, Stage::Instance, Stage::Position,
+                           new Value<SBTreePositionCache>(), 
+                           1 /* depends on qVersion */);
 
 
     // Here is where later computations during realizePosition() go; these
@@ -412,14 +416,20 @@ int SimbodyMatterSubsystemRep::realizeSubsystemTopologyImpl(State& s) const {
         allocateCacheEntry(s, Stage::Position, Stage::Dynamics, 
                            new Value<SBArticulatedBodyInertiaCache>());
 
-    // Basic tree velocity kinematics can be calculated any time after Position
-    // stage and should be filled in first during realizeVelocity() and then
-    // marked valid so later computations during the same realization can
-    // access these quantities. Note that qdots are automatically allocated in 
-    // the State's Velocity-stage cache.
+    // Basic tree velocity kinematics can be calculated any time after Instance
+    // stage, provided PositionKinematics have been realized, or unconditionally
+    // after stage Position. These should be filled in first during 
+    // realizeVelocity() and then marked valid so later computations during the 
+    // same realization can access these quantities. Note that qdots are 
+    // automatically allocated in the State's Velocity-stage cache. This has 
+    // extra dependencies on the position kinematics version and u-version so 
+    // that it is invalidated whenever a q or u changes. This can be evaluated
+    // earlier using realizeVelocityKinematics(). We guarantee this has been
+    // realized by Stage::Velociy.
     tc.treeVelocityCacheIndex = 
-        allocateLazyCacheEntry(s, Stage::Position,
-                               new Value<SBTreeVelocityCache>());
+        allocateCacheEntry(s, Stage::Instance, Stage::Velocity,
+                           new Value<SBTreeVelocityCache>(), 
+                           2 /* posKinematicsVersion, uVersion */);
 
     // Here is where later computations during realizeVelocity() go; these
     // will assume that the TreeVelocityCache is available. So you can 
@@ -1038,30 +1048,13 @@ int SimbodyMatterSubsystemRep::realizeSubsystemPositionImpl(const State& s) cons
     SimTK_STAGECHECK_GE_ALWAYS(getStage(s), Stage(Stage::Position).prev(), 
         "SimbodyMatterSubsystem::realizePosition()");
 
-    // Set up StateDigest for calculating position information.
-    const SBStateDigest stateDigest(s, *this, Stage::Position);
-    const SBInstanceCache&      ic   = stateDigest.getInstanceCache();
-    SBTreePositionCache&        tpc  = stateDigest.updTreePositionCache();
+    // We promise that position kinematics is available after Stage::Position,
+    // so force that calculation now if it hasn't already been done.
+    realizePositionKinematics(s);
 
-    // realize tree positions (kinematics)
-    // This includes all local cross-mobilizer kinematics (M in F, B in P)
-    // and all global kinematics relative to Ground (G).
-
-    // Any body which is using quaternions should calculate the quaternion
-    // constraint here and put it in the appropriate slot of qErr.
-    // Set generalized coordinates: sweep from base to tips.
-    for (int i=0 ; i<(int)rbNodeLevels.size() ; i++) 
-        for (int j=0 ; j<(int)rbNodeLevels[i].size() ; j++)
-            rbNodeLevels[i][j]->realizePosition(stateDigest); 
-
-    // Ask the constraints to calculate ancestor-relative kinematics (still 
-    // goes in TreePositionCache).
-    for (ConstraintIndex cx(0); cx < constraints.size(); ++cx)
-        getConstraint(cx).getImpl()
-            .calcConstrainedBodyTransformInAncestor(stateDigest, tpc);
-
-    // Now we're done with the TreePositionCache.
-    markCacheValueRealized(s, topologyCache.treePositionCacheIndex);
+    // Set up StateDigest for calculating remaining position information.
+    const SBStateDigest     stateDigest(s, *this, Stage::Position);
+    const SBInstanceCache&  ic = stateDigest.getInstanceCache();
 
     // MobilizedBodies
     // This will include writing the prescribed velocities (u's) into
@@ -1092,6 +1085,65 @@ int SimbodyMatterSubsystemRep::realizeSubsystemPositionImpl(const State& s) cons
     for (ConstraintIndex cx(0); cx < constraints.size(); ++cx)
         getConstraint(cx).getImpl().realizePosition(stateDigest);
     return 0;
+}
+
+
+//==============================================================================
+//                       REALIZE POSITION KINEMATICS
+//==============================================================================
+void SimbodyMatterSubsystemRep::
+realizePositionKinematics(const State& state) const {
+    const CacheEntryIndex tpcx = topologyCache.treePositionCacheIndex;
+
+    StageVersion posKinVersion;
+    const StageVersion qVersion = state.getQStageVersion();
+    if (isCacheValueRealizedWithExtras(state, tpcx, 1, &qVersion, 
+                                       posKinVersion))
+        return; // already realized
+
+    SimTK_STAGECHECK_GE_ALWAYS(getStage(state), Stage::Instance, 
+        "SimbodyMatterSubsystem::realizePositionKinematics()");
+
+    const SBStateDigest     stateDigest(state, *this, Stage::Position);
+    SBTreePositionCache&    tpc = stateDigest.updTreePositionCache();
+
+    // realize tree positions (kinematics)
+    // This includes all local cross-mobilizer kinematics (M in F, B in P)
+    // and all global kinematics relative to Ground (G).
+
+    // Any body which is using quaternions should calculate the quaternion
+    // constraint here and put it in the appropriate slot of qErr.
+    // Set generalized coordinates: sweep from base to tips.
+    for (int i=0 ; i<(int)rbNodeLevels.size() ; i++) 
+        for (int j=0 ; j<(int)rbNodeLevels[i].size() ; j++)
+            rbNodeLevels[i][j]->realizePosition(stateDigest); 
+
+    // Ask the constraints to calculate ancestor-relative kinematics (still 
+    // goes in TreePositionCache).
+    for (ConstraintIndex cx(0); cx < constraints.size(); ++cx)
+        getConstraint(cx).getImpl()
+            .calcConstrainedBodyTransformInAncestor(stateDigest, tpc);
+
+    markCacheValueRealizedWithExtras(state, tpcx, 1, &qVersion);
+}
+
+bool SimbodyMatterSubsystemRep::
+isPositionKinematicsRealized(const State&  state,
+                             StageVersion& posKinVersion) const {
+    const CacheEntryIndex tpcx = topologyCache.treePositionCacheIndex;
+    const StageVersion qVersion = state.getQStageVersion();
+    return isCacheValueRealizedWithExtras(state, tpcx, 1, &qVersion,
+                                          posKinVersion);
+}
+
+
+void SimbodyMatterSubsystemRep::
+invalidatePositionKinematics(const State& state) const {
+    // Position kinematics is assumed calculated at Position stage, regardless 
+    // of stage versions in the cache entry.
+    state.invalidateAllCacheAtOrAbove(Stage::Position);
+    const CacheEntryIndex tpcx = topologyCache.treePositionCacheIndex;
+    markCacheValueNotRealized(state, tpcx);
 }
 
 
@@ -1188,33 +1240,17 @@ int SimbodyMatterSubsystemRep::realizeSubsystemVelocityImpl(const State& s) cons
     SimTK_STAGECHECK_GE_ALWAYS(getStage(s), Stage(Stage::Velocity).prev(), 
         "SimbodyMatterSubsystem::realizeVelocity()");
 
+    // We promise that velocity kinematics is available after Stage::Velocity,
+    // so force that calculation now if it hasn't already been done.
+    realizeVelocityKinematics(s);
+
     const SBStateDigest stateDigest(s, *this, Stage::Velocity);
-    const SBInstanceCache& ic   = stateDigest.getInstanceCache();
-    SBTreeVelocityCache&   tvc  = stateDigest.updTreeVelocityCache();
-
-    // realize tree velocity kinematics
-    // This includes all local cross-mobilizer velocities (M in F, B in P)
-    // and all global velocities relative to Ground (G).
-
-    // Set generalized speeds: sweep from base to tips.
-    for (int i=0 ; i<(int)rbNodeLevels.size() ; ++i) 
-        for (int j=0 ; j<(int)rbNodeLevels[i].size() ; ++j)
-            rbNodeLevels[i][j]->realizeVelocity(stateDigest); 
-
-    // Ask the constraints to calculate ancestor-relative velocity kinematics 
-    // (still goes in TreePositionCache).
-    for (ConstraintIndex cx(0); cx < constraints.size(); ++cx)
-        getConstraint(cx).getImpl()
-            .calcConstrainedBodyVelocityInAncestor(stateDigest, tvc);
-
-    // Now we're done with the TreeVelocityCache.
-    markCacheValueRealized(s, topologyCache.treeVelocityCacheIndex);
+    const SBInstanceCache& ic = stateDigest.getInstanceCache();
 
     // MobilizedBodies
     // probably not much to do here
     for (MobilizedBodyIndex mbx(0); mbx < mobilizedBodies.size(); ++mbx)
         getMobilizedBody(mbx).getImpl().realizeVelocity(stateDigest);
-
 
     // Put velocity constraint equation errors in uErr
     Vector& uErr = stateDigest.updUErr();
@@ -1248,6 +1284,86 @@ int SimbodyMatterSubsystemRep::realizeSubsystemVelocityImpl(const State& s) cons
         getConstraint(cx).getImpl().realizeVelocity(stateDigest);
     return 0;
 }
+
+
+//==============================================================================
+//                       REALIZE VELOCITY KINEMATICS
+//==============================================================================
+void SimbodyMatterSubsystemRep::
+realizeVelocityKinematics(const State& state) const {
+    StageVersion posKinVersion;
+    const bool positionKinematicsRealized =
+                        isPositionKinematicsRealized(state, posKinVersion);
+    SimTK_ERRCHK_ALWAYS(positionKinematicsRealized, 
+        "SimbodyMatterSubsystem::realizeVelocityKinematics()",
+        "Velocity kinematics cannot be realized unless the state has been "
+        "realized to Stage::Position or realizePositionKinematics() has been "
+        "called explicitly.");
+
+    const CacheEntryIndex velx = topologyCache.treeVelocityCacheIndex;
+    const StageVersion puVersions[2] = {posKinVersion,
+                                        state.getUStageVersion()};
+    StageVersion velKinVersion; // not used
+    if (isCacheValueRealizedWithExtras(state, velx, 2, puVersions, 
+                                       velKinVersion))
+        return; // already realized
+
+    // Here we know that position kinematics has already been realized but
+    // velocity kinematics is out of date with respect to the position
+    // kinematics version number, or because a u changed since last computed.
+    // We know this subsystem's stage is at least Instance since otherwise
+    // position kinematics couldn't have been valid.
+
+    const SBStateDigest stateDigest(state, *this, Stage::Velocity);
+    const SBInstanceCache& ic   = stateDigest.getInstanceCache();
+    SBTreeVelocityCache&   tvc  = stateDigest.updTreeVelocityCache();
+
+    // realize tree velocity kinematics
+    // This includes all local cross-mobilizer velocities (M in F, B in P)
+    // and all global velocities relative to Ground (G).
+
+    // Set generalized speeds: sweep from base to tips.
+    for (int i=0 ; i<(int)rbNodeLevels.size() ; ++i) 
+        for (int j=0 ; j<(int)rbNodeLevels[i].size() ; ++j)
+            rbNodeLevels[i][j]->realizeVelocity(stateDigest); 
+
+    // Ask the constraints to calculate ancestor-relative velocity kinematics 
+    // (still goes in TreePositionCache).
+    for (ConstraintIndex cx(0); cx < constraints.size(); ++cx)
+        getConstraint(cx).getImpl()
+            .calcConstrainedBodyVelocityInAncestor(stateDigest, tvc);
+
+    // Record the version numbers we used for position kinematics and u.
+    markCacheValueRealizedWithExtras(state, velx, 2, puVersions);
+}
+
+
+// Velocity kinematics is realized only if position kinematics is realized,
+// AND the stage version of the position kinematics cache entry is unchanged
+// since we last computed velocity kinematics, AND the u's are also unchanged.
+bool SimbodyMatterSubsystemRep::
+isVelocityKinematicsRealized(const State& state, 
+                             StageVersion& velKinVersion) const {
+    StageVersion posKinVersion;
+    if (!isPositionKinematicsRealized(state, posKinVersion))
+        return false;
+
+    const CacheEntryIndex velx = topologyCache.treeVelocityCacheIndex;
+    const StageVersion puVersions[2] = 
+                                    {posKinVersion, state.getUStageVersion()};
+    return isCacheValueRealizedWithExtras(state, velx, 1, puVersions,
+                                          velKinVersion);
+}
+
+void SimbodyMatterSubsystemRep::
+invalidateVelocityKinematics(const State& state) const {
+    // Velocity kinematics is assumed calculated at Velocity stage, regardless 
+    // of the flag in the cache entry.
+    state.invalidateAllCacheAtOrAbove(Stage::Velocity);
+    const CacheEntryIndex tvcx = topologyCache.treeVelocityCacheIndex;
+    markCacheValueNotRealized(state, tvcx);
+}
+
 
 
 

--- a/Simbody/src/SimbodyMatterSubsystemRep.cpp
+++ b/Simbody/src/SimbodyMatterSubsystemRep.cpp
@@ -1428,7 +1428,7 @@ checkValidityOfTreeVelocityCache(const State& state,
 
     // We don't need to check explicitly whether Instance stage has been
     // realized because we're going to check that position kinematics has been
-    // realized and that can't happen unless Instance stages was realized first.
+    // realized and that can't happen unless Instance stage was realized first.
 
     StageVersion posKinVersion;
     const bool positionKinematicsRealized =

--- a/Simbody/src/SimbodyMatterSubsystemRep.h
+++ b/Simbody/src/SimbodyMatterSubsystemRep.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors: Derived from IVM code written by Charles Schwieters          *
  *                                                                            *
@@ -464,13 +464,27 @@ public:
 
         // REALIZATIONS //
 
+
+    // Call at Instance Stage or later.
+    void realizePositionKinematics(const State&) const;
+
+    // Call at Instance + PositionKinematics Stage or later.
+    void realizeVelocityKinematics(const State&) const;
+
     // Call at Position Stage or later.
     void realizeCompositeBodyInertias(const State&) const;
 
     // Call at Position Stage or later.
     void realizeArticulatedBodyInertias(const State&) const;
 
+    bool isPositionKinematicsRealized(const State&, 
+                                      StageVersion&) const;
+    bool isVelocityKinematicsRealized(const State&, 
+                                      StageVersion&) const;
+
     // These are just used in timing tests.
+    void invalidatePositionKinematics(const State&) const;
+    void invalidateVelocityKinematics(const State&) const;
     void invalidateCompositeBodyInertias(const State&) const;
     void invalidateArticulatedBodyInertias(const State&) const;
 

--- a/Simbody/src/SimbodyMatterSubsystemRep.h
+++ b/Simbody/src/SimbodyMatterSubsystemRep.h
@@ -1062,7 +1062,7 @@ public:
     }
 
 
-    // Must do this very carefully because the position kinematics cache entry
+    // Must do this very carefully because the velocity kinematics cache entry
     // has extra dependencies on the treePositionCache version and u-version.
     // This needs to be very fast because it gets called a lot. Keep it small
     // so it will be inlined.
@@ -1076,7 +1076,7 @@ public:
         const Stage computedBy = ce.getComputedByStage();
         assert(computedBy == Stage::Velocity); // or else we're confused
 
-        // Fast exit if we've reached Stage::Velocity since position kinematics
+        // Fast exit if we've reached Stage::Velocity since velocity kinematics
         // is guaranteed to be available there.
         if (current < computedBy) {
             // This will throw an exception if the cache enty isn't valid.

--- a/Simbody/src/SimbodyTreeState.h
+++ b/Simbody/src/SimbodyTreeState.h
@@ -658,8 +658,6 @@ public:
     Transform&       updX_AB(AncestorConstrainedBodyPoolIndex cbpx)
     {   return constrainedBodyConfigInAncestor[cbpx]; }
 public:
-    // qerr cache space is provided directly by the State
-
     // At model stage, each mobilizer (RBNode) is given a chance to grab
     // a segment of this cache entry for its own private use. This includes
     // pre-calculated sincos(q) for mobilizers with angular coordinates,

--- a/Simbody/src/SimbodyTreeState.h
+++ b/Simbody/src/SimbodyTreeState.h
@@ -1426,7 +1426,7 @@ public:
     }
 
     const Vector& getQ() const {
-        assert(stage >= Stage::Position);
+        assert(stage >= Stage::Model);
         assert(q);
         return *q;
     }
@@ -1438,7 +1438,7 @@ public:
     }
 
     const Vector& getU() const {
-        assert(stage >= Stage::Velocity);
+        assert(stage >= Stage::Model);
         assert(u);
         return *u;
     }
@@ -1501,7 +1501,7 @@ public:
 
     // Position
     Vector& updQErr() const {
-        assert(stage == Stage::Position);
+        assert(stage > Stage::Instance);
         assert(qErr);
         return *qErr;
     }
@@ -1516,7 +1516,7 @@ public:
         return *tpc;
     }
     const SBTreePositionCache& getTreePositionCache() const {
-        assert(stage > Stage::Position);
+        assert(stage > Stage::Instance);
         assert(tpc);
         return *tpc;
     }
@@ -1533,7 +1533,7 @@ public:
 
     // Velocity
     Vector& updQDot() const {
-        assert(stage == Stage::Velocity);
+        assert(stage > Stage::Instance);
         assert(qdot);
         return *qdot;
     }
@@ -1543,7 +1543,7 @@ public:
         return *qdot;
     }
     Vector& updUErr() const {
-        assert(stage == Stage::Velocity);
+        assert(stage > Stage::Instance);
         assert(uErr);
         return *uErr;
     }
@@ -1558,7 +1558,7 @@ public:
         return *tvc;
     }
     const SBTreeVelocityCache& getTreeVelocityCache() const {
-        assert(stage > Stage::Velocity);
+        assert(stage > Stage::Instance);
         assert(tvc);
         return *tvc;
     }

--- a/Simbody/tests/TestMassMatrix.cpp
+++ b/Simbody/tests/TestMassMatrix.cpp
@@ -1238,8 +1238,150 @@ void testTaskJacobians() {
     SimTK_TEST_EQ_TOL(JFmat2, JFmat, SignificantReal);
 }
 
+// Position kinematics should be valid if:
+// - realize(Position) has been done
+// - or, realize(Instance) + realizePositionKinematics()
+// It should be invalidated when:
+// - any q changes
+// - Instance stage changes
+// It should *not* be invalidated when:
+// - time changes
+void testPositionKinematics() {
+    MultibodySystem system;
+    MyForceImpl* frcp;
+    makeSystem(true, system, frcp);
+    const SimbodyMatterSubsystem& matter = system.getMatterSubsystem();
+
+    State state = system.realizeTopology();
+    const int nq = state.getNQ();
+    const int nu = state.getNU();
+    const int nb = matter.getNumBodies();
+
+    system.realizeModel(state);
+    // Randomize state.
+    state.updQ() = Test::randVector(nq);
+
+    SimTK_TEST(state.getSystemStage() == Stage::Model);
+    Vec3 syscom;
+    SimTK_TEST_MUST_THROW // stage is too low
+       (syscom = matter.calcSystemMassCenterLocationInGround(state));
+    system.realize(state, Stage::Instance);
+    SimTK_TEST_MUST_THROW // Instance alone is not enough
+       (syscom = matter.calcSystemMassCenterLocationInGround(state));
+    matter.realizePositionKinematics(state);
+    syscom = matter.calcSystemMassCenterLocationInGround(state); // OK
+    matter.invalidatePositionKinematics(state);
+    SimTK_TEST_MUST_THROW // No good again
+       (syscom = matter.calcSystemMassCenterLocationInGround(state));
+    system.realize(state, Stage::Position);
+    syscom = matter.calcSystemMassCenterLocationInGround(state); // OK
+
+    state.setTime(1.); // should not invalidate position kinematics
+    SimTK_TEST(state.getSystemStage() == Stage::Instance);
+    syscom = matter.calcSystemMassCenterLocationInGround(state); // OK
+    cout << "System COM=" << syscom << endl;
+
+    state.updQ() = Test::randVector(nq); // should invalide position kinematics
+    SimTK_TEST(state.getSystemStage() == Stage::Instance);
+    SimTK_TEST_MUST_THROW // Not up to date with q's
+       (syscom = matter.calcSystemMassCenterLocationInGround(state));
+    matter.realizePositionKinematics(state);
+    syscom = matter.calcSystemMassCenterLocationInGround(state); // OK
+
+    state.invalidateAllCacheAtOrAbove(Stage::Instance);
+    SimTK_TEST(state.getSystemStage() == Stage::Model);
+    SimTK_TEST_MUST_THROW // stage too low again
+       (syscom = matter.calcSystemMassCenterLocationInGround(state));
+
+}
+
+// Velocity kinematics should be valid if:
+// - realize(Velocity) has been done
+// - or, position kinematics is valid and realizeVelocityKinematics() has
+//   been called (and that implies that Instance stage has been realized)
+// It should be invalidated when:
+// - any q or u changes
+// - position kinematics changes
+// - Instance stage changes
+// It should *not* be invalidated when:
+// - time changes
+void testVelocityKinematics() {
+    MultibodySystem system;
+    MyForceImpl* frcp;
+    makeSystem(true, system, frcp);
+    const SimbodyMatterSubsystem& matter = system.getMatterSubsystem();
+
+    State state = system.realizeTopology();
+    const int nq = state.getNQ();
+    const int nu = state.getNU();
+    const int nb = matter.getNumBodies();
+
+    system.realizeModel(state);
+    // Randomize state.
+    state.updQ() = Test::randVector(nq);
+    state.updU() = Test::randVector(nu);
+
+    SimTK_TEST(state.getSystemStage() == Stage::Model);
+    Vec3 syscomv;
+    SimTK_TEST_MUST_THROW // stage is too low
+       (syscomv = matter.calcSystemMassCenterVelocityInGround(state));
+    system.realize(state, Stage::Instance);
+    SimTK_TEST_MUST_THROW // Instance alone is not enough
+       (syscomv = matter.calcSystemMassCenterVelocityInGround(state));
+    matter.realizePositionKinematics(state);
+    SimTK_TEST_MUST_THROW // Instance + pos kinematics is not enough
+       (syscomv = matter.calcSystemMassCenterVelocityInGround(state));
+    matter.realizeVelocityKinematics(state);
+    syscomv = matter.calcSystemMassCenterLocationInGround(state); // OK
+
+    matter.invalidateVelocityKinematics(state);
+    SimTK_TEST_MUST_THROW // No good again
+       (syscomv = matter.calcSystemMassCenterVelocityInGround(state));
+    matter.realizeVelocityKinematics(state);
+    syscomv = matter.calcSystemMassCenterLocationInGround(state); // OK
+
+    matter.invalidatePositionKinematics(state);
+    SimTK_TEST_MUST_THROW // No good again
+       (syscomv = matter.calcSystemMassCenterVelocityInGround(state));
+    system.realize(state, Stage::Velocity);
+    syscomv = matter.calcSystemMassCenterVelocityInGround(state); // OK
+
+    state.setTime(1.); // should not invalidate velocity kinematics
+    SimTK_TEST(state.getSystemStage() == Stage::Instance);
+    syscomv = matter.calcSystemMassCenterVelocityInGround(state); // OK
+    cout << "System COM vel=" << syscomv << endl;
+
+    state.updU() = Test::randVector(nu); // should invalide velocity kinematics
+    SimTK_TEST(state.getSystemStage() == Stage::Instance);
+    SimTK_TEST_MUST_THROW // Not up to date with u's
+       (syscomv = matter.calcSystemMassCenterVelocityInGround(state));
+    matter.realizeVelocityKinematics(state);
+    syscomv = matter.calcSystemMassCenterVelocityInGround(state); // OK
+    
+    state.updQ() = Test::randVector(nq); // invalides position kinematics
+    SimTK_TEST_MUST_THROW // Pos kinematics no good
+       (syscomv = matter.calcSystemMassCenterVelocityInGround(state));
+    matter.realizePositionKinematics(state);
+    SimTK_TEST_MUST_THROW // Still not enough; need to recalc vel kinematics
+       (syscomv = matter.calcSystemMassCenterVelocityInGround(state));
+    matter.realizeVelocityKinematics(state);
+    syscomv = matter.calcSystemMassCenterVelocityInGround(state); // OK
+
+    state.invalidateAllCacheAtOrAbove(Stage::Instance);
+    SimTK_TEST(state.getSystemStage() == Stage::Model);
+    SimTK_TEST_MUST_THROW // stage too low again
+       (syscomv = matter.calcSystemMassCenterVelocityInGround(state));
+    // Fails because realizePositionKinematics() or realize(Position) needed.
+    SimTK_TEST_MUST_THROW(matter.realizeVelocityKinematics(state));
+    system.realize(state, Stage::Position);
+    matter.realizeVelocityKinematics(state);
+    syscomv = matter.calcSystemMassCenterVelocityInGround(state); // OK
+}
+
 int main() {
     SimTK_START_TEST("TestMassMatrix");
+        SimTK_SUBTEST(testPositionKinematics);
+        SimTK_SUBTEST(testVelocityKinematics);
         SimTK_SUBTEST(testRel2Cart);
         SimTK_SUBTEST(testJacobianBiasTerms);
         SimTK_SUBTEST(testCompositeInertia);

--- a/Simbody/tests/adhoc/TestMultibodyPerformance.cpp
+++ b/Simbody/tests/adhoc/TestMultibodyPerformance.cpp
@@ -101,6 +101,7 @@ void doRealizeDynamics2Acceleration(MultibodySystem& system, State& state) {
 // Cost to re-evaluate accelerations after updating velocities, but leaving
 // the positions unchanged (e.g. semi-implicit Euler iterating velocities).
 void doRealizeVelocity2Acceleration(MultibodySystem& system, State& state) {
+    state.updU(); // should invalidate velocity kinematics
     state.invalidateAllCacheAtOrAbove(Stage::Velocity);
     system.realize(state, Stage::Acceleration);
 }
@@ -108,6 +109,7 @@ void doRealizeVelocity2Acceleration(MultibodySystem& system, State& state) {
 // Cost for a complete acceleration calculation at a new time and state.
 // This includes the cost of articulated body inertias.
 void doRealizeTime2Acceleration(MultibodySystem& system, State& state) {
+    state.updQ(); // should invalidate position & velocity kinematics
     state.invalidateAllCacheAtOrAbove(Stage::Time);
     system.realize(state, Stage::Acceleration);
 }

--- a/Simbody/tests/adhoc/TestMultibodyPerformance.cpp
+++ b/Simbody/tests/adhoc/TestMultibodyPerformance.cpp
@@ -63,6 +63,18 @@ void doRealizeVelocity(MultibodySystem& system, State& state) {
     system.realize(state, Stage::Velocity);
 }
 
+void doRealizePositionKinematics(MultibodySystem& system, State& state) {
+    const SimbodyMatterSubsystem& matter = system.getMatterSubsystem();
+    matter.invalidatePositionKinematics(state);
+    matter.realizePositionKinematics(state);
+}
+
+void doRealizeVelocityKinematics(MultibodySystem& system, State& state) {
+    const SimbodyMatterSubsystem& matter = system.getMatterSubsystem();
+    matter.invalidateVelocityKinematics(state);
+    matter.realizeVelocityKinematics(state);
+}
+
 void doRealizeArticulatedBodyInertias(MultibodySystem& system, State& state) {
     const SimbodyMatterSubsystem& matter = system.getMatterSubsystem();
     matter.invalidateArticulatedBodyInertias(state);
@@ -183,7 +195,9 @@ void timeComputation(MultibodySystem& system, void function(MultibodySystem& sys
 void runAllTests(MultibodySystem& system, bool useEulerAngles=false) {
     std::cout << "# dofs=" << system.getMatterSubsystem().getNumMobilities() << "\n";
     timeComputation(system, doRealizeTime, "realizeTime", 5000, useEulerAngles);
+    timeComputation(system, doRealizePositionKinematics, "realizePositionKinematics", 5000, useEulerAngles);
     timeComputation(system, doRealizePosition, "realizePosition", 5000, useEulerAngles);
+    timeComputation(system, doRealizeVelocityKinematics, "realizeVelocityKinematics", 5000, useEulerAngles);
     timeComputation(system, doRealizeVelocity, "realizeVelocity", 5000, useEulerAngles);
     timeComputation(system, doRealizeArticulatedBodyInertias, "doRealizeArticulatedBodyInertias", 3000, useEulerAngles);
     timeComputation(system, doRealizeDynamics, "realizeDynamics", 5000, useEulerAngles);


### PR DESCRIPTION
This PR adds some flexibility to make state cache entries have more subtle dependencies than just realization stages, then uses that new capability to allow early evaluation and time independence of position and velocity kinematics (that is, mapping generalized coordinates to spatial pose and generalized speeds to spatial velocities).

Now changing time does not invalidate kinematics, and only `Stage::Instance` is required for position kinematics. Velocity kinematics requires `Stage::Instance` plus already-realized position kinematics. New (optional) methods `realizePositionKinematics()` and `realizeVelocityKinematics()` can be used to get these quantities without having to wait until `Stage::Position` or `Stage::Velocity` are done. 

Also added move construction and move assignment for State objects.

Fixes #185. Fixes #188. Will address related #370 (articulated body inertias) in a separate PR.