### PR TITLE
Changes to allow swig 3.0.5 to process certain Simbody headers.

### DIFF
--- a/SimTKcommon/Mechanics/include/SimTKcommon/internal/MassProperties.h
+++ b/SimTKcommon/Mechanics/include/SimTKcommon/internal/MassProperties.h
@@ -191,12 +191,12 @@ Typedefs exist for the most common invocations of Inertia_\<P\>:
 **/
 template <class P>
 class SimTK_SimTKCOMMON_EXPORT Inertia_ {
+public:
     typedef P               RealP;
     typedef Vec<3,P>        Vec3P;
     typedef SymMat<3,P>     SymMat33P;
     typedef Mat<3,3,P>      Mat33P;
     typedef Rotation_<P>    RotationP;
-public:
 /// Default is a NaN-ed out mess to avoid accidents, even in Release mode.
 /// Other than this value, an Inertia matrix should always be valid.
 Inertia_() : I_OF_F(NTraits<P>::getNaN()) {}
@@ -1357,6 +1357,7 @@ Typedefs exist for the most common invocations of MassProperties_\<P\>:
  - \ref SimTK::dMassProperties "dMassProperties" for double precision **/
 template <class P>
 class SimTK_SimTKCOMMON_EXPORT MassProperties_ {
+public:
     typedef P               RealP;
     typedef Vec<3,P>        Vec3P;
     typedef UnitInertia_<P> UnitInertiaP;
@@ -1367,7 +1368,6 @@ class SimTK_SimTKCOMMON_EXPORT MassProperties_ {
     typedef Rotation_<P>    RotationP;
     typedef Transform_<P>   TransformP;
     typedef Inertia_<P>     InertiaP;
-public:
 /** Create a mass properties object in which the mass, mass center, and 
 inertia are meaningless; you must assign values before using this. **/
 MassProperties_() { setMassProperties(0,Vec3P(0),UnitInertiaP()); }

--- a/SimTKcommon/Mechanics/include/SimTKcommon/internal/MassProperties.h
+++ b/SimTKcommon/Mechanics/include/SimTKcommon/internal/MassProperties.h
@@ -191,12 +191,8 @@ Typedefs exist for the most common invocations of Inertia_\<P\>:
 **/
 template <class P>
 class SimTK_SimTKCOMMON_EXPORT Inertia_ {
-public:
-    typedef P               RealP;
-    typedef Vec<3,P>        Vec3P;
-    typedef SymMat<3,P>     SymMat33P;
-    typedef Mat<3,3,P>      Mat33P;
     typedef Rotation_<P>    RotationP;
+public:
 /// Default is a NaN-ed out mess to avoid accidents, even in Release mode.
 /// Other than this value, an Inertia matrix should always be valid.
 Inertia_() : I_OF_F(NTraits<P>::getNaN()) {}
@@ -209,65 +205,65 @@ Inertia_() : I_OF_F(NTraits<P>::getNaN()) {}
 /// and s the length of a side of the cube. Note that many rigid
 /// bodies of different shapes and masses can have the same inertia
 /// matrix.
-explicit Inertia_(const RealP& moment) : I_OF_F(moment) 
+explicit Inertia_(const P& moment) : I_OF_F(moment) 
 {   errChk("Inertia::Inertia(moment)"); }
 
 /// Create an Inertia matrix for a point mass at a given location,
 /// measured from the origin OF of the implicit frame F, and expressed
 /// in F. Cost is 14 flops.
-Inertia_(const Vec3P& p, const RealP& mass) : I_OF_F(pointMassAt(p,mass)) {}
+Inertia_(const Vec<3,P>& p, const P& mass) : I_OF_F(pointMassAt(p,mass)) {}
 
 /// Create an inertia matrix from a vector of the \e moments of
 /// inertia (the inertia matrix diagonal) and optionally a vector of
 /// the \e products of inertia (the off-diagonals). Moments are
 /// in the order xx,yy,zz; products are xy,xz,yz.
-explicit Inertia_(const Vec3P& moments, const Vec3P& products=Vec3P(0)) 
+explicit Inertia_(const Vec<3,P>& moments, const Vec<3,P>& products=Vec<3,P>(0)) 
 {   I_OF_F.updDiag()  = moments;
     I_OF_F.updLower() = products;
     errChk("Inertia::Inertia(moments,products)"); }
 
 /// Create a principal inertia matrix (only non-zero on diagonal).
-Inertia_(const RealP& xx, const RealP& yy, const RealP& zz) 
-{   I_OF_F = SymMat33P(xx,
+Inertia_(const P& xx, const P& yy, const P& zz) 
+{   I_OF_F = SymMat<3,P>(xx,
                         0, yy,
                         0,  0, zz);
     errChk("Inertia::setInertia(xx,yy,zz)"); }
 
 /// This is a general inertia matrix. Note the order of these
 /// arguments: moments of inertia first, then products of inertia.
-Inertia_(const RealP& xx, const RealP& yy, const RealP& zz,
-            const RealP& xy, const RealP& xz, const RealP& yz) 
-{   I_OF_F = SymMat33P(xx,
+Inertia_(const P& xx, const P& yy, const P& zz,
+            const P& xy, const P& xz, const P& yz) 
+{   I_OF_F = SymMat<3,P>(xx,
                         xy, yy,
                         xz, yz, zz);
     errChk("Inertia::setInertia(xx,yy,zz,xy,xz,yz)"); }
 
 /// Construct an Inertia from a symmetric 3x3 matrix. The diagonals must
 /// be nonnegative and satisfy the triangle inequality.
-explicit Inertia_(const SymMat33P& inertia) : I_OF_F(inertia)
+explicit Inertia_(const SymMat<3,P>& inertia) : I_OF_F(inertia)
 {   errChk("Inertia::Inertia(SymMat33)"); }
 
 /// Construct an Inertia matrix from a 3x3 symmetric matrix. In Debug mode
 /// we'll test that the supplied matrix is numerically close to symmetric, and
 /// that it satisfies other requirements of an Inertia matrix.
-explicit Inertia_(const Mat33P& m)
+explicit Inertia_(const Mat<3,3,P>& m)
 {   SimTK_ERRCHK(m.isNumericallySymmetric(), 
                     "Inertia(Mat33)", "The supplied matrix was not symmetric.");
-    I_OF_F = SymMat33P(m);
+    I_OF_F = SymMat<3,P>(m);
     errChk("Inertia(Mat33)"); }
 
 
 /// Set an inertia matrix to have only principal moments (that is, it
 /// will be diagonal). Returns a reference to "this" like an assignment operator.
-Inertia_& setInertia(const RealP& xx, const RealP& yy, const RealP& zz) {
-    I_OF_F = RealP(0); I_OF_F(0,0) = xx; I_OF_F(1,1) = yy;  I_OF_F(2,2) = zz;
+Inertia_& setInertia(const P& xx, const P& yy, const P& zz) {
+    I_OF_F = P(0); I_OF_F(0,0) = xx; I_OF_F(1,1) = yy;  I_OF_F(2,2) = zz;
     errChk("Inertia::setInertia(xx,yy,zz)");
     return *this;
 }
 
 /// Set principal moments and optionally off-diagonal terms.
 /// Returns a reference to "this" like an assignment operator.
-Inertia_& setInertia(const Vec3P& moments, const Vec3P& products=Vec3P(0)) {
+Inertia_& setInertia(const Vec<3,P>& moments, const Vec<3,P>& products=Vec<3,P>(0)) {
     I_OF_F.updDiag()  = moments;
     I_OF_F.updLower() = products;
     errChk("Inertia::setInertia(moments,products)");
@@ -279,9 +275,9 @@ Inertia_& setInertia(const Vec3P& moments, const Vec3P& products=Vec3P(0)) {
 /// Behaves like an assignment statement. Will throw an error message
 /// in Debug mode if the supplied elements do not constitute a valid
 /// Inertia matrix.
-Inertia_& setInertia(const RealP& xx, const RealP& yy, const RealP& zz,
-                        const RealP& xy, const RealP& xz, const RealP& yz) {
-    setInertia(Vec3P(xx,yy,zz), Vec3P(xy,xz,yz));
+Inertia_& setInertia(const P& xx, const P& yy, const P& zz,
+                        const P& xy, const P& xz, const P& yz) {
+    setInertia(Vec<3,P>(xx,yy,zz), Vec<3,P>(xy,xz,yz));
     errChk("Inertia::setInertia(xx,yy,zz,xy,xz,yz)");
     return *this;
 }
@@ -317,7 +313,7 @@ Inertia_& operator/=(const P& s) {I_OF_F /= s; return *this;}
 /// point mass of mass m (that is, the same as the body mass) located at CF 
 /// (measured in F) about OF. Cost is 20 flops.
 /// @see shiftToMassCenterInPlace(), shiftFromMassCenter()
-Inertia_ shiftToMassCenter(const Vec3P& CF, const RealP& mass) const 
+Inertia_ shiftToMassCenter(const Vec<3,P>& CF, const P& mass) const 
 {   Inertia_ I(*this); I -= pointMassAt(CF, mass);
     I.errChk("Inertia::shiftToMassCenter()");
     return I; }
@@ -332,7 +328,7 @@ Inertia_ shiftToMassCenter(const Vec3P& CF, const RealP& mass) const
 /// (measured in F) about OF. Cost is 20 flops.
 /// @see shiftToMassCenter() if you want to leave this object unmolested.
 /// @see shiftFromMassCenterInPlace()
-Inertia_& shiftToMassCenterInPlace(const Vec3P& CF, const RealP& mass) 
+Inertia_& shiftToMassCenterInPlace(const Vec<3,P>& CF, const P& mass) 
 {   (*this) -= pointMassAt(CF, mass);
     errChk("Inertia::shiftToMassCenterInPlace()");
     return *this; }
@@ -344,7 +340,7 @@ Inertia_& shiftToMassCenterInPlace(const Vec3P& CF, const RealP& mass)
 /// point mass of mass mtot (the total body mass) located at p, about CF.
 /// Cost is 20 flops.
 /// @see shiftFromMassCenterInPlace(), shiftToMassCenter()
-Inertia_ shiftFromMassCenter(const Vec3P& p, const RealP& mass) const
+Inertia_ shiftFromMassCenter(const Vec<3,P>& p, const P& mass) const
 {   Inertia_ I(*this); I += pointMassAt(p, mass);
     I.errChk("Inertia::shiftFromMassCenter()");
     return I; }
@@ -357,7 +353,7 @@ Inertia_ shiftFromMassCenter(const Vec3P& p, const RealP& mass) const
 /// Cost is 20 flops.
 /// @see shiftFromMassCenter() if you want to leave this object unmolested.
 /// @see shiftToMassCenterInPlace()
-Inertia_& shiftFromMassCenterInPlace(const Vec3P& p, const RealP& mass)
+Inertia_& shiftFromMassCenterInPlace(const Vec<3,P>& p, const P& mass)
 {   (*this) += pointMassAt(p, mass);
     errChk("Inertia::shiftFromMassCenterInPlace()");
     return *this; }
@@ -392,24 +388,24 @@ Inertia_& reexpressInPlace(const Rotation_<P>& R_FB)
 Inertia_& reexpressInPlace(const InverseRotation_<P>& R_FB)
 {   I_OF_F = (~R_FB).reexpressSymMat33(I_OF_F); return *this; }
 
-RealP trace() const {return I_OF_F.trace();}
+P trace() const {return I_OF_F.trace();}
 
 /// This is an implicit conversion to a const SymMat33.
-operator const SymMat33P&() const {return I_OF_F;}
+operator const SymMat<3,P>&() const {return I_OF_F;}
 
 /// Obtain a reference to the underlying symmetric matrix type.
-const SymMat33P& asSymMat33() const {return I_OF_F;}
+const SymMat<3,P>& asSymMat33() const {return I_OF_F;}
 
 /// Expand the internal packed representation into a full 3x3 symmetric
 /// matrix with all elements set.
-Mat33P toMat33() const {return Mat33P(I_OF_F);}
+Mat<3,3,P> toMat33() const {return Mat<3,3,P>(I_OF_F);}
 
 /// Obtain the inertia moments (diagonal of the Inertia matrix) as a Vec3
 /// ordered xx, yy, zz.
-const Vec3P& getMoments()  const {return I_OF_F.getDiag();}
+const Vec<3,P>& getMoments()  const {return I_OF_F.getDiag();}
 /// Obtain the inertia products (off-diagonals of the Inertia matrix)
 /// as a Vec3 with elements ordered xy, xz, yz.
-const Vec3P& getProducts() const {return I_OF_F.getLower();}
+const Vec<3,P>& getProducts() const {return I_OF_F.getLower();}
 
 bool isNaN()    const {return I_OF_F.isNaN();}
 bool isInf()    const {return I_OF_F.isInf();}
@@ -429,20 +425,20 @@ bool isNumericallyEqual(const Inertia_<P>& other, double tol) const
 
 /// %Test some conditions that must hold for a valid Inertia matrix.
 /// Cost is about 25 flops.
-static bool isValidInertiaMatrix(const SymMat33P& m) {
+static bool isValidInertiaMatrix(const SymMat<3,P>& m) {
     if (m.isNaN()) return false;
 
-    const Vec3P& d = m.diag();
+    const Vec<3,P>& d = m.diag();
     if (!(d >= 0)) return false;    // diagonals must be nonnegative
 
-    const RealP Slop = std::max(d.sum(),RealP(1))
+    const P Slop = std::max(d.sum(),P(1))
                        * NTraits<P>::getSignificant();
 
     if (!(d[0]+d[1]+Slop>=d[2] && d[0]+d[2]+Slop>=d[1] && d[1]+d[2]+Slop>=d[0]))
         return false;               // must satisfy triangle inequality
 
     // Thanks to Paul Mitiguy for this condition on products of inertia.
-    const Vec3P& p = m.getLower();
+    const Vec<3,P>& p = m.getLower();
     if (!( d[0]+Slop>=std::abs(2*p[2])
         && d[1]+Slop>=std::abs(2*p[1])
         && d[2]+Slop>=std::abs(2*p[0])))
@@ -459,13 +455,13 @@ static Inertia_ pointMassAtOrigin() {return Inertia_(0);}
 /// a given location measured from the origin of the implicit F frame.
 /// This is equivalent to m*crossMatSq(p) but is implemented elementwise
 /// here for speed, giving a cost of 14 flops.
-static Inertia_ pointMassAt(const Vec3P& p, const RealP& m) {
-    const Vec3P mp = m*p;       // 3 flops
-    const RealP mxx = mp[0]*p[0];
-    const RealP myy = mp[1]*p[1];
-    const RealP mzz = mp[2]*p[2];
-    const RealP nmx = -mp[0];
-    const RealP nmy = -mp[1];
+static Inertia_ pointMassAt(const Vec<3,P>& p, const P& m) {
+    const Vec<3,P> mp = m*p;       // 3 flops
+    const P mxx = mp[0]*p[0];
+    const P myy = mp[1]*p[1];
+    const P mzz = mp[2]*p[2];
+    const P nmx = -mp[0];
+    const P nmy = -mp[1];
     return Inertia_( myy+mzz,  mxx+mzz,  mxx+myy,
                         nmx*p[1], nmx*p[2], nmy*p[2] );
 }
@@ -479,33 +475,33 @@ static Inertia_ pointMassAt(const Vec3P& p, const RealP& m) {
 
 /// Create a UnitInertia matrix for a unit mass sphere of radius \a r centered
 /// at the origin.
-inline static Inertia_ sphere(const RealP& r);
+inline static Inertia_ sphere(const P& r);
 
 /// Unit-mass cylinder aligned along z axis;  use radius and half-length.
 /// If r==0 this is a thin rod; hz=0 it is a thin disk.
-inline static Inertia_ cylinderAlongZ(const RealP& r, const RealP& hz);
+inline static Inertia_ cylinderAlongZ(const P& r, const P& hz);
 
 /// Unit-mass cylinder aligned along y axis;  use radius and half-length.
 /// If r==0 this is a thin rod; hy=0 it is a thin disk.
-inline static Inertia_ cylinderAlongY(const RealP& r, const RealP& hy);
+inline static Inertia_ cylinderAlongY(const P& r, const P& hy);
 
 /// Unit-mass cylinder aligned along x axis; use radius and half-length.
 /// If r==0 this is a thin rod; hx=0 it is a thin disk.
-inline static Inertia_ cylinderAlongX(const RealP& r, const RealP& hx);
+inline static Inertia_ cylinderAlongX(const P& r, const P& hx);
 
 /// Unit-mass brick given by half-lengths in each direction. One dimension zero
 /// gives inertia of a thin rectangular sheet; two zero gives inertia
 /// of a thin rod in the remaining direction.
-inline static Inertia_ brick(const RealP& hx, const RealP& hy, const RealP& hz);
+inline static Inertia_ brick(const P& hx, const P& hy, const P& hz);
 
 /// Alternate interface to brick() that takes a Vec3 for the half lengths.
-inline static Inertia_ brick(const Vec3P& halfLengths);
+inline static Inertia_ brick(const Vec<3,P>& halfLengths);
 
 /// Unit-mass ellipsoid given by half-lengths in each direction.
-inline static Inertia_ ellipsoid(const RealP& hx, const RealP& hy, const RealP& hz);
+inline static Inertia_ ellipsoid(const P& hx, const P& hy, const P& hz);
 
 /// Alternate interface to ellipsoid() that takes a Vec3 for the half lengths.
-inline static Inertia_ ellipsoid(const Vec3P& halfLengths);
+inline static Inertia_ ellipsoid(const Vec<3,P>& halfLengths);
 
 //@}
 
@@ -528,10 +524,10 @@ void errChk(const char* methodName) const {
     SimTK_ERRCHK(!isNaN(), methodName,
         "Inertia matrix contains a NaN.");
 
-    const Vec3P& d = I_OF_F.getDiag();  // moments
-    const Vec3P& p = I_OF_F.getLower(); // products
-    const RealP Ixx = d[0], Iyy = d[1], Izz = d[2];
-    const RealP Ixy = p[0], Ixz = p[1], Iyz = p[2];
+    const Vec<3,P>& d = I_OF_F.getDiag();  // moments
+    const Vec<3,P>& p = I_OF_F.getLower(); // products
+    const P Ixx = d[0], Iyy = d[1], Izz = d[2];
+    const P Ixy = p[0], Ixz = p[1], Iyz = p[2];
 
     SimTK_ERRCHK3(d >= -SignificantReal, methodName,
         "Diagonals of an Inertia matrix must be nonnegative; got %g,%g,%g.",
@@ -540,7 +536,7 @@ void errChk(const char* methodName) const {
     // TODO: This is looser than it should be as a workaround for distorted
     // rotation matrices that were produced by an 11,000 body chain that
     // Sam Flores encountered. 
-    const RealP Slop = std::max(d.sum(),RealP(1))
+    const P Slop = std::max(d.sum(),P(1))
                        * std::sqrt(NTraits<P>::getEps());
 
     SimTK_ERRCHK3(   Ixx+Iyy+Slop>=Izz 
@@ -562,7 +558,7 @@ void errChk(const char* methodName) const {
 
 // Inertia expressed in frame F and about F's origin OF. Note that frame F
 // is implicit here; all we actually have are the inertia scalars.
-SymMat33P I_OF_F; 
+SymMat<3,P> I_OF_F; 
 };
 
 /// Add two compatible inertia matrices, meaning they must be taken about the
@@ -934,28 +930,28 @@ void operator/=(int) {}
 // Implement Inertia methods which are pass-throughs to UnitInertia methods.
 
 template <class P> inline Inertia_<P> Inertia_<P>::
-sphere(const RealP& r) 
+sphere(const P& r) 
 {   return UnitInertia_<P>::sphere(r); }
 template <class P> inline Inertia_<P> Inertia_<P>::
-cylinderAlongZ(const RealP& r, const RealP& hz)
+cylinderAlongZ(const P& r, const P& hz)
 {   return UnitInertia_<P>::cylinderAlongZ(r,hz); }
 template <class P> inline Inertia_<P> Inertia_<P>::
-cylinderAlongY(const RealP& r, const RealP& hy)
+cylinderAlongY(const P& r, const P& hy)
 {   return UnitInertia_<P>::cylinderAlongY(r,hy); }
 template <class P> inline Inertia_<P> Inertia_<P>::
-cylinderAlongX(const RealP& r, const RealP& hx)
+cylinderAlongX(const P& r, const P& hx)
 {   return UnitInertia_<P>::cylinderAlongX(r,hx); }
 template <class P> inline Inertia_<P> Inertia_<P>::
-brick(const RealP& hx, const RealP& hy, const RealP& hz)
+brick(const P& hx, const P& hy, const P& hz)
 {   return UnitInertia_<P>::brick(hx,hy,hz); }
 template <class P> inline Inertia_<P> Inertia_<P>::
-brick(const Vec3P& halfLengths)
+brick(const Vec<3,P>& halfLengths)
 {   return UnitInertia_<P>::brick(halfLengths); }
 template <class P> inline Inertia_<P> Inertia_<P>::
-ellipsoid(const RealP& hx, const RealP& hy, const RealP& hz)
+ellipsoid(const P& hx, const P& hy, const P& hz)
 {   return UnitInertia_<P>::ellipsoid(hx,hy,hz); }
 template <class P> inline Inertia_<P> Inertia_<P>::
-ellipsoid(const Vec3P& halfLengths)
+ellipsoid(const Vec<3,P>& halfLengths)
 {   return UnitInertia_<P>::ellipsoid(halfLengths); }
 
 
@@ -1358,41 +1354,31 @@ Typedefs exist for the most common invocations of MassProperties_\<P\>:
 template <class P>
 class SimTK_SimTKCOMMON_EXPORT MassProperties_ {
 public:
-    typedef P               RealP;
-    typedef Vec<3,P>        Vec3P;
-    typedef UnitInertia_<P> UnitInertiaP;
-    typedef Mat<3,3,P>      Mat33P;
-    typedef Mat<6,6,P>      Mat66P;
-    typedef SymMat<3,P>     SymMat33P;
-    typedef Mat<2,2,Mat33P> SpatialMatP;
-    typedef Rotation_<P>    RotationP;
-    typedef Transform_<P>   TransformP;
-    typedef Inertia_<P>     InertiaP;
 /** Create a mass properties object in which the mass, mass center, and 
 inertia are meaningless; you must assign values before using this. **/
-MassProperties_() { setMassProperties(0,Vec3P(0),UnitInertiaP()); }
+MassProperties_() { setMassProperties(0,Vec<3,P>(0),UnitInertia_<P>()); }
 /** Create a mass properties object from individually supplied mass,
 mass center, and inertia matrix.  The inertia matrix is divided by the
 mass to produce the unit inertia. **/
-MassProperties_(const RealP& m, const Vec3P& com, const InertiaP& inertia)
+MassProperties_(const P& m, const Vec<3,P>& com, const Inertia_<P>& inertia)
     { setMassProperties(m,com,inertia); }
 /** Create a mass properties object from individually supplied mass,
 mass center, and unit inertia (gyration) matrix. **/
-MassProperties_(const RealP& m, const Vec3P& com, const UnitInertiaP& gyration)
+MassProperties_(const P& m, const Vec<3,P>& com, const UnitInertia_<P>& gyration)
     { setMassProperties(m,com,gyration); }
 
 /** Set mass, center of mass, and inertia. The inertia is divided by the mass to
 produce the unit inertia. Behaves like an assignment in that
 a reference to the modified MassProperties object is returned. **/
-MassProperties_& setMassProperties(const RealP& m, const Vec3P& com, const InertiaP& inertia) {
+MassProperties_& setMassProperties(const P& m, const Vec<3,P>& com, const Inertia_<P>& inertia) {
     mass = m;
     comInB = com;
     if (m == 0) {
         SimTK_ASSERT(inertia.asSymMat33().getAsVec() == 0, "Mass is zero but inertia is nonzero");
-        unitInertia_OB_B = UnitInertiaP(0);
+        unitInertia_OB_B = UnitInertia_<P>(0);
     }
     else {
-        unitInertia_OB_B = UnitInertiaP(inertia*(1/m));
+        unitInertia_OB_B = UnitInertia_<P>(inertia*(1/m));
     }
     return *this;
 }
@@ -1400,51 +1386,51 @@ MassProperties_& setMassProperties(const RealP& m, const Vec3P& com, const Inert
 /** Set mass, center of mass, and unit inertia. Behaves like an assignment in
 that a reference to the modified MassProperties object is returned. **/
 MassProperties_& setMassProperties
-   (const RealP& m, const Vec3P& com, const UnitInertiaP& gyration)
+   (const P& m, const Vec<3,P>& com, const UnitInertia_<P>& gyration)
 {   mass=m; comInB=com; unitInertia_OB_B=gyration; return *this; }
 
 /** Return the mass currently stored in this MassProperties object. **/
-const RealP& getMass() const {return mass;}
+const P& getMass() const {return mass;}
 /** Return the mass center currently stored in this MassProperties object;
 this is expressed in an implicit frame we call "B", and measured from B's
 origin, but you have to know what that frame is in order to interpret the 
 returned vector. **/
-const Vec3P& getMassCenter() const {return comInB;}
+const Vec<3,P>& getMassCenter() const {return comInB;}
 /** Return the unit inertia currently stored in this MassProperties object;
 this is expressed in an implicit frame we call "B", and measured about B's
 origin, but you have to know what that frame is in order to interpret the 
 returned value correctly. **/
-const UnitInertiaP& getUnitInertia() const {return unitInertia_OB_B;}
+const UnitInertia_<P>& getUnitInertia() const {return unitInertia_OB_B;}
 /** Return the inertia matrix for this MassProperties object; this is equal
 to the unit inertia times the mass and costs 6 flops. It is expressed in 
 an implicit frame we call "B", and measured about B's origin, but you have 
 to know what that frame is in order to interpret the returned value
 correctly. **/
-const InertiaP calcInertia() const {return mass*unitInertia_OB_B;}
+const Inertia_<P> calcInertia() const {return mass*unitInertia_OB_B;}
 /** OBSOLETE -- this is just here for compatibility with 2.2; since the
 UnitInertia is stored now the full inertia must be calculated at a cost of
 6 flops, hence the method name should be calcInertia() and that's what
 you should use unless you want getUnitInertia(). **/
-const InertiaP getInertia() const {return calcInertia();}
+const Inertia_<P> getInertia() const {return calcInertia();}
 
 /** Return the inertia of this MassProperties object, but measured about the
 mass center rather than about the (implicit) B frame origin. The result is
 still expressed in B. **/
-InertiaP calcCentralInertia() const {
-    return mass*unitInertia_OB_B - InertiaP(comInB, mass);
+Inertia_<P> calcCentralInertia() const {
+    return mass*unitInertia_OB_B - Inertia_<P>(comInB, mass);
 }
 /** Return the inertia of this MassProperties object, but with the "measured
 about" point shifted from the (implicit) B frame origin to a new point that
 is supplied in \a newOriginB which must be a vector measured from the B frame
 origin and expressed in B. The result is still expressed in B. **/
-InertiaP calcShiftedInertia(const Vec3P& newOriginB) const {
-    return calcCentralInertia() + InertiaP(newOriginB-comInB, mass);
+Inertia_<P> calcShiftedInertia(const Vec<3,P>& newOriginB) const {
+    return calcCentralInertia() + Inertia_<P>(newOriginB-comInB, mass);
 }
 /** Return the inertia of this MassProperties object, but transformed to
 from the implicit B frame to a new frame C whose pose relative to B is
 supplied. Note that this affects both the "measured about" point and the
 "expressed in" frame. **/
-InertiaP calcTransformedInertia(const TransformP& X_BC) const {
+Inertia_<P> calcTransformedInertia(const Transform_<P>& X_BC) const {
     return calcShiftedInertia(X_BC.p()).reexpress(X_BC.R());
 }
 /** Return a new MassProperties object that is the same as this one but with 
@@ -1452,7 +1438,7 @@ the origin point shifted from the (implicit) B frame origin to a new point that
 is supplied in \a newOriginB which must be a vector measured from the B frame
 origin and expressed in B. This affects both the mass center vector and the
 inertia. The result is still expressed in B. **/
-MassProperties_ calcShiftedMassProps(const Vec3P& newOriginB) const {
+MassProperties_ calcShiftedMassProps(const Vec<3,P>& newOriginB) const {
     return MassProperties_(mass, comInB-newOriginB,
                             calcShiftedInertia(newOriginB));
 }
@@ -1466,7 +1452,7 @@ object is expressed, and the point about which the mass properties are
 measured, are implicit; we don't actually have any way to verify that 
 it is in B. Make sure you are certain about the current frame before using this 
 method. **/
-MassProperties_ calcTransformedMassProps(const TransformP& X_BC) const {
+MassProperties_ calcTransformedMassProps(const Transform_<P>& X_BC) const {
     return MassProperties_(mass, ~X_BC*comInB, calcTransformedInertia(X_BC));
 }
 
@@ -1478,7 +1464,7 @@ a shift as well. Note that the frame in which a MassProperties object is
 expressed is implicit; we don't actually have any way to verify that it is in 
 B. Make sure you are certain about the current frame before using this 
 method. **/
-MassProperties_ reexpress(const RotationP& R_BC) const {
+MassProperties_ reexpress(const Rotation_<P>& R_BC) const {
     return MassProperties_(mass, ~R_BC*comInB, unitInertia_OB_B.reexpress(R_BC));
 }
 
@@ -1491,20 +1477,20 @@ By default we use SignificantReal (about 1e-14 in double precision) as the
 tolerance but you can override that. If you are just checking to see whether
 the mass was explicitly set to zero (rather than calculated) you can use
 isExactlyMassless() instead. @see isExactlyMassless(), isNearlyCentral() **/
-bool isNearlyMassless(const RealP& tol=SignificantReal) const { 
+bool isNearlyMassless(const P& tol=SignificantReal) const { 
     return mass <= tol; 
 }
 
 /** Return true only if the mass center stored here is \e exactly zero.\ If 
 the mass center resulted from a computation, you should use isNearlyCentral()
 instead. @see isNearlyCentral(), isExactlyMassless() **/
-bool isExactlyCentral() const { return comInB==Vec3P(0); }
+bool isExactlyCentral() const { return comInB==Vec<3,P>(0); }
 /** Return true if the mass center stored here is zero to within a small tolerance.
 By default we use SignificantReal (about 1e-14 in double precision) as the
 tolerance but you can override that. If you are just checking to see whether
 the mass center was explicitly set to zero (rather than calculated) you can use
 isExactlyCentral() instead. @see isExactlyCentral(), isNearlyMassless() **/
-bool isNearlyCentral(const RealP& tol=SignificantReal) const {
+bool isNearlyCentral(const P& tol=SignificantReal) const {
     return comInB.normSqr() <= tol*tol;
 }
 
@@ -1529,8 +1515,8 @@ bool isFinite() const {
 /** Convert this MassProperties object to a spatial inertia matrix and return
 it as a SpatialMat, which is a 2x2 matrix of 3x3 submatrices. 
 @see toMat66() **/
-SpatialMatP toSpatialMat() const {
-    SpatialMatP M;
+Mat<2,2,Mat<3,3,P>> toSpatialMat() const {
+    Mat<2,2,Mat<3,3,P>> M;
     M(0,0) = mass*unitInertia_OB_B.toMat33();
     M(0,1) = mass*crossMat(comInB);
     M(1,0) = ~M(0,1);
@@ -1543,8 +1529,8 @@ form of an ordinary 6x6 matrix, \e not a SpatialMat. Logically these are
 the same but the ordering of the elements in memory is different between
 a Mat66 and SpatialMat. 
 @see toSpatialMat() **/
-Mat66P toMat66() const {
-    Mat66P M;
+Mat<6,6,P> toMat66() const {
+    Mat<6,6,P> M;
     M.template updSubMat<3,3>(0,0) = mass*unitInertia_OB_B.toMat33();
     M.template updSubMat<3,3>(0,3) = mass*crossMat(comInB);
     M.template updSubMat<3,3>(3,0) = ~M.template getSubMat<3,3>(0,3);
@@ -1553,9 +1539,9 @@ Mat66P toMat66() const {
 }
 
 private:
-RealP        mass;
-Vec3P        comInB;         // meas. from B origin, expr. in B
-UnitInertiaP unitInertia_OB_B;   // about B origin, expr. in B
+P               mass;
+Vec<3,P>        comInB;         // meas. from B origin, expr. in B
+UnitInertia_<P> unitInertia_OB_B;   // about B origin, expr. in B
 };
 
 /** Output a human-readable representation of a MassProperties object to

--- a/SimTKcommon/Mechanics/include/SimTKcommon/internal/Rotation.h
+++ b/SimTKcommon/Mechanics/include/SimTKcommon/internal/Rotation.h
@@ -1281,6 +1281,7 @@ Rotation class for more information. **/
 //-----------------------------------------------------------------------------
 template <class P>
 class InverseRotation_ : public Mat<3,3,P>::TransposeType {
+public:
 typedef P               RealP;
 typedef Rotation_<P>    RotationP;
 typedef Mat<3,3,P>      Mat33P; // not the base type!
@@ -1291,7 +1292,6 @@ typedef Vec<2,P>        Vec2P;
 typedef Vec<3,P>        Vec3P;
 typedef Vec<4,P>        Vec4P;
 typedef Quaternion_<P>  QuaternionP;
-public:
 /** This is the type of the underlying 3x3 matrix; note that it will have
 unusual row and column spacing since we're viewing it as transposed. **/
 typedef typename Mat<3,3,P>::TransposeType  BaseMat;

--- a/SimTKcommon/Mechanics/include/SimTKcommon/internal/Rotation.h
+++ b/SimTKcommon/Mechanics/include/SimTKcommon/internal/Rotation.h
@@ -1281,17 +1281,14 @@ Rotation class for more information. **/
 //-----------------------------------------------------------------------------
 template <class P>
 class InverseRotation_ : public Mat<3,3,P>::TransposeType {
-public:
-typedef P               RealP;
-typedef Rotation_<P>    RotationP;
 typedef Mat<3,3,P>      Mat33P; // not the base type!
-typedef SymMat<3,P>     SymMat33P;
 typedef Mat<2,2,P>      Mat22P;
 typedef Mat<3,2,P>      Mat32P;
 typedef Vec<2,P>        Vec2P;
 typedef Vec<3,P>        Vec3P;
 typedef Vec<4,P>        Vec4P;
 typedef Quaternion_<P>  QuaternionP;
+public:
 /** This is the type of the underlying 3x3 matrix; note that it will have
 unusual row and column spacing since we're viewing it as transposed. **/
 typedef typename Mat<3,3,P>::TransposeType  BaseMat;
@@ -1322,24 +1319,24 @@ matrix should be one that is formed as products of vectors expressed in A, such
 as inertia, unit inertia (gyration) or covariance matrices. This can be done 
 efficiently exploiting properties of R and S. Cost is 57 flops.
 @see Rotation::reexpressSymMat33() **/
-SimTK_SimTKCOMMON_EXPORT SymMat33P 
-reexpressSymMat33(const SymMat33P& S_BB) const;
+SimTK_SimTKCOMMON_EXPORT SymMat<3,P> 
+reexpressSymMat33(const SymMat<3,P>& S_BB) const;
 
 /** We can invert an InverseRotation just by recasting it to a Rotation at 
 zero cost. **/
 //@{
-const RotationP&  invert() const 
-{return *reinterpret_cast<const RotationP*>(this);}
-RotationP&        updInvert() {return *reinterpret_cast<RotationP*>(this);}
+const Rotation_<P>&  invert() const 
+{return *reinterpret_cast<const Rotation_<P>*>(this);}
+Rotation_<P>&        updInvert() {return *reinterpret_cast<Rotation_<P>*>(this);}
 //@}
 
 /** Transpose, and transpose operators (override BaseMat versions of transpose).
 For an orthogonal matrix like this one transpose is the same as inverse. **/
 //@{
-const RotationP&  transpose() const  { return invert(); }
-const RotationP&  operator~() const  { return invert(); }
-RotationP&        updTranspose()     { return updInvert(); }
-RotationP&        operator~()        { return updInvert(); }
+const Rotation_<P>&  transpose() const  { return invert(); }
+const Rotation_<P>&  operator~() const  { return invert(); }
+Rotation_<P>&        updTranspose()     { return updInvert(); }
+Rotation_<P>&        operator~()        { return updInvert(); }
 //@}
 
 /** Access individual rows and columns of this InverseRotation; no cost or

--- a/SimTKcommon/Mechanics/include/SimTKcommon/internal/UnitVec.h
+++ b/SimTKcommon/Mechanics/include/SimTKcommon/internal/UnitVec.h
@@ -54,8 +54,8 @@ typedef UnitVec<double,1>   dUnitVec3;
 //-----------------------------------------------------------------------------
 template <class P, int S>
 class UnitVec : public Vec<3,P,S> {
-    typedef P   RealP;
 public:
+    typedef P   RealP;
     typedef Vec<3,P,S>      BaseVec;
     typedef UnitRow<P,S>    TransposeType;
 

--- a/SimTKcommon/Mechanics/include/SimTKcommon/internal/UnitVec.h
+++ b/SimTKcommon/Mechanics/include/SimTKcommon/internal/UnitVec.h
@@ -55,7 +55,6 @@ typedef UnitVec<double,1>   dUnitVec3;
 template <class P, int S>
 class UnitVec : public Vec<3,P,S> {
 public:
-    typedef P   RealP;
     typedef Vec<3,P,S>      BaseVec;
     typedef UnitRow<P,S>    TransposeType;
 
@@ -83,7 +82,7 @@ public:
     /// Create a unit vector in the direction of the vector (x,y,z) whose measure
     /// numbers are supplied -- this requires an expensive normalization since
     /// we don't know that the supplied vector is normalized.
-    UnitVec(const RealP& x, const RealP& y, const RealP& z) : BaseVec(x,y,z)  
+    UnitVec(const P& x, const P& y, const P& z) : BaseVec(x,y,z)  
     {   static_cast<BaseVec&>(*this) /= BaseVec::norm(); }
 
     /// Implicit conversion from a coordinate axis XAxis, YAxis, or ZAxis to
@@ -95,7 +94,7 @@ public:
     /// UnitVec3.\ The axis direction is given by one of XAxis, YAxis, ZAxis 
     /// or NegXAxis, NegYAxis, NegZAxis.\ Does not require any computation.
     UnitVec(const CoordinateDirection& dir) : BaseVec(0) 
-    {   BaseVec::operator[](dir.getAxis()) = RealP(dir.getDirection()); }
+    {   BaseVec::operator[](dir.getAxis()) = P(dir.getDirection()); }
 
     /// Construct a unit axis vector 100 010 001 given 0,1, or 2; this is not
     /// an implicit conversion.
@@ -140,11 +139,11 @@ public:
     /// Return one element of this unit vector as a const reference; there is no 
     /// corresponding writable index function since changing a single element of
     /// a unit vector would violate the contract that it has unit length at all times.
-    const RealP&  operator[](int i) const  { return BaseVec::operator[](i); }
+    const P&  operator[](int i) const  { return BaseVec::operator[](i); }
     /// Return one element of this unit vector as a const reference; there is no 
     /// corresponding writable index function since changing a single element of
     /// a unit vector would violate the contract that it has unit length at all times.
-    const RealP&  operator()(int i) const  { return BaseVec::operator()(i); }
+    const P&  operator()(int i) const  { return BaseVec::operator()(i); }
 
     /// Return a new unit vector whose measure numbers are the absolute values
     /// of the ones here. This will still have unit length but will be
@@ -166,14 +165,14 @@ public:
     /// give us an already-normalized vector which we simply accept as
     /// normalized without checking (this version accepts an input
     /// vector of any stride).
-    template <int S2> UnitVec(const Vec<3,RealP,S2>& v, bool) : BaseVec(v) { }
+    template <int S2> UnitVec(const Vec<3,P,S2>& v, bool) : BaseVec(v) { }
 
     /// (Advanced) Reinterpret a given memory location as a %UnitVec like
     /// this one, without checking -- don't use this if you aren't absolutely 
     /// certain that the memory location actually \e does contain a unit vector, 
     /// with the correct stride! This overrides the base Vec class method of the
     /// same name.
-    static const UnitVec& getAs(const RealP* p)  
+    static const UnitVec& getAs(const P* p)  
     {   return *reinterpret_cast<const UnitVec*>(p); }
 };
 
@@ -210,7 +209,6 @@ operator!=(const UnitVec<P,S1>& u1, const UnitVec<P,S2>& u2)
 //-----------------------------------------------------------------------------
 template <class P, int S>
 class UnitRow : public Row<3,P,S> {
-    typedef P   RealP;
 public:
     typedef Row<3,P,S>      BaseRow;
     typedef UnitVec<P,S>    TransposeType;
@@ -245,7 +243,7 @@ public:
 
     /// Create a unit row from explicitly specified measure numbers (x,y,z); 
     /// requires expensive normalization.
-    UnitRow(const RealP& x, const RealP& y, const RealP& z)
+    UnitRow(const P& x, const P& y, const P& z)
     :   BaseRow(x,y,z)
     {   static_cast<BaseRow&>(*this) /= BaseRow::norm(); }
 
@@ -280,11 +278,11 @@ public:
     /// Return one element of this unit row as a const reference; there is no 
     /// corresponding writable index function since changing a single element of
     /// a unit vector would violate the contract that it has unit length at all times.
-    const RealP&  operator[](int i) const  { return BaseRow::operator[](i); }
+    const P&  operator[](int i) const  { return BaseRow::operator[](i); }
     /// Return one element of this unit row as a const reference; there is no 
     /// corresponding writable index function since changing a single element of
     /// a unit vector would violate the contract that it has unit length at all times.
-    const RealP&  operator()(int i) const  { return BaseRow::operator()(i); }
+    const P&  operator()(int i) const  { return BaseRow::operator()(i); }
 
     /// Return a new UnitRow whose measure numbers are the absolute values
     /// of the ones here. This will still have unit length but will be
@@ -313,7 +311,7 @@ public:
     /// certain that the memory location actually \e does contain a unit vector,
     /// with the correct stride! This overrides the base Row class method of the
     /// same name.
-    static const UnitRow& getAs(const RealP* p)  
+    static const UnitRow& getAs(const P* p)  
     {   return *reinterpret_cast<const UnitRow*>(p); }
 };
 

--- a/SimTKcommon/Mechanics/src/Rotation.cpp
+++ b/SimTKcommon/Mechanics/src/Rotation.cpp
@@ -810,13 +810,13 @@ Rotation_<P>::reexpressSymMat33(const SymMat33P& S_BB) const {
 // memory locations so that the net effect is to use the transpose of
 // the original rotation from which this was created.
 template <class P> SymMat<3,P>
-InverseRotation_<P>::reexpressSymMat33(const SymMat33P& S_BB) const {
-    const RealP a=S_BB(0,0), b=S_BB(1,1), c=S_BB(2,2);
-    const RealP d=S_BB(1,0), e=S_BB(2,0), f=S_BB(2,1);
+InverseRotation_<P>::reexpressSymMat33(const SymMat<3,P>& S_BB) const {
+    const P a=S_BB(0,0), b=S_BB(1,1), c=S_BB(2,2);
+    const P d=S_BB(1,0), e=S_BB(2,0), f=S_BB(2,1);
     // Note reversal of row and column spacing here (normal is 3,1).
-    const Mat<3,3,RealP,1,3>& R   = this->asMat33();
+    const Mat<3,3,P,1,3>& R   = this->asMat33();
     // RR is just the first two columns of R.
-    const Mat<3,2,RealP,1,3>& RR  = R.template getSubMat<3,2>(0,0);
+    const Mat<3,2,P,1,3>& RR  = R.template getSubMat<3,2>(0,0);
 
     const Mat32P L( a-c ,  d,
                      d  , b-c,
@@ -825,15 +825,15 @@ InverseRotation_<P>::reexpressSymMat33(const SymMat33P& S_BB) const {
     const Mat22P Y( R[1]*L(0), R[1]*L(1),
                     R[2]*L(0), R[2]*L(1) );
 
-    const RealP Z10 = Y[0]*~RR[0], Z11 = Y[0]*~RR[1],
-                Z20 = Y[1]*~RR[0], Z21 = Y[1]*~RR[1], Z22= Y[1]*~RR[2];
-    const RealP Z00 = (L(0,0)+L(1,1)) - (Z11+Z22);
+    const P Z10 = Y[0]*~RR[0], Z11 = Y[0]*~RR[1],
+            Z20 = Y[1]*~RR[0], Z21 = Y[1]*~RR[1], Z22= Y[1]*~RR[2];
+    const P Z00 = (L(0,0)+L(1,1)) - (Z11+Z22);
 
     const Vec3P Rv( R(0,1)*e-R(0,0)*f,
                     R(1,1)*e-R(1,0)*f,
                     R(2,1)*e-R(2,0)*f );
 
-    return SymMat33P( Z00 + c,
+    return SymMat<3,P>( Z00 + c,
                       Z10 + Rv[2], Z11 + c,
                       Z20 - Rv[1], Z21 + Rv[0], Z22 + c );
 }

--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
@@ -281,7 +281,7 @@ class RealizeCheckFailed : public Base {
 public:
     RealizeCheckFailed(const char* fn, int ln, Stage g, 
                        int subsystemId, const char* subsystemName,
-                       const char* fmt ...) : Base(fn,ln)
+                       const char* fmt, ...) : Base(fn,ln)
     {
         char buf[1024];
         va_list args;

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
@@ -120,9 +120,8 @@ public:
     typedef typename CNT<E>::Precision          EPrecision;
     typedef typename CNT<E>::ScalarNormSq       EScalarNormSq;
 
-public:
     /** Every Composite Numerical Type (CNT) must define these values. **/
-#ifndef SWIG
+    #ifndef SWIG
     enum {
         NRows               = M,
         NCols               = N,
@@ -146,7 +145,7 @@ public:
         IsPrecision         = 0,
         SignInterpretation  = CNT<E>::SignInterpretation
     };
-#endif
+    #endif
 
     typedef Mat<M,N,E,CS,RS>                T;
     typedef Mat<M,N,ENeg,CS,RS>             TNeg;

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
@@ -95,6 +95,7 @@ std::cout << Matrix(myMat33) << std::endl;
 @see SymMat, Vec, Row
 **/
 template <int M, int N, class ELT, int CS, int RS> class Mat {
+public:
     typedef ELT                                 E;
     typedef typename CNT<E>::TNeg               ENeg;
     typedef typename CNT<E>::TWithoutNegator    EWithoutNegator;
@@ -121,6 +122,7 @@ template <int M, int N, class ELT, int CS, int RS> class Mat {
 
 public:
     /** Every Composite Numerical Type (CNT) must define these values. **/
+#ifndef SWIG
     enum {
         NRows               = M,
         NCols               = N,
@@ -144,6 +146,7 @@ public:
         IsPrecision         = 0,
         SignInterpretation  = CNT<E>::SignInterpretation
     };
+#endif
 
     typedef Mat<M,N,E,CS,RS>                T;
     typedef Mat<M,N,ENeg,CS,RS>             TNeg;

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
@@ -234,6 +234,7 @@ public:
 
     /** These compile-time constants are required of every Composite
     Numerical Type (CNT). **/
+#ifndef SWIG
     enum {
         NRows               = M,
         NCols               = 1,
@@ -255,6 +256,7 @@ public:
         IsPrecision         = 0,
         SignInterpretation  = CNT<E>::SignInterpretation
     };
+#endif
 
     // These are reinterpretations of the current data, so have the
     // same packing (stride).

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
@@ -234,7 +234,7 @@ public:
 
     /** These compile-time constants are required of every Composite
     Numerical Type (CNT). **/
-#ifndef SWIG
+    #ifndef SWIG
     enum {
         NRows               = M,
         NCols               = 1,
@@ -256,7 +256,7 @@ public:
         IsPrecision         = 0,
         SignInterpretation  = CNT<E>::SignInterpretation
     };
-#endif
+    #endif
 
     // These are reinterpretations of the current data, so have the
     // same packing (stride).

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -782,7 +782,9 @@ template<> struct Is64BitHelper<false>
 platform, meaning that the size of a pointer is the same as the size of a 
 long long; otherwise it will be FalseType and we have a 32-bit platform meaning
 that the size of a pointer is the same as an int. **/
-static const bool Is64BitPlatform = sizeof(size_t) > sizeof(int);
+// We use a constexpr function to avoid a bug in SWIG.
+constexpr bool detect64BitPlatform() { return (sizeof(size_t) > sizeof(int)); }
+static const bool Is64BitPlatform = detect64BitPlatform();
 typedef Is64BitHelper<Is64BitPlatform>::Result Is64BitPlatformType;
 
 


### PR DESCRIPTION
The changes I made here are based on discussions in https://github.com/opensim-org/opensim-core/issues/592.

I chose to remove the template class typedefs necessary, but I left the ones that I didn't need to change (with perhaps 1 or 2 exceptions). Also, I chose *not* to remove any typedefs for Mat.h; instead I put the typedefs in the public section. I justify this because Vec.h has similar typedefs that are public. By making only the necessary changes, I hope to have minimized the chance of introducing a bug.

Also, for computation within enums, I chose to use `#ifndef SWIG` rather than resorting to a `constexpr` function in order to make sure the C++ code remains clear and that I don't introduce a bug.

I've tested OpenSim wrapping against these changes, and both the python and java wrapping compile (and the python tests and testContext both pass). You can see my changes to OpenSim here: https://github.com/opensim-org/opensim-core/tree/swig-simtk