### PR TITLE
Defer calculation of articulated body inertias until Acceleration stage

### DIFF
--- a/SimTKcommon/include/SimTKcommon/Testing.h
+++ b/SimTKcommon/include/SimTKcommon/Testing.h
@@ -560,6 +560,7 @@ private:
      "Test values should NOT have been numerically equivalent at tolerance=%g.",(tol));}
 
 #ifndef SimTK_TEST_SUPPRESS_EXPECTED_THROW
+
 /// Test that the supplied statement throws an std::exception of some kind.
 #define SimTK_TEST_MUST_THROW(stmt)             \
     do {int threw=0; try {stmt;}                \
@@ -607,7 +608,7 @@ private:
 
 // When we're only required to throw in Debug, we have to suppress the
 // test case altogether in Release because it may cause damage. 
-#if defined(NDEBUG)
+#ifdef NDEBUG
     /// Include a bad statement when in Debug and insist that it get caught,
     /// but don't include the statement at all in Release.
     #define SimTK_TEST_MUST_THROW_DEBUG(stmt)
@@ -623,6 +624,7 @@ private:
     #define SimTK_TEST_MUST_THROW_EXC_DEBUG(stmt,exc) \
                 SimTK_TEST_MUST_THROW_EXC(stmt,exc)
 #endif
+
 #else // expected throws are suppressed
 #define SimTK_TEST_MUST_THROW(stmt)
 #define SimTK_TEST_MUST_THROW_SHOW(stmt)

--- a/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
+++ b/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
@@ -2777,6 +2777,12 @@ above in `state` because position kinematics is assumed to be
 valid after Position stage, regardless of lazy evaluation status. **/
 void invalidatePositionKinematics(const State& state) const;
 
+/** (Advanced) Check whether position kinematics has already been realized.
+This will be true after realizePositionKinematics() or realize(Position);
+false after invalidation of Stage::Instance, a change to a generalized
+coordinate `q`, or after a call to invalidatePositionKinematics(). **/
+bool isPositionKinematicsRealized(const State&) const;
+
 /** (Advanced) Force invalidation of velocity kinematics, which otherwise 
 remains valid until an instance-stage variable, generalized coordinate q, or
 generalized speed u is modified, or if PositionKinematics is explicitly
@@ -2787,10 +2793,23 @@ above in `state` because velocity kinematics is assumed to be
 valid after Velocity stage, regardless of lazy evaluation status. **/
 void invalidateVelocityKinematics(const State& state) const;
 
+/** (Advanced) Check whether velocity kinematics has already been realized.
+This will be true after realizeVelocityKinematics() or realize(Velocity);
+false if isPositionKinematicsRealized() would return false, after a change
+to a generalized speed `u`, or after a call to 
+invalidateVelocityKinematics(). **/
+bool isVelocityKinematicsRealized(const State&) const;
+
 /** (Advanced) This is useful for timing computation time for 
 realizeCompositeBodyInertias(), which otherwise will not recalculate them
 if called repeatedly. **/
 void invalidateCompositeBodyInertias(const State& state) const;
+
+/** (Advanced) Check whether composite body inertias have already been realized.
+This will be true only after an explicit call to realizeCompositeBodyInertias();
+false if isPositionKinematicsRealized() would return false or after a call to 
+invalidateCompositeBodyInertias(). **/
+bool isCompositeBodyInertiasRealized(const State&) const;
 
 /** (Advanced) Force invalidation of articulated body inertias (ABIs), which 
 otherwise remain valid until a position-stage variable is modified or any other 
@@ -2801,6 +2820,12 @@ because ABIs are assumed to be valid after Acceleration stage, regardless of
 lazy evaluation status. **/
 void invalidateArticulatedBodyInertias(const State& state) const;
 
+/** (Advanced) Check whether articulated body inertias have already been 
+realized. This will be true after realizeArticulatedBodyInertias() or
+realize(Acceleration); false if isPositionKinematicsRealized() would return 
+false, or after a call to invalidateArticulatedBodyInertias(). **/
+bool isArticulatedBodyInertiasRealized(const State&) const;
+
 /** (Advanced) Force invalidation of articulated body velocity computations, 
 which otherwise remain valid until a velocity- or position-stage variable is
 modified or any other prerequisite is invalidated. This is useful for timing 
@@ -2809,6 +2834,13 @@ recalculate if called repeatedly. Note that this also invalidates Acceleration
 stage in `state` because these computations are assumed to be valid after 
 Acceleration stage, regardless of lazy evaluation status. **/
 void invalidateArticulatedBodyVelocity(const State& state) const;
+
+/** (Advanced) Check whether articulated body velocity computations have already
+been realized. This will be true after realizeArticulatedBodyVelocity() or
+realize(Acceleration); false if isArticulatedBodyInertiasRealized() or
+isVelocityKinematicsRealized() would return false, or after a call to 
+invalidateArticulatedBodyVelocity(). **/
+bool isArticulatedBodyVelocityRealized(const State&) const;
 /**@}**/
 
 
@@ -2889,11 +2921,11 @@ const Vec3& getParticleAcceleration(const State& s, ParticleIndex p) const {
 /**@}**/
 
 //==============================================================================
-/** @name                  Deprecated methods
+/** @name                    Deprecated methods
 
-These methods are deprecated because there is a better way now to do what they
-used to do. This may involve just a name change, calling signature, or something
-more substantial; see the documentation for the individual obsolete methods.
+If you are still using any methods in this section, please stop. If that's a
+problem, please post to the Simbody forum and explain why the method should
+not be deprecated.
 **/
 
 /**@{**/

--- a/Simbody/src/RigidBodyNode.cpp
+++ b/Simbody/src/RigidBodyNode.cpp
@@ -102,6 +102,7 @@ RigidBodyNode::calcJointIndependentKinematicsVel(
         updGyroscopicForce(vc)               = SpatialVec(Vec3(0), Vec3(0));
         updMobilizerCoriolisAcceleration(vc) = SpatialVec(Vec3(0), Vec3(0));
         updTotalCoriolisAcceleration(vc)     = SpatialVec(Vec3(0), Vec3(0));
+        updTotalCentrifugalForces(vc)        = SpatialVec(Vec3(0), Vec3(0));
         return;
     }
 
@@ -116,24 +117,24 @@ RigidBodyNode::calcJointIndependentKinematicsVel(
     const Vec3& w_GB = V_GB[0]; // for convenience
     const Vec3& v_GB = V_GB[1];
 
-    // Calculate gyroscopic moment and force (48 flops). Although this is 
+    // Calculate gyroscopic moment and force b (48 flops). Although this is 
     // really a dynamic quantity (requires spatial inertia and is itself
     // a force), we calculate this here rather than in stage Dynamics because 
     // it is needed in inverse dynamics but does not require articulated body 
     // inertias to be calculated. This could be deferred until needed but
     // probably isn't worth the trouble.
-    updGyroscopicForce(vc) = getMass() *                   // 6 flops
-        SpatialVec( w_GB % (getUnitInertia_OB_G(pc)*w_GB), // moment (24 flops)
-                   (w_GB % (w_GB % getCB_G(pc))));         // force  (18 flops)
-
+    const SpatialVec b  = getMass() *                       // 6 flops
+        SpatialVec(w_GB % (getUnitInertia_OB_G(pc)*w_GB),   // moment (24 flops)
+                   w_GB % (w_GB % getCB_G(pc)));            // force  (18 flops)   
+    updGyroscopicForce(vc) = b;
 
     // Parent velocity.
     const Vec3& w_GP = V_GP[0]; // for convenience
     const Vec3& v_GP = V_GP[1];
 
     // Calculate this mobilizer's incremental contribution to coriolis 
-    // acceleration, and this body's total coriolis acceleration (it parent's 
-    // coriolis  acceleration plus the incremental contribution).
+    // acceleration a, and this body's total coriolis acceleration A (it 
+    // parent's coriolis acceleration plus the incremental contribution).
     //
     // We just calculated 
     // (1)  V_GB = J*u = ~Phi * V_GP + H*u 
@@ -149,7 +150,7 @@ RigidBodyNode::calcJointIndependentKinematicsVel(
     // CAUTION: our definition of H is transposed from Jain's and Schwieters'.
     //
     // So the incremental contribution to the coriolis acceleration is
-    //   Amob = ~PhiDot * V_GP + HDot * u
+    //   A = ~PhiDot * V_GP + HDot * u
     // As correctly calculated in Schwieters' paper, Eq [16], the first term 
     // above simplifies to SpatialVec( 0, w_GP % (v_GB-v_GP) ). However, 
     // Schwieters' second term in [16] is correct only if H is constant in P, 
@@ -161,17 +162,20 @@ RigidBodyNode::calcJointIndependentKinematicsVel(
     // Note: despite all the ground-relative velocities here, this is just
     // the contribution of the cross-joint velocity, but reexpressed in G.
     const SpatialVec& VD_PB_G = getVD_PB_G(vc);
-    const SpatialVec  Amob(VD_PB_G[0], 
-                           VD_PB_G[1] + w_GP % (v_GB-v_GP)); // 15 flops
+    const SpatialVec  A(VD_PB_G[0], 
+                        VD_PB_G[1] + w_GP % (v_GB-v_GP)); // 15 flops
+    updMobilizerCoriolisAcceleration(vc) = A;
 
-    updMobilizerCoriolisAcceleration(vc) = Amob;
-
-    // Finally, the total coriolis acceleration (normally just called "coriolis
+    // Next, the total coriolis acceleration a (normally just called "coriolis
     // acceleration"!) of body B is the total coriolis acceleration of its 
-    // parent shifted outward, plus B's local contribution that we just 
-    // calculated.
-    updTotalCoriolisAcceleration(vc) =
-        PhiT * parent->getTotalCoriolisAcceleration(vc) + Amob; // 18 flops
+    // parent shifted outward, plus B's local contribution A that we just 
+    // calculated (18 flops).
+    const SpatialVec a = PhiT * parent->getTotalCoriolisAcceleration(vc) + A;   
+    updTotalCoriolisAcceleration(vc) = a;
+
+    // Finally, calculate the total of the rotational velocity-dependent forces 
+    // acting on this body (45 flops).
+    updTotalCentrifugalForces(vc) =  getMk_G(pc) * a + b;
 }
 
 
@@ -199,7 +203,7 @@ Real RigidBodyNode::calcKineticEnergy(
 // This routine expects that coriolis accelerations, gyroscopic forces, and
 // articulated body inertias are already available.
 // As written, the calling order doesn't matter.
-// Cost is 117 flops.
+// Cost is 72 flops.
 void 
 RigidBodyNode::calcJointIndependentDynamicsVel(
     const SBTreePositionCache&              pc,
@@ -209,7 +213,6 @@ RigidBodyNode::calcJointIndependentDynamicsVel(
 {
     if (nodeNum == 0) { // ground, just in case
         updMobilizerCentrifugalForces(dc)    = SpatialVec(Vec3(0), Vec3(0));
-        updTotalCentrifugalForces(dc)       = SpatialVec(Vec3(0), Vec3(0));
         return;
     }
 
@@ -217,9 +220,6 @@ RigidBodyNode::calcJointIndependentDynamicsVel(
     updMobilizerCentrifugalForces(dc) =
         getP(abc) * getMobilizerCoriolisAcceleration(vc) + getGyroscopicForce(vc);
 
-    // 45 flops
-    updTotalCentrifugalForces(dc) = 
-        getMk_G(pc) * getTotalCoriolisAcceleration(vc) + getGyroscopicForce(vc);
 }
 
 

--- a/Simbody/src/RigidBodyNode.h
+++ b/Simbody/src/RigidBodyNode.h
@@ -199,7 +199,7 @@ virtual int calcQPoolSize(const SBModelVars&) const = 0;
 virtual void performQPrecalculations(const SBStateDigest& sbs,
                                      const Real* q,  int nq,
                                      Real* posCache, int nPosCache,
-                                     Real* qErr,     int nQErr) const=0;
+                                     Real* qErr,     int nQErr) const = 0;
 
 // This mandatory routine calculates the across-joint transform X_FM generated
 // by the supplied q values. This may depend on sines & cosines or normalized
@@ -511,11 +511,12 @@ virtual void multiplyBySystemJacobianTranspose(
 
 virtual void calcEquivalentJointForces(
     const SBTreePositionCache&  pc,
-    const SBDynamicsCache&      dc,
+    const SBTreeVelocityCache&  vc,
     const SpatialVec*           bodyForces,
     SpatialVec*                 allZ,
     Real*                       jointForces) const
-  { SimTK_THROW2(Exception::UnimplementedVirtualMethod, "RigidBodeNode", "calcEquivalentJointForces"); }
+  { SimTK_THROW2(Exception::UnimplementedVirtualMethod, "RigidBodeNode", 
+    "calcEquivalentJointForces"); }
 
 virtual void calcUDotPass1Inward(
     const SBInstanceCache&                  ic,
@@ -584,19 +585,12 @@ virtual void multiplyByMPass2Inward(
     Real*                       allTau) const
   { SimTK_THROW2(Exception::UnimplementedVirtualMethod, "RigidBodeNode", "multiplyByMPass2Inward"); }
 
-
-virtual void setVelFromSVel(const SBStateDigest&,
-                            const SpatialVec&, Vector& u) const {SimTK_THROW2(Exception::UnimplementedVirtualMethod, "RigidBodeNode", "setVelFromSVel");}
-
 // Note that this requires columns of H to be packed like SpatialVec.
 virtual const SpatialVec& getHCol(const SBTreePositionCache&, int j) const 
 {SimTK_THROW2(Exception::UnimplementedVirtualMethod, "RigidBodeNode", "getHCol");}
 
 virtual const SpatialVec& getH_FMCol(const SBTreePositionCache&, int j) const 
 {SimTK_THROW2(Exception::UnimplementedVirtualMethod, "RigidBodeNode", "getH_FMCol");}
-
-//TODO (does this even belong here?)
-virtual void velFromCartesian() {}
 
 
     // BASE CLASS METHODS //
@@ -877,6 +871,9 @@ SpatialVec&       updMobilizerCoriolisAcceleration(SBTreeVelocityCache&       vc
 const SpatialVec& getTotalCoriolisAcceleration(const SBTreeVelocityCache& vc) const {return fromB(vc.totalCoriolisAcceleration);}
 SpatialVec&       updTotalCoriolisAcceleration(SBTreeVelocityCache&       vc) const {return toB  (vc.totalCoriolisAcceleration);}
 
+const SpatialVec& getTotalCentrifugalForces(const SBTreeVelocityCache& vc) const {return fromB(vc.totalCentrifugalForces);}
+SpatialVec&       updTotalCentrifugalForces(SBTreeVelocityCache&       vc) const {return toB  (vc.totalCentrifugalForces);}
+
     // DYNAMICS INFO
 
 // Composite body inertias.
@@ -894,9 +891,6 @@ ArticulatedInertia&       updPPlus(SBArticulatedBodyInertiaCache&       abc) con
 
 const SpatialVec& getMobilizerCentrifugalForces(const SBDynamicsCache& dc) const {return fromB(dc.mobilizerCentrifugalForces);}
 SpatialVec&       updMobilizerCentrifugalForces(SBDynamicsCache&       dc) const {return toB  (dc.mobilizerCentrifugalForces);}
-
-const SpatialVec& getTotalCentrifugalForces(const SBDynamicsCache& dc) const {return fromB(dc.totalCentrifugalForces);}
-SpatialVec&       updTotalCentrifugalForces(SBDynamicsCache&       dc) const {return toB  (dc.totalCentrifugalForces);}
 
 const SpatialVec& getZ(const SBTreeAccelerationCache& tac) const {return fromB(tac.z);}
 SpatialVec&       updZ(SBTreeAccelerationCache&       tac) const {return toB  (tac.z);}

--- a/Simbody/src/RigidBodyNode.h
+++ b/Simbody/src/RigidBodyNode.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors: Derived from IVM code written by Charles Schwieters          *
  *                                                                            *
@@ -149,11 +149,13 @@ enum QuaternionUse {
 bool isQuaternionEverUsed() const
 {   return quaternionUse==QuaternionMayBeUsed; }
 
-virtual ~RigidBodyNode() {}
+virtual ~RigidBodyNode() = default;
+RigidBodyNode(const RigidBodyNode&) = delete;
+RigidBodyNode& operator=(const RigidBodyNode&) = delete;
 
     // MOBILIZER-SPECIFIC VIRTUAL METHODS //
 
-virtual const char* type()     const {return "unknown";}
+virtual const char* type() const {return "unknown";}
 virtual int  getDOF()   const=0; //number of independent dofs
 virtual int  getMaxNQ() const=0; //dofs plus extra quaternion coordinate if any
 
@@ -469,7 +471,6 @@ virtual void realizeVelocity(
 // stage calculations which must go tip-to-base (e.g. articulated
 // body inertias).
 virtual void realizeDynamics(
-    const SBArticulatedBodyInertiaCache&    abc,
     const SBStateDigest&                    sbs) const=0;
 
 // There is no realizeAcceleration().
@@ -522,7 +523,7 @@ virtual void calcUDotPass1Inward(
     const SBInstanceCache&                  ic,
     const SBTreePositionCache&              pc,
     const SBArticulatedBodyInertiaCache&    abc,
-    const SBDynamicsCache&                  dc,
+    const SBArticulatedBodyVelocityCache&   abvc,
     const Real*                             jointForces,
     const SpatialVec*                       bodyForces,
     const Real*                             allUDot,
@@ -595,7 +596,6 @@ virtual const SpatialVec& getH_FMCol(const SBTreePositionCache&, int j) const
 
     // BASE CLASS METHODS //
 
-RigidBodyNode& operator=(const RigidBodyNode&);
 
 static RigidBodyNode* createGroundNode();
 
@@ -786,6 +786,19 @@ const UnitInertia& getUnitInertia_OB_G(const SBTreePositionCache& pc) const
 // *parent's* body frame P.
 const Transform& getX_GP(const SBTreePositionCache& pc) const {assert(parent); return parent->getX_GB(pc);}
 
+// These depend only on PositionKinematics but they are delayed until needed.
+
+// Composite body inertias.
+const SpatialInertia& getR(const SBCompositeBodyInertiaCache& cbc) const {return fromB(cbc.compositeBodyInertia);}
+SpatialInertia&       updR(SBCompositeBodyInertiaCache&       cbc) const {return toB  (cbc.compositeBodyInertia);}
+
+// Articulated body inertias and related calculations
+const ArticulatedInertia& getP(const SBArticulatedBodyInertiaCache& abc) const {return fromB(abc.articulatedBodyInertia);}
+ArticulatedInertia&       updP(SBArticulatedBodyInertiaCache&       abc) const {return toB  (abc.articulatedBodyInertia);}
+
+const ArticulatedInertia& getPPlus(const SBArticulatedBodyInertiaCache& abc) const {return fromB(abc.pPlus);}
+ArticulatedInertia&       updPPlus(SBArticulatedBodyInertiaCache&       abc) const {return toB  (abc.pPlus);}
+
         // VELOCITY INFO
 
 const SpatialVec& getV_FM(const SBTreeVelocityCache& vc) const {return fromB(vc.mobilizerRelativeVelocity);}
@@ -874,35 +887,31 @@ SpatialVec&       updTotalCoriolisAcceleration(SBTreeVelocityCache&       vc) co
 const SpatialVec& getTotalCentrifugalForces(const SBTreeVelocityCache& vc) const {return fromB(vc.totalCentrifugalForces);}
 SpatialVec&       updTotalCentrifugalForces(SBTreeVelocityCache&       vc) const {return toB  (vc.totalCentrifugalForces);}
 
+// This requires both velocity kinematics (from SBTreeVelocityCache) and 
+// articulated body inertias (from SBArticulatedBodyInertiaCache).
+const SpatialVec& getArticulatedBodyCentrifugalForces
+   (const SBArticulatedBodyVelocityCache& abvc) const 
+{   return fromB(abvc.articulatedBodyCentrifugalForces); }
+SpatialVec& updArticulatedBodyCentrifugalForces
+   (SBArticulatedBodyVelocityCache& abvc) const 
+{   return toB(abvc.articulatedBodyCentrifugalForces); }
+
+
     // DYNAMICS INFO
 
-// Composite body inertias.
-const SpatialInertia& getR(const SBCompositeBodyInertiaCache& cbc) const {return fromB(cbc.compositeBodyInertia);}
-SpatialInertia&       updR(SBCompositeBodyInertiaCache&       cbc) const {return toB  (cbc.compositeBodyInertia);}
+const SpatialMat& getY(const SBDynamicsCache& dc) const {return fromB(dc.Y);}
+SpatialMat&       updY(SBDynamicsCache&       dc) const {return toB  (dc.Y);}
 
-// Articulated body inertias and related calculations
-const ArticulatedInertia& getP(const SBArticulatedBodyInertiaCache& abc) const {return fromB(abc.articulatedBodyInertia);}
-ArticulatedInertia&       updP(SBArticulatedBodyInertiaCache&       abc) const {return toB  (abc.articulatedBodyInertia);}
 
-const ArticulatedInertia& getPPlus(const SBArticulatedBodyInertiaCache& abc) const {return fromB(abc.pPlus);}
-ArticulatedInertia&       updPPlus(SBArticulatedBodyInertiaCache&       abc) const {return toB  (abc.pPlus);}
 
-// Others
 
-const SpatialVec& getMobilizerCentrifugalForces(const SBDynamicsCache& dc) const {return fromB(dc.mobilizerCentrifugalForces);}
-SpatialVec&       updMobilizerCentrifugalForces(SBDynamicsCache&       dc) const {return toB  (dc.mobilizerCentrifugalForces);}
+    // ACCELERATION INFO
 
 const SpatialVec& getZ(const SBTreeAccelerationCache& tac) const {return fromB(tac.z);}
 SpatialVec&       updZ(SBTreeAccelerationCache&       tac) const {return toB  (tac.z);}
 
 const SpatialVec& getZPlus(const SBTreeAccelerationCache& tac) const {return fromB(tac.zPlus);}
 SpatialVec&       updZPlus(SBTreeAccelerationCache&       tac) const {return toB  (tac.zPlus);}
-
-
-const SpatialMat& getY(const SBDynamicsCache& dc) const {return fromB(dc.Y);}
-SpatialMat&       updY(SBDynamicsCache&       dc) const {return toB  (dc.Y);}
-
-    // ACCELERATION INFO
 
 // Extract from the cache A_GB, the spatial acceleration of this body's frame B measured in and
 // expressed in ground. This contains the inertial angular acceleration of B in G, and the
@@ -977,13 +986,13 @@ void calcJointIndependentKinematicsVel(
     const SBTreePositionCache& pc,
     SBTreeVelocityCache&       vc) const;
 
-// Calculate velocity-dependent quantities which will be needed for
-// computing accelerations.
-void calcJointIndependentDynamicsVel(
+// Calculate velocity-dependent quantities that involve articulated body
+// inertias and are needed for computing accelerations.
+void realizeArticulatedBodyVelocityCache(
     const SBTreePositionCache&              pc,
-    const SBArticulatedBodyInertiaCache&    abc,
     const SBTreeVelocityCache&              vc,
-    SBDynamicsCache&                        dc) const;
+    const SBArticulatedBodyInertiaCache&    abc,
+    SBArticulatedBodyVelocityCache&         abvc) const;
 
 
 protected:

--- a/Simbody/src/RigidBodyNodeSpec.cpp
+++ b/Simbody/src/RigidBodyNodeSpec.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors: Derived from IVM code written by Charles Schwieters          *
  *                                                                            *
@@ -21,11 +21,9 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-/**@file
- * This file contains implementations of the base class methods for the
- * templatized class RigidBodyNodeSpec<dof, noR_FM, noX_MB, noR_PF>, and instantiations of the 
- * class for all possible values of the arguments.
- */
+/* This file contains implementations of the base class methods for the
+templatized class RigidBodyNodeSpec<dof, noR_FM, noX_MB, noR_PF>, and 
+instantiations of the class for all possible values of the arguments. */
 
 #include "SimbodyMatterSubsystemRep.h"
 #include "RigidBodyNode.h"
@@ -44,8 +42,9 @@
 // CAUTION: our H matrix definition is transposed from Jain and Schwieters.
 // Cost: 60 + 45*dof flops
 template<int dof, bool noR_FM, bool noX_MB, bool noR_PF> void
-RigidBodyNodeSpec<dof, noR_FM, noX_MB, noR_PF>::calcParentToChildVelocityJacobianInGround(
-    const SBModelVars&          mv,
+RigidBodyNodeSpec<dof, noR_FM, noX_MB, noR_PF>::
+calcParentToChildVelocityJacobianInGround
+   (const SBModelVars&          mv,
     const SBTreePositionCache&  pc, 
     HType&                      H_PB_G) const
 {
@@ -66,7 +65,7 @@ RigidBodyNodeSpec<dof, noR_FM, noX_MB, noR_PF>::calcParentToChildVelocityJacobia
         // want r_MB_F, that is, the vector from Mo to Bo, expressed in F
         const Vec3&     r_MB   = getX_MB().p();     // fixed
         const Rotation& R_FM   = getX_FM(pc).R();   // just calculated
-        const Vec3      r_MB_F = (noR_FM ? r_MB : R_FM*r_MB);         // 15 flops
+        const Vec3      r_MB_F = (noR_FM ? r_MB : R_FM*r_MB);       // 15 flops
         HType H_MB_F;
         H_MB_F[0] =  Vec3(0); // fills top row with zero
         H_MB_F[1] = -r_MB_F % H_FM[0]; // 9*dof (negation not actually done)
@@ -358,7 +357,7 @@ RigidBodyNodeSpec<dof, noR_FM, noX_MB, noR_PF>::calcUDotPass1Inward(
     const SBInstanceCache&                  ic,
     const SBTreePositionCache&              pc,
     const SBArticulatedBodyInertiaCache&    abc,
-    const SBDynamicsCache&                  dc,
+    const SBArticulatedBodyVelocityCache&   abvc,
     const Real*                             jointForces,
     const SpatialVec*                       bodyForces,
     const Real*                             allUDot,
@@ -378,7 +377,7 @@ RigidBodyNodeSpec<dof, noR_FM, noX_MB, noR_PF>::calcUDotPass1Inward(
     const HType&              G = getG(abc);
 
     // z = Pa+b - F
-    z = getMobilizerCentrifugalForces(dc) - F; // 6 flops
+    z = getArticulatedBodyCentrifugalForces(abvc) - F; // 6 flops
 
     // z += P H udot_p if prescribed
     if (isPrescribed && !isUDotKnownToBeZero(ic)) {

--- a/Simbody/src/RigidBodyNodeSpec.cpp
+++ b/Simbody/src/RigidBodyNodeSpec.cpp
@@ -824,7 +824,7 @@ multiplyBySystemJacobianTranspose(
 template<int dof, bool noR_FM, bool noX_MB, bool noR_PF> void
 RigidBodyNodeSpec<dof, noR_FM, noX_MB, noR_PF>::calcEquivalentJointForces(
     const SBTreePositionCache&  pc,
-    const SBDynamicsCache&      dc,
+    const SBTreeVelocityCache&  vc,
     const SpatialVec*           bodyForces,
     SpatialVec*                 allZ,
     Real*                       jointForces) const 
@@ -835,7 +835,7 @@ RigidBodyNodeSpec<dof, noR_FM, noX_MB, noR_PF>::calcEquivalentJointForces(
 
     // Centrifugal forces are MA+b where M is body spatial inertia,
     // A is total coriolis acceleration, and b is gyroscopic force.
-    z = myBodyForce - getTotalCentrifugalForces(dc);
+    z = myBodyForce - getTotalCentrifugalForces(vc);
 
     for (unsigned i=0; i<children.size(); ++i) {
         const SpatialVec& zChild    = allZ[children[i]->getNodeNum()];
@@ -847,18 +847,6 @@ RigidBodyNodeSpec<dof, noR_FM, noX_MB, noR_PF>::calcEquivalentJointForces(
     eps  = ~getH(pc) * z;
 }
 
-//
-// to be called from base to tip.
-//
-template<int dof, bool noR_FM, bool noX_MB, bool noR_PF> void
-RigidBodyNodeSpec<dof, noR_FM, noX_MB, noR_PF>::setVelFromSVel(
-    const SBTreePositionCache&  pc, 
-    const SBTreeVelocityCache&  mc,
-    const SpatialVec&           sVel, 
-    Vector&                     u) const 
-{
-    toU(u) = ~getH(pc) * (sVel - (~getPhi(pc) * parent->getV_GB(mc)));
-}
 
     ////////////////////
     // INSTANTIATIONS //

--- a/Simbody/src/RigidBodyNodeSpec.h
+++ b/Simbody/src/RigidBodyNodeSpec.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors:                                                              *
  *    Charles Schwieters (NIH): wrote the public domain IVM code from which   *
@@ -78,143 +78,155 @@ RigidBodyNodeSpec(const MassProperties& mProps_B,
     qIndex   = nextQSlot;
 }
 
-void updateSlots(UIndex& nextUSlot, USquaredIndex& nextUSqSlot, QIndex& nextQSlot) {
+void updateSlots(UIndex& nextUSlot, USquaredIndex& nextUSqSlot, 
+                 QIndex& nextQSlot) {
     // OK to call virtual method here.
     nextUSlot   += getDOF();
     nextUSqSlot += getDOF()*getDOF();
     nextQSlot   += getMaxNQ();
 }
 
-virtual ~RigidBodyNodeSpec() {}
+//------------------------------------------------------------------------------
+// These override RigidBodyNode virtuals. Note that not all pure virtuals
+// are overridden here; RigidBodyNodeSpec is still abstract.   
 
-// This is the type of the joint transition matrix H, but our definition
-// of H is transposed from Jain's or Schwieters'. That is, what we're 
-// calling H here is what Jain calls H* and Schwieters calls H^T. So
-// our H matrix is 6 x nu, or more usefully it is 2 rows of Vec3's.
-// The first row define how u's contribute to angular velocities; the
-// second defines how u's contribute to linear velocities.
-typedef Mat<2,dof,Vec3> HType;
+~RigidBodyNodeSpec() override = default;
 
-// Provide default implementations for setQToFitTransformImpl() and setQToFitVelocityImpl() 
-// which are implemented using the rotational and translational quantity routines. These assume
-// that the rotational and translational coordinates are independent, with rotation handled
-// first and then left alone. If a mobilizer type needs to deal with rotation and
-// translation simultaneously, it should provide a specific implementation for these two routines.
-// *Each* mobilizer must implement setQToFit{Rotation,Translation} and 
-// setUToFit{AngularVelocity,LinearVelocity}; there are no defaults.
-
-virtual void setQToFitTransformImpl(const SBStateDigest& sbs, const Transform& X_FM, Vector& q) const {
-    setQToFitRotationImpl   (sbs,X_FM.R(),q);
-    setQToFitTranslationImpl(sbs,X_FM.p(),q);
+int getDOF() const override {return dof;}
+int getMaxNQ() const override {
+    assert(quaternionUse == QuaternionIsNeverUsed);
+    return dof; // maxNQ can be larger than dof if there's a quaternion
 }
 
-virtual void setUToFitVelocityImpl(const SBStateDigest& sbs, const Vector& q, const SpatialVec& V_FM, Vector& u) const {
-    setUToFitAngularVelocityImpl(sbs,q,V_FM[0],u);
-    setUToFitLinearVelocityImpl (sbs,q,V_FM[1],u);
+// Default method must be overridden if there is a chance that NQ
+// might not be the same as NU.
+int getNQInUse(const SBModelVars&) const override {
+    assert(quaternionUse == QuaternionIsNeverUsed); 
+    return dof; // DOF <= NQ <= maxNQ
 }
 
-// The following routines calculate joint-specific position kinematic
-// quantities. They may assume that *all* position kinematics (not just
-// joint-specific) has been done for the parent, and that the position
-// state variables q are available. Each routine may also assume that the
-// previous routines have been called, in the order below.
-// The routines are structured as operators -- they use the State but
-// do not change anything in it, including the cache. Instead they are
-// passed arguments to write their results into. In practice, these
-// arguments will typically be in the State cache (see below).
+// Currently NU is always just the Mobilizer's DOFs (the template argument)
+// Later we may want to offer modeling options to lock joints, or perhaps
+// break them.
+int getNUInUse(const SBModelVars&) const override {
+    return dof;
+}
 
+// Default method must be overridden if this mobilizer might use a
+// quaternion under some conditions.
+bool isUsingQuaternion(const SBStateDigest&, 
+                       MobilizerQIndex& startOfQuaternion) const override {
+    assert(quaternionUse == QuaternionIsNeverUsed);
+    startOfQuaternion.invalidate();
+    return false;
+}
 
-// This mandatory routine calculates the joint transition matrix H_FM, giving
-// the change of velocity induced by the generalized speeds u for this 
-// mobilizer, expressed in the mobilizer's inboard "fixed" frame F (attached to
-// this body's parent). 
-// This method constitutes the *definition* of the generalized speeds for
-// a particular joint.
-// This routine can depend on X_FM having already
-// been calculated and available in the PositionCache but must NOT depend
-// on any quantities involving Ground or other bodies.
-// Note: this calculates the H matrix *as defined*; we might reverse
-// the frames in use. So we call this H_F0M0 while the possibly reversed
-// version is H_FM. Be sure to use X_F0M0 in your calculation for H_F0M0
-// if you need access to the cross-mobilizer transform.
-// CAUTION: our definition of H is transposed from Jain and Schwieters.
-virtual void calcAcrossJointVelocityJacobian(
-    const SBStateDigest& sbs,
-    HType&               H_F0M0) const=0;
+// Concrete mobilizer must override calcQDot() and calcQDotDot() if qdot might 
+// not be be the same as u under *any* circumstance.
 
-// This mandatory routine calculates the time derivative taken in F of
-// the matrix H_FM (call it HDot_FM). This is zero if the generalized
-// speeds are all defined in terms of the F frame, which is often the case.
-// This routine can depend on X_FM and H_FM being available already in
-// the state PositionCache, and V_FM being already in the state VelocityCache.
-// However, it must NOT depend on any quantities involving Ground or other bodies.
-// Note: this calculates the HDot matrix *as defined*; we might reverse
-// the frames in use. So we call this HDot_F0M0 while the possibly reversed
-// version is HDot_FM. Be sure to use X_F0M0 and V_F0M0 in your calculation
-// of HDot_F0M0 if you need access to the cross-mobilizer transform and/or velocity.
-// CAUTION: our definition of H is transposed from Jain and Schwieters.
-virtual void calcAcrossJointVelocityJacobianDot(
-    const SBStateDigest& sbs,
-    HType&               HDot_F0M0) const = 0;
-
-// We allow a mobilizer to be defined in reverse when that is more
-// convenient. That is, the H matrix can be defined by giving H_F0M0=H_MF and 
-// HDot_F0M0=HDot_MF instead of H_FM and HDot_FM. In that case the 
-// following methods are called instead of the above; the default 
-// implementation postprocesses the output from the above methods, but a 
-// mobilizer can override it if it knows how to get the job done faster.
-virtual void calcReverseMobilizerH_FM(
-    const SBStateDigest& sbs,
-    HType&               H_FM) const;
-
-virtual void calcReverseMobilizerHDot_FM(
-    const SBStateDigest& sbs,
-    HType&               HDot_FM) const;
-
-// This routine is NOT joint specific, but cannot be called until the across-joint
-// transform X_FM has been calculated and is available in the State cache.
-void calcBodyTransforms(
-    const SBTreePositionCache&  pc, 
-    Transform&                  X_PB, 
-    Transform&                  X_GB) const 
+// This method should calculate qdot=N*u, where N=N(q) is the kinematic
+// coupling matrix. State digest should be at Stage::Position.
+void calcQDot(const SBStateDigest&, 
+              const Real* u, Real* qdot) const override 
 {
-    const Transform& X_MB = getX_MB();   // fixed
-    const Transform& X_PF = getX_PF();   // fixed
-    const Transform& X_FM = getX_FM(pc); // just calculated
-    const Transform& X_GP = getX_GP(pc); // already calculated
-
-    const Transform X_FB = (noX_MB ? X_FM : X_FM*X_MB); // 63 flops
-    X_PB = (noR_PF ? Transform(X_FB.R(), X_PF.p()+X_FB.p()) : X_PF*X_FB); // 63 flops
-    X_GB = X_GP * X_PB;        //  63 flops
+    assert(qdotHandling == QDotIsAlwaysTheSameAsU);
+    Vec<dof>::updAs(qdot) = Vec<dof>::getAs(u); // default says qdot=u
 }
 
-// Same for all mobilizers. The return matrix here is precisely the 
-// one used by Jain and Schwieters, but transposed.
-void calcParentToChildVelocityJacobianInGround(
-    const SBModelVars&          mv,
-    const SBTreePositionCache&  pc, 
-    HType&                      H_PB_G) const;
+// This method should calculate qdotdot=N*udot + NDot*u, where N=N(q),
+// NDot=NDot(q,u). State digest should be at Stage::Velocity.
+void calcQDotDot(const SBStateDigest&, 
+                         const Real* udot, Real* qdotdot) const override
+{
+    assert(qdotHandling == QDotIsAlwaysTheSameAsU);
+    Vec<dof>::updAs(qdotdot) = Vec<dof>::getAs(udot); // default: qdotdot=udot
+}
 
-// Same for all mobilizers. This is the time derivative of 
-// the matrix H_PB_G above, with the derivative taken in the 
-// Ground frame.
-void calcParentToChildVelocityJacobianInGroundDot(
-    const SBModelVars&          mv,
-    const SBTreePositionCache&  pc, 
-    const SBTreeVelocityCache&  vc, 
-    HType&                      HDot_PB_G) const;
+// State digest should be at Stage::Position for calculating N (the matrix that
+// maps generalized speeds u to coordinate derivatives qdot, qdot=Nu). The 
+// default implementation assumes nq==nu and the nqXnu block of N corresponding 
+// to this mobilizer is identity. Then either operation (regardless of side) 
+// just copies nu numbers from in to out.
+//
+// THIS MUST BE OVERRIDDEN by any mobilizer for which nq != nu, or qdot != u.
+void multiplyByN(const SBStateDigest&, bool matrixOnRight,  
+                 const Real* in, Real* out) const override
+{
+    assert(qdotHandling == QDotIsAlwaysTheSameAsU);
+    Vec<dof>::updAs(out) = Vec<dof>::getAs(in);
+}
 
-void realizeModel(SBStateDigest& sbs) const 
+void multiplyByNInv(const SBStateDigest&, bool matrixOnRight, 
+                    const Real* in, Real* out) const override
+{
+    assert(qdotHandling == QDotIsAlwaysTheSameAsU);
+    Vec<dof>::updAs(out) = Vec<dof>::getAs(in);
+}
+
+// State digest should be at Stage::Velocity for calculating NDot (the matrix 
+// that is used in mapping generalized accelerations udot to coordinate 2nd 
+// derivatives qdotdot, qdotdot=N udot + NDot u. The default implementation 
+// assumes nq==nu and the nqXnu block of N corresponding to this mobilizer is 
+// identity, so NDot is an nuXnu block of zeroes. Then either operation 
+// (regardless of side) just copies nu zeros to out.
+//
+// THIS MUST BE OVERRIDDEN by any mobilizer for which nq != nu, or qdot != u.
+void multiplyByNDot(const SBStateDigest&, bool matrixOnRight, 
+                    const Real* in, Real* out) const override
+{
+    assert(qdotHandling == QDotIsAlwaysTheSameAsU);
+    Vec<dof>::updAs(out) = 0;
+}
+
+// Return true if any change is made to the q vector.
+bool enforceQuaternionConstraints(
+    const SBStateDigest&    sbs,
+    Vector&                 q,
+    Vector&                 qErrest) const override
+{
+    assert(quaternionUse == QuaternionIsNeverUsed);
+    return false;
+}
+
+
+void convertToEulerAngles(const Vector& inputQ, 
+                          Vector& outputQ) const override {
+    // The default implementation just copies Q.  Subclasses may override this.
+    assert(quaternionUse == QuaternionIsNeverUsed);
+    toQ(outputQ) = fromQ(inputQ);
+}
+
+void convertToQuaternions(const Vector& inputQ, 
+                          Vector& outputQ) const override {
+    // The default implementation just copies Q.  Subclasses may override this.
+    assert(quaternionUse == QuaternionIsNeverUsed);
+    toQ(outputQ) = fromQ(inputQ);
+}
+
+// These routines give each node a chance to set appropriate defaults in a piece
+// of the state corresponding to a particular stage. Default implementations here
+// assume non-ball joint; override if necessary.
+//      setMobilizerDefault{Model,Instance,Time,Dynamics,Acceleration}Values
+//          retain base class do-nothing default implementation.
+void setMobilizerDefaultPositionValues(const SBModelVars& s, 
+                                       Vector& q) const override 
+{   toQ(q) = 0; }
+
+void setMobilizerDefaultVelocityValues(const SBModelVars&, 
+                                       Vector& u) const override 
+{   toU(u) = 0; }
+
+void realizeModel(SBStateDigest& sbs) const override 
 {
 }
 
-void realizeInstance(const SBStateDigest& sbs) const
+void realizeInstance(const SBStateDigest& sbs) const override
 {
 }
 
 // Set a new configuration and calculate the consequent kinematics.
 // Must call base-to-tip.
-void realizePosition(const SBStateDigest& sbs) const 
+void realizePosition(const SBStateDigest& sbs) const override 
 {
     const SBModelVars&      mv   = sbs.getModelVars();
     const SBModelCache&     mc   = sbs.getModelCache();
@@ -290,7 +302,7 @@ void realizePosition(const SBStateDigest& sbs) const
 //   HDot    time derivative of H (==H_PB_G) hinge matrix relating body frames
 //   VD_PB_G acceleration remainder term HDot*u, expr. in G
 // The code is the same for all joints, although parametrized by ndof.
-void realizeVelocity(const SBStateDigest& sbs) const 
+void realizeVelocity(const SBStateDigest& sbs) const override
 {
     const SBModelVars&          mv = sbs.getModelVars();
     const SBTreePositionCache&  pc = sbs.getTreePositionCache();
@@ -322,7 +334,7 @@ void realizeVelocity(const SBStateDigest& sbs) const
 
 // Articulated body inertias have been calculated; here we're 
 void realizeDynamics(const SBArticulatedBodyInertiaCache&   abc,
-                     const SBStateDigest&                   sbs) const 
+                     const SBStateDigest&                   sbs) const override
 {
     const SBTreePositionCache&  pc = sbs.getTreePositionCache();
     const SBTreeVelocityCache&  vc = sbs.getTreeVelocityCache();
@@ -337,7 +349,7 @@ void realizeDynamics(const SBArticulatedBodyInertiaCache&   abc,
 
 // There is no realizeAcceleration().
 
-void realizeReport(const SBStateDigest& sbs) const
+void realizeReport(const SBStateDigest& sbs) const override
 {
 }
 
@@ -348,9 +360,7 @@ void realizeReport(const SBStateDigest& sbs) const
 void realizeArticulatedBodyInertiasInward(
     const SBInstanceCache&          ic,
     const SBTreePositionCache&      pc,
-    SBArticulatedBodyInertiaCache&  abc) const;
-
-// calcJointIndependentDynamicsVel() must be called after ArticulatedBodyInertias.
+    SBArticulatedBodyInertiaCache&  abc) const override;
 
 // This dynamics-stage calculation is needed for handling constraints. It
 // must be called base-to-tip (outward);
@@ -358,191 +368,243 @@ void realizeYOutward(
     const SBInstanceCache&                  ic,
     const SBTreePositionCache&              pc,
     const SBArticulatedBodyInertiaCache&    abc,
-    SBDynamicsCache&                        dc) const;
+    SBDynamicsCache&                        dc) const override;
 
-// These routines give each node a chance to set appropriate defaults in a piece
-// of the state corresponding to a particular stage. Default implementations here
-// assume non-ball joint; override if necessary.
-virtual void setMobilizerDefaultModelValues   (const SBTopologyCache&, SBModelVars&)  const {}
-virtual void setMobilizerDefaultInstanceValues(const SBModelVars&, SBInstanceVars&) const {}
-virtual void setMobilizerDefaultTimeValues    (const SBModelVars&, SBTimeVars&)    const {}
+void multiplyBySystemJacobian(
+    const SBTreePositionCache&  pc,
+    const Real*                 v,
+    SpatialVec*                 Jv) const override;
 
-virtual void setMobilizerDefaultPositionValues(const SBModelVars& s, Vector& q) const 
-{
-    toQ(q) = 0;
-}
-virtual void setMobilizerDefaultVelocityValues(const SBModelVars&, Vector& u) const 
-{
-    toU(u) = 0;
-}
-virtual void setMobilizerDefaultDynamicsValues(const SBModelVars&, SBDynamicsVars&) const {}
-virtual void setMobilizerDefaultAccelerationValues(const SBModelVars&, 
-                                                   SBDynamicsVars& v) const {}
-
-int          getDOF()            const {return dof;}
-virtual int  getMaxNQ()          const {
-    assert(quaternionUse == QuaternionIsNeverUsed);
-    return dof; // maxNQ can be larger than dof if there's a quaternion
-}
-
-// Default method must be overridden if there is a chance that NQ
-// might not be the same as NU.
-virtual int  getNQInUse(const SBModelVars&) const {
-    assert(quaternionUse == QuaternionIsNeverUsed); 
-    return dof; // DOF <= NQ <= maxNQ
-}
-
-// Currently NU is always just the Mobilizer's DOFs (the template argument)
-// Later we may want to offer modeling options to lock joints, or perhaps
-// break them.
-virtual int  getNUInUse(const SBModelVars&) const {
-    return dof;
-}
-
-// Default method must be overridden if this mobilizer might use a
-// quaternion under some conditions.
-virtual bool isUsingQuaternion(const SBStateDigest&, MobilizerQIndex& startOfQuaternion) const {
-    assert(quaternionUse == QuaternionIsNeverUsed);
-    startOfQuaternion.invalidate();
-    return false;
-}
-
-// You must override the next few methods if qdot might not be the same
-// as u under *any* circumstance.
-
-// This method should calculate qdot=N*u, where N=N(q) is the kinematic
-// coupling matrix. State digest should be at Stage::Position.
-virtual void calcQDot(const SBStateDigest&, 
-                      const Real* u, Real* qdot) const 
-{
-    assert(qdotHandling == QDotIsAlwaysTheSameAsU);
-    Vec<dof>::updAs(qdot) = Vec<dof>::getAs(u); // default says qdot=u
-}
-
-// This method should calculate u=N^-1*qdot, where N=N(q).
-// State digest should be at Stage::Position.
-virtual void calcLocalUFromLocalQDot(const SBStateDigest&, 
-                                     const Real* qdot, Real* u) const 
-{
-    assert(qdotHandling == QDotIsAlwaysTheSameAsU);
-    Vec<dof>::updAs(u) = Vec<dof>::getAs(qdot); // default says u=qdot
-}
-
-// This method should calculate qdotdot=N*udot + NDot*u, where N=N(q),
-// NDot=NDot(q,u). State digest should be at Stage::Velocity.
-virtual void calcQDotDot(const SBStateDigest&, 
-                         const Real* udot, Real* qdotdot) const
-{
-    assert(qdotHandling == QDotIsAlwaysTheSameAsU);
-    Vec<dof>::updAs(qdotdot) = Vec<dof>::getAs(udot); // default: qdotdot=udot
-}
-
-// This method should calculate udot=N^-1*(qdotdot-NDot*u), where N=N(q),
-// NDot=NDot(q,u). State digest should be at Stage::Velocity.
-virtual void calcLocalUDotFromLocalQDotDot(const SBStateDigest&, 
-                                           const Real* qdotdot, Real* udot) const
-{
-    assert(qdotHandling == QDotIsAlwaysTheSameAsU);
-    Vec<dof>::updAs(udot) = Vec<dof>::getAs(qdotdot); // default: udot=qdotdot
-}
-
-
-
-
-// State digest should be at Stage::Position for calculating N (the matrix that
-// maps generalized speeds u to coordinate derivatives qdot, qdot=Nu). The 
-// default implementation assumes nq==nu and the nqXnu block of N corresponding 
-// to this mobilizer is identity. Then either operation (regardless of side) 
-// just copies nu numbers from in to out.
-//
-// THIS MUST BE OVERRIDDEN by any mobilizer for which nq != nu, or qdot != u.
-virtual void multiplyByN(const SBStateDigest&, bool matrixOnRight,  
-                         const Real* in, Real* out) const
-{
-    assert(qdotHandling == QDotIsAlwaysTheSameAsU);
-    Vec<dof>::updAs(out) = Vec<dof>::getAs(in);
-}
-
-virtual void multiplyByNInv(const SBStateDigest&, bool matrixOnRight, 
-                            const Real* in, Real* out) const
-{
-    assert(qdotHandling == QDotIsAlwaysTheSameAsU);
-    Vec<dof>::updAs(out) = Vec<dof>::getAs(in);
-}
-
-// State digest should be at Stage::Velocity for calculating NDot (the matrix 
-// that is used in mapping generalized accelerations udot to coordinate 2nd 
-// derivatives qdotdot, qdotdot=N udot + NDot u. The default implementation 
-// assumes nq==nu and the nqXnu block of N corresponding to this mobilizer is 
-// identity, so NDot is an nuXnu block of zeroes. Then either operation 
-// (regardless of side) just copies nu zeros to out.
-//
-// THIS MUST BE OVERRIDDEN by any mobilizer for which nq != nu, or qdot != u.
-virtual void multiplyByNDot(const SBStateDigest&, bool matrixOnRight, 
-                            const Real* in, Real* out) const
-{
-    assert(qdotHandling == QDotIsAlwaysTheSameAsU);
-    Vec<dof>::updAs(out) = 0;
-}
-
-
-// No default implementations here for:
-// calcMobilizerTransformFromQ
-// calcMobilizerVelocityFromU
-// calcMobilizerAccelerationFromUDot
-// calcParentToChildTransformFromQ
-// calcParentToChildVelocityFromU
-// calcParentToChildAccelerationFromUDot
-
-
-virtual void setVelFromSVel(
+void multiplyBySystemJacobianTranspose(
     const SBTreePositionCache&  pc, 
+    SpatialVec*                 zTmp,
+    const SpatialVec*           X, 
+    Real*                       JtX) const override;
+
+void calcEquivalentJointForces(
+    const SBTreePositionCache&  pc,
     const SBTreeVelocityCache&  vc,
-    const SpatialVec&           sVel, 
-    Vector&                     u) const;
+    const SpatialVec*           bodyForces,
+    SpatialVec*                 allZ,
+    Real*                       jointForces) const override;
 
-// Return true if any change is made to the q vector.
-virtual bool enforceQuaternionConstraints(
-    const SBStateDigest&    sbs,
-    Vector&                 q,
-    Vector&                 qErrest) const 
-{
-    assert(quaternionUse == QuaternionIsNeverUsed);
-    return false;
-}
+void calcUDotPass1Inward(
+    const SBInstanceCache&      ic,
+    const SBTreePositionCache&  pc,
+    const SBArticulatedBodyInertiaCache&,
+    const SBDynamicsCache&      dc,
+    const Real*                 jointForces,
+    const SpatialVec*           bodyForces,
+    const Real*                 allUDot,
+    SpatialVec*                 allZ,
+    SpatialVec*                 allGepsilon,
+    Real*                       allEpsilon) const override;
 
-void convertToEulerAngles(const Vector& inputQ, Vector& outputQ) const {
-    // The default implementation just copies Q.  Subclasses may override this.
-    assert(quaternionUse == QuaternionIsNeverUsed);
-    toQ(outputQ) = fromQ(inputQ);
-}
+void calcUDotPass2Outward(
+    const SBInstanceCache&      ic,
+    const SBTreePositionCache&  pc,
+    const SBArticulatedBodyInertiaCache&,
+    const SBTreeVelocityCache&  vc,
+    const SBDynamicsCache&      dc,
+    const Real*                 epsilonTmp,
+    SpatialVec*                 allA_GB,
+    Real*                       allUDot,
+    Real*                       allTau) const override;
 
-void convertToQuaternions(const Vector& inputQ, Vector& outputQ) const {
-    // The default implementation just copies Q.  Subclasses may override this.
-    assert(quaternionUse == QuaternionIsNeverUsed);
-    toQ(outputQ) = fromQ(inputQ);
-}
+void multiplyByMInvPass1Inward(
+    const SBInstanceCache&      ic,
+    const SBTreePositionCache&  pc,
+    const SBArticulatedBodyInertiaCache&,
+    const Real*                 f,
+    SpatialVec*                 allZ,
+    SpatialVec*                 allGepsilon,
+    Real*                       allEpsilon) const override;
+
+void multiplyByMInvPass2Outward(
+    const SBInstanceCache&      ic,
+    const SBTreePositionCache&  pc,
+    const SBArticulatedBodyInertiaCache&,
+    const Real*                 epsilonTmp,
+    SpatialVec*                 allA_GB,
+    Real*                       allUDot) const override;
+
+// Also serves as pass 1 for inverse dynamics.
+void calcBodyAccelerationsFromUdotOutward(
+    const SBTreePositionCache&  pc,
+    const SBTreeVelocityCache&  vc,
+    const Real*                 allUDot,
+    SpatialVec*                 allA_GB) const override;
+
+void calcInverseDynamicsPass2Inward(
+    const SBTreePositionCache&  pc,
+    const SBTreeVelocityCache&  vc,
+    const SpatialVec*           allA_GB,
+    const Real*                 jointForces,
+    const SpatialVec*           bodyForces,
+    SpatialVec*                 allFTmp,
+    Real*                       allTau) const override; 
+
+void multiplyByMPass1Outward(
+    const SBTreePositionCache&  pc,
+    const Real*                 allUDot,
+    SpatialVec*                 allA_GB) const override;
+void multiplyByMPass2Inward(
+    const SBTreePositionCache&  pc,
+    const SpatialVec*           allA_GB,
+    SpatialVec*                 allFTmp,
+    Real*                       allTau) const override;
 
 // Get a column of H_PB_G, which is what Jain calls H* and Schwieters calls H^T.
-const SpatialVec& getHCol(const SBTreePositionCache& pc, int j) const {
+const SpatialVec& 
+getHCol(const SBTreePositionCache& pc, int j) const override {
     return getH(pc)(j);
 }
 
 // Get a column of H_FM the local cross-mobilizer hinge matrix expressed in the
 // parent (inboard) mobilizer frame F.
-const SpatialVec& getH_FMCol(const SBTreePositionCache& pc, int j) const {
+const SpatialVec& 
+getH_FMCol(const SBTreePositionCache& pc, int j) const override {
     return getH_FM(pc)(j);
 }
 
+// Provide default implementations for setQToFitTransformImpl() and 
+// setQToFitVelocityImpl() which are implemented using the rotational and 
+// translational quantity routines. These assume that the rotational and 
+// translational coordinates are independent, with rotation handled first and 
+// then left alone. If a mobilizer type needs to deal with rotation and
+// translation simultaneously, it should provide a specific implementation for 
+// these two routines. *Each* mobilizer must implement 
+// setQToFit{Rotation,Translation} and 
+// setUToFit{AngularVelocity,LinearVelocity}; there are no defaults.
+
+void setQToFitTransformImpl(const SBStateDigest& sbs, const Transform& X_FM, 
+                            Vector& q) const override {
+    setQToFitRotationImpl   (sbs,X_FM.R(),q);
+    setQToFitTranslationImpl(sbs,X_FM.p(),q);
+}
+
+void setUToFitVelocityImpl(const SBStateDigest& sbs, const Vector& q, 
+                           const SpatialVec& V_FM, Vector& u) const override {
+    setUToFitAngularVelocityImpl(sbs,q,V_FM[0],u);
+    setUToFitLinearVelocityImpl (sbs,q,V_FM[1],u);
+}
+
+// End of RigidBodyNode overrides.
+//------------------------------------------------------------------------------
+
+
+// The following routines calculate joint-specific position kinematic
+// quantities. They may assume that *all* position kinematics (not just
+// joint-specific) has been done for the parent, and that the position
+// state variables q are available. Each routine may also assume that the
+// previous routines have been called, in the order below.
+// The routines are structured as operators -- they use the State but
+// do not change anything in it, including the cache. Instead they are
+// passed arguments to write their results into. In practice, these
+// arguments will typically be in the State cache (see below).
+
+// This is the type of the joint transition matrix H, but our definition
+// of H is transposed from Jain's or Schwieters'. That is, what we're 
+// calling H here is what Jain calls H* and Schwieters calls H^T. So
+// our H matrix is 6 x nu, or more usefully it is 2 rows of Vec3's.
+// The first row define how u's contribute to angular velocities; the
+// second defines how u's contribute to linear velocities.
+typedef Mat<2,dof,Vec3> HType;
+
+// This mandatory routine calculates the joint transition matrix H_FM, giving
+// the change of velocity induced by the generalized speeds u for this 
+// mobilizer, expressed in the mobilizer's inboard "fixed" frame F (attached to
+// this body's parent). 
+// This method constitutes the *definition* of the generalized speeds for
+// a particular joint.
+// This routine can depend on X_FM having already
+// been calculated and available in the PositionCache but must NOT depend
+// on any quantities involving Ground or other bodies.
+// Note: this calculates the H matrix *as defined*; we might reverse
+// the frames in use. So we call this H_F0M0 while the possibly reversed
+// version is H_FM. Be sure to use X_F0M0 in your calculation for H_F0M0
+// if you need access to the cross-mobilizer transform.
+// CAUTION: our definition of H is transposed from Jain and Schwieters.
+virtual void calcAcrossJointVelocityJacobian(
+    const SBStateDigest& sbs,
+    HType&               H_F0M0) const = 0;
+
+// This mandatory routine calculates the time derivative taken in F of
+// the matrix H_FM (call it HDot_FM). This is zero if the generalized
+// speeds are all defined in terms of the F frame, which is often the case.
+// This routine can depend on X_FM and H_FM being available already in
+// the state PositionCache, and V_FM being already in the state VelocityCache.
+// However, it must NOT depend on any quantities involving Ground or other bodies.
+// Note: this calculates the HDot matrix *as defined*; we might reverse
+// the frames in use. So we call this HDot_F0M0 while the possibly reversed
+// version is HDot_FM. Be sure to use X_F0M0 and V_F0M0 in your calculation
+// of HDot_F0M0 if you need access to the cross-mobilizer transform and/or velocity.
+// CAUTION: our definition of H is transposed from Jain and Schwieters.
+virtual void calcAcrossJointVelocityJacobianDot(
+    const SBStateDigest& sbs,
+    HType&               HDot_F0M0) const = 0;
+
+// We allow a mobilizer to be defined in reverse when that is more
+// convenient. That is, the H matrix can be defined by giving H_F0M0=H_MF and 
+// HDot_F0M0=HDot_MF instead of H_FM and HDot_FM. In that case the 
+// following methods are called instead of the above; the default 
+// implementation postprocesses the output from the above methods, but a 
+// mobilizer can override it if it knows how to get the job done faster.
+virtual void calcReverseMobilizerH_FM(
+    const SBStateDigest& sbs,
+    HType&               H_FM) const;
+
+virtual void calcReverseMobilizerHDot_FM(
+    const SBStateDigest& sbs,
+    HType&               HDot_FM) const;
+
+// This routine is NOT joint specific, but cannot be called until the across-joint
+// transform X_FM has been calculated and is available in the State cache.
+void calcBodyTransforms(
+    const SBTreePositionCache&  pc, 
+    Transform&                  X_PB, 
+    Transform&                  X_GB) const 
+{
+    const Transform& X_MB = getX_MB();   // fixed
+    const Transform& X_PF = getX_PF();   // fixed
+    const Transform& X_FM = getX_FM(pc); // just calculated
+    const Transform& X_GP = getX_GP(pc); // already calculated
+
+    const Transform X_FB = (noX_MB ? X_FM                   // cheap
+                                   : X_FM*X_MB);            // 63 flops
+    X_PB = (noR_PF ? Transform(X_FB.R(), X_PF.p()+X_FB.p()) // cheap
+                   : X_PF*X_FB);                            // 63 flops
+    X_GB = X_GP * X_PB;                                     // 63 flops
+}
+
+// Same for all mobilizers. The return matrix here is precisely the 
+// one used by Jain and Schwieters, but transposed.
+void calcParentToChildVelocityJacobianInGround(
+    const SBModelVars&          mv,
+    const SBTreePositionCache&  pc, 
+    HType&                      H_PB_G) const;
+
+// Same for all mobilizers. This is the time derivative of 
+// the matrix H_PB_G above, with the derivative taken in the 
+// Ground frame.
+void calcParentToChildVelocityJacobianInGroundDot(
+    const SBModelVars&          mv,
+    const SBTreePositionCache&  pc, 
+    const SBTreeVelocityCache&  vc, 
+    HType&                      HDot_PB_G) const;
+
+
 // Access to body-oriented state and cache entries is the same for all nodes,
-// and joint oriented access is almost the same but parametrized by dof. There is a special
-// case for quaternions because they use an extra state variable, and although we don't
-// have to we make special scalar routines available for 1-dof joints. Note that all State access
-// routines are inline, not virtual, so the cost is just an indirection and an index.
+// and joint oriented access is almost the same but parametrized by dof. There 
+// is a special case for quaternions because they use an extra state variable, 
+// and although we don't have to we make special scalar routines available for
+// 1-dof joints. Note that all State access routines are inline, not virtual, so
+// the cost is just an indirection and an index.
 //
-// TODO: these inner-loop methods probably shouldn't be indexing a Vector, which requires
-// several indirections. Instead, the top-level caller should find the Real* data contained in the
-// Vector and then pass that to the RigidBodyNode routines which will call these ones.
+// TODO: these inner-loop methods probably shouldn't be indexing a Vector, which
+// requires several indirections. Instead, the top-level caller should find the 
+// Real* data contained in the Vector and then pass that to the RigidBodyNode 
+// routines which will call these ones.
 
 // General joint-dependent select-my-goodies-from-the-pool routines.
 const Vec<dof>&     fromQ  (const Real* q)   const {return Vec<dof>::getAs(&q[qIndex]);}
@@ -571,9 +633,9 @@ Vec3&       toQVec3  (      Real* q, int offs) const {return Vec3::updAs(&q[qInd
 const Vec3& fromUVec3(const Real* u, int offs) const {return Vec3::getAs(&u[uIndex+offs]);}
 Vec3&       toUVec3  (      Real* u, int offs) const {return Vec3::updAs(&u[uIndex+offs]);}
 
-// These provide an identical interface for when q,u are given as Vectors rather than Reals.
-
-const Vec<dof>&     fromQ  (const Vector& q)   const {return fromQ(&q[0]);} // convert to array of Real
+// These provide an identical interface for when q,u are given as Vectors rather 
+// than Reals. Just convert to array of reals and then use an above method.
+const Vec<dof>&     fromQ  (const Vector& q)   const {return fromQ(&q[0]);}
 Vec<dof>&           toQ    (      Vector& q)   const {return toQ  (&q[0]);}
 const Vec<dof>&     fromU  (const Vector& u)   const {return fromU(&u[0]);}
 Vec<dof>&           toU    (      Vector& u)   const {return toU  (&u[0]);}
@@ -587,18 +649,21 @@ Real&       to1U    (      Vector& u)   const {return to1U    (&u[0]);}
 const Real& from1USq(const Vector& uSq) const {return from1USq(&uSq[0]);}
 Real&       to1USq  (      Vector& uSq) const {return to1USq  (&uSq[0]);}
 
-// Same, specialized for quaternions. We're assuming that the quaternion comes first in the coordinates.
+// Same, specialized for quaternions. We're assuming that the quaternion comes 
+// first in the coordinates.
 const Vec4& fromQuat(const Vector& q) const {return fromQuat(&q[0]);}
 Vec4&       toQuat  (      Vector& q) const {return toQuat  (&q[0]);}
 
-// Extract a Vec3 from a Q-like or U-like object, beginning at an offset from the qIndex or uIndex.
+// Extract a Vec3 from a Q-like or U-like object, beginning at an offset from
+// the qIndex or uIndex.
 const Vec3& fromQVec3(const Vector& q, int offs) const {return fromQVec3(&q[0], offs);}
 Vec3&       toQVec3  (      Vector& q, int offs) const {return toQVec3  (&q[0], offs);}
 const Vec3& fromUVec3(const Vector& u, int offs) const {return fromUVec3(&u[0], offs);}
 Vec3&       toUVec3  (      Vector& u, int offs) const {return toUVec3  (&u[0], offs);}
 
-// Applications of the above extraction routines to particular interesting items in the State. Note
-// that you can't use these for quaternions since they extract "dof" items.
+// Applications of the above extraction routines to particular interesting items
+// in the State. Note that you can't use these for quaternions since they 
+// extract "dof" items.
 
 // Cache entries (cache is mutable in a const State)
 
@@ -607,152 +672,75 @@ Vec3&       toUVec3  (      Vector& u, int offs) const {return toUVec3  (&u[0], 
 
 // CAUTION: our H definition is transposed from Jain and Schwieters.
 const HType& getH_FM(const SBTreePositionCache& pc) const
-  { return HType::getAs(&pc.storageForH_FM[2*uIndex]); }
+{   return HType::getAs(&pc.storageForH_FM[2*uIndex]); }
 HType&       updH_FM(SBTreePositionCache& pc) const
-  { return HType::updAs(&pc.storageForH_FM[2*uIndex]); }
+{   return HType::updAs(&pc.storageForH_FM[2*uIndex]); }
 
 // "H" here should really be H_PB_G, that is, cross joint transition
 // matrix relating parent and body frames, but expressed in Ground.
 // CAUTION: our H definition is transposed from Jain and Schwieters.
 const HType& getH(const SBTreePositionCache& pc) const
-  { return HType::getAs(&pc.storageForH[2*uIndex]); }
+{   return HType::getAs(&pc.storageForH[2*uIndex]); }
 HType&       updH(SBTreePositionCache& pc) const
-  { return HType::updAs(&pc.storageForH[2*uIndex]); }
+{   return HType::updAs(&pc.storageForH[2*uIndex]); }
 
     // Velocity
 
 // CAUTION: our H definition is transposed from Jain and Schwieters.
 const HType& getHDot_FM(const SBTreeVelocityCache& vc) const
-  { return HType::getAs(&vc.storageForHDot_FM[2*uIndex]); }
+{   return HType::getAs(&vc.storageForHDot_FM[2*uIndex]); }
 HType&       updHDot_FM(SBTreeVelocityCache& vc) const
-  { return HType::updAs(&vc.storageForHDot_FM[2*uIndex]); }
+{   return HType::updAs(&vc.storageForHDot_FM[2*uIndex]); }
 
 // CAUTION: our H definition is transposed from Jain and Schwieters.
 const HType& getHDot(const SBTreeVelocityCache& vc) const
-  { return HType::getAs(&vc.storageForHDot[2*uIndex]); }
+{   return HType::getAs(&vc.storageForHDot[2*uIndex]); }
 HType&       updHDot(SBTreeVelocityCache& vc) const
-  { return HType::updAs(&vc.storageForHDot[2*uIndex]); }
+{   return HType::updAs(&vc.storageForHDot[2*uIndex]); }
 
     // Dynamics
 
 // These are calculated with articulated body inertias.
 const Mat<dof,dof>& getD(const SBArticulatedBodyInertiaCache& abc) const 
-{return fromUSq(abc.storageForD);}
+{   return fromUSq(abc.storageForD); }
 Mat<dof,dof>&       updD(SBArticulatedBodyInertiaCache&       abc) const 
-{return toUSq  (abc.storageForD);}
+{   return toUSq  (abc.storageForD); }
 
 const Mat<dof,dof>& getDI(const SBArticulatedBodyInertiaCache& abc) const 
-{return fromUSq(abc.storageForDI);}
+{   return fromUSq(abc.storageForDI); }
 Mat<dof,dof>&       updDI(SBArticulatedBodyInertiaCache&       abc) const 
-{return toUSq  (abc.storageForDI);}
+{   return toUSq  (abc.storageForDI); }
 
 const Mat<2,dof,Vec3>& getG(const SBArticulatedBodyInertiaCache& abc) const
-  { return Mat<2,dof,Vec3>::getAs(&abc.storageForG[2*uIndex]); }
+{   return Mat<2,dof,Vec3>::getAs(&abc.storageForG[2*uIndex]); }
 Mat<2,dof,Vec3>&       updG(SBArticulatedBodyInertiaCache&       abc) const
-  { return Mat<2,dof,Vec3>::updAs(&abc.storageForG[2*uIndex]); }
+{   return Mat<2,dof,Vec3>::updAs(&abc.storageForG[2*uIndex]); }
 
 const Vec<dof>& getTau(const SBInstanceCache& ic, const Real* tau) const {
-    const PresForcePoolIndex tauIx = ic.getMobodInstanceInfo(nodeNum).firstPresForce;
+    const PresForcePoolIndex tauIx = 
+        ic.getMobodInstanceInfo(nodeNum).firstPresForce;
     assert(tauIx.isValid());
     return Vec<dof>::getAs(&tau[tauIx]);
 }
 Vec<dof>& updTau(const SBInstanceCache& ic, Real* tau) const {
-    const PresForcePoolIndex tauIx = ic.getMobodInstanceInfo(nodeNum).firstPresForce;
+    const PresForcePoolIndex tauIx = 
+        ic.getMobodInstanceInfo(nodeNum).firstPresForce;
     assert(tauIx.isValid());
     return Vec<dof>::updAs(&tau[tauIx]);
 }
 
     // Acceleration
 
-const Vec<dof>&   getEpsilon (const SBTreeAccelerationCache& ac) const {return fromU (ac.epsilon);}
-Vec<dof>&         updEpsilon (SBTreeAccelerationCache&       ac) const {return toU   (ac.epsilon);}
-const Real&       get1Epsilon(const SBTreeAccelerationCache& ac) const {return from1U(ac.epsilon);}
-Real&             upd1Epsilon(SBTreeAccelerationCache&       ac) const {return to1U  (ac.epsilon);}
+const Vec<dof>& getEpsilon (const SBTreeAccelerationCache& ac) const
+{   return fromU (ac.epsilon); }
+Vec<dof>& updEpsilon (SBTreeAccelerationCache& ac) const
+{   return toU   (ac.epsilon); }
+const Real& get1Epsilon(const SBTreeAccelerationCache& ac) const
+{   return from1U(ac.epsilon); }
+Real& upd1Epsilon(SBTreeAccelerationCache& ac) const
+{   return to1U  (ac.epsilon); }
 
 
-void multiplyBySystemJacobian(
-    const SBTreePositionCache&  pc,
-    const Real*                 v,
-    SpatialVec*                 Jv) const;
-
-void multiplyBySystemJacobianTranspose(
-    const SBTreePositionCache&  pc, 
-    SpatialVec*                 zTmp,
-    const SpatialVec*           X, 
-    Real*                       JtX) const;
-
-void calcEquivalentJointForces(
-    const SBTreePositionCache&  pc,
-    const SBDynamicsCache&      dc,
-    const SpatialVec*           bodyForces,
-    SpatialVec*                 allZ,
-    Real*                       jointForces) const;
-
-void calcUDotPass1Inward(
-    const SBInstanceCache&      ic,
-    const SBTreePositionCache&  pc,
-    const SBArticulatedBodyInertiaCache&,
-    const SBDynamicsCache&      dc,
-    const Real*                 jointForces,
-    const SpatialVec*           bodyForces,
-    const Real*                 allUDot,
-    SpatialVec*                 allZ,
-    SpatialVec*                 allGepsilon,
-    Real*                       allEpsilon) const;
-
-void calcUDotPass2Outward(
-    const SBInstanceCache&      ic,
-    const SBTreePositionCache&  pc,
-    const SBArticulatedBodyInertiaCache&,
-    const SBTreeVelocityCache&  vc,
-    const SBDynamicsCache&      dc,
-    const Real*                 epsilonTmp,
-    SpatialVec*                 allA_GB,
-    Real*                       allUDot,
-    Real*                       allTau) const;
-
-void multiplyByMInvPass1Inward(
-    const SBInstanceCache&      ic,
-    const SBTreePositionCache&  pc,
-    const SBArticulatedBodyInertiaCache&,
-    const Real*                 f,
-    SpatialVec*                 allZ,
-    SpatialVec*                 allGepsilon,
-    Real*                       allEpsilon) const override;
-
-void multiplyByMInvPass2Outward(
-    const SBInstanceCache&      ic,
-    const SBTreePositionCache&  pc,
-    const SBArticulatedBodyInertiaCache&,
-    const Real*                 epsilonTmp,
-    SpatialVec*                 allA_GB,
-    Real*                       allUDot) const override;
-
-// Also serves as pass 1 for inverse dynamics.
-void calcBodyAccelerationsFromUdotOutward(
-    const SBTreePositionCache&  pc,
-    const SBTreeVelocityCache&  vc,
-    const Real*                 allUDot,
-    SpatialVec*                 allA_GB) const;
-
-void calcInverseDynamicsPass2Inward(
-    const SBTreePositionCache&  pc,
-    const SBTreeVelocityCache&  vc,
-    const SpatialVec*           allA_GB,
-    const Real*                 jointForces,
-    const SpatialVec*           bodyForces,
-    SpatialVec*                 allFTmp,
-    Real*                       allTau) const; 
-
-void multiplyByMPass1Outward(
-    const SBTreePositionCache&  pc,
-    const Real*                 allUDot,
-    SpatialVec*                 allA_GB) const;
-void multiplyByMPass2Inward(
-    const SBTreePositionCache&  pc,
-    const SpatialVec*           allA_GB,
-    SpatialVec*                 allFTmp,
-    Real*                       allTau) const;
 
 };
 

--- a/Simbody/src/RigidBodyNodeSpec.h
+++ b/Simbody/src/RigidBodyNodeSpec.h
@@ -332,19 +332,9 @@ void realizeVelocity(const SBStateDigest& sbs) const override
     calcJointIndependentKinematicsVel(pc,vc);
 }
 
-// Articulated body inertias have been calculated; here we're 
-void realizeDynamics(const SBArticulatedBodyInertiaCache&   abc,
-                     const SBStateDigest&                   sbs) const override
+void realizeDynamics(const SBStateDigest&) const override
 {
-    const SBTreePositionCache&  pc = sbs.getTreePositionCache();
-    const SBTreeVelocityCache&  vc = sbs.getTreeVelocityCache();
-    SBDynamicsCache&            dc = sbs.updDynamicsCache();
-
-    // Mobilizer-specific.
-    // None.
-
-    // Mobilizer independent.
-    calcJointIndependentDynamicsVel(pc,abc,vc,dc);
+    // nothing to do
 }
 
 // There is no realizeAcceleration().
@@ -353,8 +343,9 @@ void realizeReport(const SBStateDigest& sbs) const override
 {
 }
 
-// Use base class implementation of calcCompositeBodyInertiasInward() since
-// that is independent of mobilities.
+// Use base class implementations of calcCompositeBodyInertiasInward()
+// and realizeArticulatedBodyVelocityCache() since they are independent of 
+// mobilities.
 
 // This is a dynamics-stage calculation and must be called tip-to-base (inward).
 void realizeArticulatedBodyInertiasInward(
@@ -392,7 +383,7 @@ void calcUDotPass1Inward(
     const SBInstanceCache&      ic,
     const SBTreePositionCache&  pc,
     const SBArticulatedBodyInertiaCache&,
-    const SBDynamicsCache&      dc,
+    const SBArticulatedBodyVelocityCache&,
     const Real*                 jointForces,
     const SpatialVec*           bodyForces,
     const Real*                 allUDot,

--- a/Simbody/src/RigidBodyNodeSpec_Derived.cpp
+++ b/Simbody/src/RigidBodyNodeSpec_Derived.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors: Peter Eastman, Charles Schwieters                            *
  *                                                                            *
@@ -47,7 +47,8 @@
 
 // A macro for instantiating rigid body nodes.
 #define INSTANTIATE(CLASS, ...) \
-    bool noX_MB = (getDefaultOutboardFrame().p() == 0 && getDefaultOutboardFrame().R() == Mat33(1)); \
+    bool noX_MB = (   getDefaultOutboardFrame().p() == 0 \
+                   && getDefaultOutboardFrame().R() == Mat33(1)); \
     bool noR_PF = (getDefaultInboardFrame().R() == Mat33(1)); \
     if (noX_MB) { \
         if (noR_PF) \

--- a/Simbody/src/RigidBodyNode_LoneParticle.cpp
+++ b/Simbody/src/RigidBodyNode_LoneParticle.cpp
@@ -155,8 +155,8 @@ void realizeInstance(const SBStateDigest& sbs) const {
     updGyroscopicForce(vc) = SpatialVec(Vec3(0), Vec3(0));
     updMobilizerCoriolisAcceleration(vc) = SpatialVec(Vec3(0), Vec3(0));
     updTotalCoriolisAcceleration(vc) = SpatialVec(Vec3(0), Vec3(0));
+    updTotalCentrifugalForces(vc) = SpatialVec(Vec3(0), Vec3(0));
     updMobilizerCentrifugalForces(dc) = SpatialVec(Vec3(0), Vec3(0));
-    updTotalCentrifugalForces(dc) = SpatialVec(Vec3(0), Vec3(0));
     updY(dc) = SpatialMat(Mat33(0), Mat33(0), Mat33(0), Mat33(1/getMass()));
     updA_GB(ac)[0] = Vec3(0);
 }
@@ -239,7 +239,7 @@ void multiplyBySystemJacobianTranspose(
 
 void calcEquivalentJointForces(
         const SBTreePositionCache&  pc,
-        const SBDynamicsCache&      dc,
+        const SBTreeVelocityCache&  vc,
         const SpatialVec*           bodyForces,
         SpatialVec*                 allZ,
         Real*                       jointForces) const {

--- a/Simbody/src/RigidBodyNode_LoneParticle.cpp
+++ b/Simbody/src/RigidBodyNode_LoneParticle.cpp
@@ -6,9 +6,9 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2011-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2011-15 Stanford University and the Authors.        *
  * Authors: Peter Eastman                                                     *
- * Contributors:                                                              *
+ * Contributors: Michael Sherman                                              *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -26,26 +26,23 @@
 #include "MobilizedBodyImpl.h"
 #include "RigidBodyNodeSpec_Translation.h"
 
-/**
- * This is a specialized class used for MobilizedBody::Translation objects that satisfy
- * all of the following requirements:
- * 
- * <ul>
- * <li>The body has no children.</li>
- * <li>The body's parent is ground.</li>
- * <li>The inboard and outboard transforms are both identities.</li>
- * <li>The body is not reversed.</li>
- * </ul>
- * 
- * These assumptions allow lots of routines to be implemented in simpler, faster ways.
+/* This is a specialized class used for MobilizedBody::Translation objects that 
+satisfy all of the following requirements:
+ -  The body has no children.
+ -  The body's parent is ground.
+ -  The inboard and outboard transforms are both identities.
+ -  The body is not reversed.
+
+ These assumptions allow lots of routines to be implemented simpler and faster.
  */
 class RBNodeLoneParticle : public RigidBodyNode {
 public:
 RBNodeLoneParticle(const MassProperties& mProps_B,
-                UIndex&               nextUSlot,
-                USquaredIndex&        nextUSqSlot,
-                QIndex&               nextQSlot)
-  : RigidBodyNode(mProps_B, Vec3(0), Vec3(0), QDotIsAlwaysTheSameAsU, QuaternionIsNeverUsed, false) {
+                   UIndex&               nextUSlot,
+                   USquaredIndex&        nextUSqSlot,
+                   QIndex&               nextQSlot)
+:   RigidBodyNode(mProps_B, Vec3(0), Vec3(0), 
+                  QDotIsAlwaysTheSameAsU, QuaternionIsNeverUsed, false) {
     uIndex = nextUSlot;
     uSqIndex = nextUSqSlot;
     qIndex = nextQSlot;
@@ -54,92 +51,95 @@ RBNodeLoneParticle(const MassProperties& mProps_B,
     nextQSlot += 3;
 }
 
-const char* type() const {return "loneparticle";}
-int  getDOF() const {return 3;}
-int  getMaxNQ() const {return 3;}
+const char* type() const override {return "loneparticle";}
+int  getDOF() const override {return 3;}
+int  getMaxNQ() const override {return 3;}
 
-int getNQInUse(const SBModelVars&) const {return 3;}
-int getNUInUse(const SBModelVars&) const {return 3;}
+int getNQInUse(const SBModelVars&) const override {return 3;}
+int getNUInUse(const SBModelVars&) const override {return 3;}
 
-bool isUsingQuaternion(const SBStateDigest&, MobilizerQIndex& startOfQuaternion) const {
+bool isUsingQuaternion(const SBStateDigest&, 
+                       MobilizerQIndex& startOfQuaternion) const override {
     return false;
 }
 
-bool isUsingAngles(const SBStateDigest&, MobilizerQIndex& startOfAngles, int& nAngles) const {
-    return false;
-}
-
-int calcQPoolSize(const SBModelVars&) const {
+int calcQPoolSize(const SBModelVars&) const override {
     return 0;
 }
 
 void performQPrecalculations(const SBStateDigest& sbs,
                              const Real* q, int nq,
                              Real* qCache,  int nQCache,
-                             Real* qErr,    int nQErr) const {
+                             Real* qErr,    int nQErr) const override {
     assert(q && nq==3 && nQCache==0 && nQErr==0);
 }
 
 void calcX_FM(const SBStateDigest& sbs,
               const Real* q,      int nq,
               const Real* qCache, int nQCache,
-              Transform&  X_FM) const {
+              Transform&  X_FM) const override {
     assert(q && nq==3 && nQCache==0);
     X_FM = Transform(Rotation(), Vec3::getAs(&q[0]));
 }
 
-void calcQDot(const SBStateDigest&, const Real* u, Real* qdot) const {
+void calcQDot(const SBStateDigest&, const Real* u, Real* qdot) const override {
     Vec3::updAs(qdot) = Vec3::getAs(u);
 }
-void calcQDotDot(const SBStateDigest&, const Real* udot, Real* qdotdot) const {
+void calcQDotDot(const SBStateDigest&, const Real* udot, 
+                 Real* qdotdot) const override {
     Vec3::updAs(qdotdot) = Vec3::getAs(udot);
 }
 
-void multiplyByN(const SBStateDigest&, bool matrixOnRight, const Real* in, Real* out) const {
+void multiplyByN(const SBStateDigest&, bool matrixOnRight, const Real* in, 
+                 Real* out) const override {
     Vec3::updAs(out) = Vec3::getAs(in);
 }
-void multiplyByNInv(const SBStateDigest&, bool matrixOnRight, const Real* in, Real* out) const {
+void multiplyByNInv(const SBStateDigest&, bool matrixOnRight, const Real* in, 
+                    Real* out) const override {
     Vec3::updAs(out) = Vec3::getAs(in);
 }
-void multiplyByNDot(const SBStateDigest&, bool matrixOnRight, const Real* in, Real* out) const {
+void multiplyByNDot(const SBStateDigest&, bool matrixOnRight, const Real* in, 
+                    Real* out) const override {
     Vec3::updAs(out) = 0;
 }
 
 bool enforceQuaternionConstraints(
     const SBStateDigest& sbs,
     Vector&            q,
-    Vector&            qErrest) const {
+    Vector&            qErrest) const override {
     return false;
 }
 
-void convertToEulerAngles(const Vector& inputQ, Vector& outputQ) const {
+void convertToEulerAngles(const Vector& inputQ, 
+                          Vector& outputQ) const override {
     Vec3::updAs(&outputQ[qIndex]) = Vec3::getAs(&inputQ[qIndex]);
 }
 
-void convertToQuaternions(const Vector& inputQ, Vector& outputQ) const {
+void convertToQuaternions(const Vector& inputQ, 
+                          Vector& outputQ) const override {
     Vec3::updAs(&outputQ[qIndex]) = Vec3::getAs(&inputQ[qIndex]);
 }
 
 void setMobilizerDefaultModelValues
-   (const SBTopologyCache&, SBModelVars&)        const {}
+   (const SBTopologyCache&, SBModelVars&)        const override {}
 
 void setMobilizerDefaultInstanceValues    
-   (const SBModelVars&,     SBInstanceVars&)     const {}
+   (const SBModelVars&,     SBInstanceVars&)     const override {}
 void setMobilizerDefaultTimeValues        
-   (const SBModelVars&,     SBTimeVars&)         const {}
+   (const SBModelVars&,     SBTimeVars&)         const override {}
 void setMobilizerDefaultPositionValues    
-   (const SBModelVars&,     Vector& q)           const {q = 0;}
+   (const SBModelVars&,     Vector& q)           const override {q = 0;}
 void setMobilizerDefaultVelocityValues    
-   (const SBModelVars&,     Vector& u)           const {u = 0;}
+   (const SBModelVars&,     Vector& u)           const override {u = 0;}
 void setMobilizerDefaultDynamicsValues    
-   (const SBModelVars&,     SBDynamicsVars&)     const {}
+   (const SBModelVars&,     SBDynamicsVars&)     const override {}
 void setMobilizerDefaultAccelerationValues
-   (const SBModelVars&,     SBAccelerationVars&) const {}
+   (const SBModelVars&,     SBAccelerationVars&) const override {}
 
-void realizeModel(SBStateDigest& sbs) const {
+void realizeModel(SBStateDigest& sbs) const override {
 }
 
-void realizeInstance(const SBStateDigest& sbs) const {
+void realizeInstance(const SBStateDigest& sbs) const override {
     // Initialize cache entries that will never be changed at later stages.
     
     SBTreePositionCache& pc = sbs.updTreePositionCache();
@@ -156,12 +156,11 @@ void realizeInstance(const SBStateDigest& sbs) const {
     updMobilizerCoriolisAcceleration(vc) = SpatialVec(Vec3(0), Vec3(0));
     updTotalCoriolisAcceleration(vc) = SpatialVec(Vec3(0), Vec3(0));
     updTotalCentrifugalForces(vc) = SpatialVec(Vec3(0), Vec3(0));
-    updMobilizerCentrifugalForces(dc) = SpatialVec(Vec3(0), Vec3(0));
     updY(dc) = SpatialMat(Mat33(0), Mat33(0), Mat33(0), Mat33(1/getMass()));
     updA_GB(ac)[0] = Vec3(0);
 }
 
-void realizePosition(const SBStateDigest& sbs) const {
+void realizePosition(const SBStateDigest& sbs) const override {
     SBTreePositionCache& pc = sbs.updTreePositionCache();
     Transform& X_FM = toB(pc.bodyJointInParentJointFrame);
     const Vec3& q = Vec3::getAs(&sbs.getQ()[qIndex]);
@@ -173,7 +172,7 @@ void realizePosition(const SBStateDigest& sbs) const {
     updMk_G(pc) = SpatialInertia(getMass(), getCOM_B(), getUnitInertia_OB_B());
 }
 
-void realizeVelocity(const SBStateDigest& sbs) const {
+void realizeVelocity(const SBStateDigest& sbs) const override {
     SBTreeVelocityCache& vc = sbs.updTreeVelocityCache();
     const Vector& allU = sbs.getU();
     const Vec3& u = Vec3::getAs(&allU[uIndex]);
@@ -184,18 +183,18 @@ void realizeVelocity(const SBStateDigest& sbs) const {
     updV_GB(vc)[1] = u;
 }
 
-void realizeDynamics(const SBArticulatedBodyInertiaCache& abc, const SBStateDigest& sbs) const {
+void realizeDynamics(const SBStateDigest&) const override {
 }
 
 // There is no realizeAcceleration().
 
-void realizeReport(const SBStateDigest& sbs) const {
+void realizeReport(const SBStateDigest&) const override {
 }
 
 void realizeArticulatedBodyInertiasInward(
         const SBInstanceCache&          ic,
         const SBTreePositionCache&      pc,
-        SBArticulatedBodyInertiaCache&  abc) const {
+        SBArticulatedBodyInertiaCache&  abc) const override {
     ArticulatedInertia& P     = updP(abc);
     ArticulatedInertia& PPlus = updPPlus(abc);
 
@@ -206,19 +205,19 @@ void realizeYOutward(
             const SBInstanceCache&                ic,
             const SBTreePositionCache&            pc,
             const SBArticulatedBodyInertiaCache&  abc,
-            SBDynamicsCache&                      dc) const {
+            SBDynamicsCache&                      dc) const override {
 }
 
 void calcCompositeBodyInertiasInward
    (const SBTreePositionCache& pc, 
-    Array_<SpatialInertia,MobilizedBodyIndex>& R) const {
+    Array_<SpatialInertia,MobilizedBodyIndex>& R) const override {
     toB(R) = getMk_G(pc);
 }
 
 void multiplyBySystemJacobian(
         const SBTreePositionCache&  pc,
         const Real*                 v,
-        SpatialVec*                 Jv) const {
+        SpatialVec*                 Jv) const override {
     const Vec3& in = Vec3::getAs(&v[uIndex]);
     SpatialVec& out = Jv[nodeNum];
     out = ~getPhi(pc) * Jv[parent->getNodeNum()];
@@ -229,7 +228,7 @@ void multiplyBySystemJacobianTranspose(
         const SBTreePositionCache&  pc, 
         SpatialVec*                 zTmp,
         const SpatialVec*           X, 
-        Real*                       JtX) const {
+        Real*                       JtX) const override {
     const SpatialVec& in = X[getNodeNum()];
     Vec3& out = Vec3::updAs(&JtX[getUIndex()]);
     SpatialVec& z = zTmp[getNodeNum()];
@@ -242,7 +241,7 @@ void calcEquivalentJointForces(
         const SBTreeVelocityCache&  vc,
         const SpatialVec*           bodyForces,
         SpatialVec*                 allZ,
-        Real*                       jointForces) const {
+        Real*                       jointForces) const override {
     const SpatialVec& myBodyForce = bodyForces[nodeNum];
     SpatialVec& z = allZ[nodeNum];
     Vec3& eps = Vec3::updAs(&jointForces[uIndex]);
@@ -252,15 +251,15 @@ void calcEquivalentJointForces(
 
 void calcUDotPass1Inward(
         const SBInstanceCache&                  ic,
-        const SBTreePositionCache&              pc,
-        const SBArticulatedBodyInertiaCache&    abc,
-        const SBDynamicsCache&                  dc,
+        const SBTreePositionCache&,
+        const SBArticulatedBodyInertiaCache&,
+        const SBArticulatedBodyVelocityCache&,
         const Real*                             jointForces,
         const SpatialVec*                       bodyForces,
         const Real*                             allUDot,
         SpatialVec*                             allZ,
         SpatialVec*                             allZPlus,
-        Real*                                   allEpsilon) const 
+        Real*                                   allEpsilon) const override 
 {
     const Vec3&         f       = Vec3::getAs(&jointForces[uIndex]);
     const SpatialVec&   F       = bodyForces[nodeNum];
@@ -295,7 +294,7 @@ void calcUDotPass2Outward(
         const Real*                             allEpsilon,
         SpatialVec*                             allA_GB,
         Real*                                   allUDot,
-        Real*                                   allTau) const {
+        Real*                                   allTau) const override {
     const Vec3& eps = Vec3::getAs(&allEpsilon[uIndex]);
     SpatialVec& A_GB = allA_GB[nodeNum];
     Vec3& udot = Vec3::updAs(&allUDot[uIndex]);
@@ -364,7 +363,7 @@ void calcBodyAccelerationsFromUdotOutward(
         const SBTreePositionCache&  pc,
         const SBTreeVelocityCache&  vc,
         const Real*                 allUDot,
-        SpatialVec*                 allA_GB) const {
+        SpatialVec*                 allA_GB) const override {
     const Vec3& udot = Vec3::getAs(&allUDot[uIndex]);
     SpatialVec& A_GB = allA_GB[nodeNum];
     A_GB = SpatialVec(Vec3(0), udot);
@@ -376,7 +375,7 @@ void calcInverseDynamicsPass2Inward(
         const Real*                 jointForces,
         const SpatialVec*           bodyForces,
         SpatialVec*                 allF,
-        Real*                       allTau) const {
+        Real*                       allTau) const override {
     const Vec3& myJointForce = Vec3::getAs(&jointForces[uIndex]);
     const SpatialVec& myBodyForce = bodyForces[nodeNum];
     const SpatialVec& A_GB = allA_GB[nodeNum];
@@ -389,7 +388,7 @@ void calcInverseDynamicsPass2Inward(
 void multiplyByMPass1Outward(
         const SBTreePositionCache&  pc,
         const Real*                 allUDot,
-        SpatialVec*                 allA_GB) const {
+        SpatialVec*                 allA_GB) const override {
     const Vec3& udot = Vec3::getAs(&allUDot[uIndex]);
     SpatialVec& A_GB = allA_GB[nodeNum];
     A_GB = SpatialVec(Vec3(0), udot);
@@ -398,7 +397,7 @@ void multiplyByMPass2Inward(
         const SBTreePositionCache&  pc,
         const SpatialVec*           allA_GB,
         SpatialVec*                 allF,
-        Real*                       allTau) const {
+        Real*                       allTau) const override {
     const SpatialVec& A_GB = allA_GB[nodeNum];
     SpatialVec& F = allF[nodeNum];
     Vec3& tau = Vec3::updAs(&allTau[uIndex]);
@@ -406,7 +405,8 @@ void multiplyByMPass2Inward(
     tau = F[1];
 }
 
-const SpatialVec& getHCol(const SBTreePositionCache& pc, int j) const {
+const SpatialVec& getHCol(const SBTreePositionCache& pc, 
+                          int j) const override {
     Mat<2,3,Vec3> H = Mat<2,3,Vec3>::getAs(&pc.storageForH[2*uIndex]);
     SpatialVec& col = H(j);
     col = SpatialVec(Vec3(0), Vec3(0));
@@ -414,7 +414,8 @@ const SpatialVec& getHCol(const SBTreePositionCache& pc, int j) const {
     return col;
 }
 
-const SpatialVec& getH_FMCol(const SBTreePositionCache& pc, int j) const {
+const SpatialVec& getH_FMCol(const SBTreePositionCache& pc, 
+                             int j) const override {
     Mat<2,3,Vec3> H = Mat<2,3,Vec3>::getAs(&pc.storageForH_FM[2*uIndex]);
     SpatialVec& col = H(j);
     col = SpatialVec(Vec3(0), Vec3(0));
@@ -422,21 +423,27 @@ const SpatialVec& getH_FMCol(const SBTreePositionCache& pc, int j) const {
     return col;
 }
 
-void setQToFitTransformImpl(const SBStateDigest&, const Transform& X_F0M0, Vector& q) const {
+void setQToFitTransformImpl(const SBStateDigest&, const Transform& X_F0M0, 
+                            Vector& q) const override {
     Vec3::updAs(&q[qIndex]) = X_F0M0.p();
 }
-void setQToFitRotationImpl(const SBStateDigest&, const Rotation& R_F0M0, Vector& q) const {
+void setQToFitRotationImpl(const SBStateDigest&, const Rotation& R_F0M0, 
+                           Vector& q) const override {
 }
-void setQToFitTranslationImpl(const SBStateDigest&, const Vec3& p_F0M0, Vector& q) const {
+void setQToFitTranslationImpl(const SBStateDigest&, const Vec3& p_F0M0, 
+                              Vector& q) const override {
     Vec3::updAs(&q[qIndex]) = p_F0M0;
 }
 
-void setUToFitVelocityImpl(const SBStateDigest&, const Vector& q, const SpatialVec& V_F0M0, Vector& u) const {
+void setUToFitVelocityImpl(const SBStateDigest&, const Vector& q, 
+                           const SpatialVec& V_F0M0, Vector& u) const override {
     Vec3::updAs(&u[uIndex]) = V_F0M0[1];
 }
-void setUToFitAngularVelocityImpl(const SBStateDigest&, const Vector& q, const Vec3& w_F0M0, Vector& u) const {    
+void setUToFitAngularVelocityImpl(const SBStateDigest&, const Vector& q, 
+                                  const Vec3& w_F0M0, Vector& u) const override {    
 }
-void setUToFitLinearVelocityImpl(const SBStateDigest&, const Vector& q, const Vec3& v_F0M0, Vector& u) const {
+void setUToFitLinearVelocityImpl(const SBStateDigest&, const Vector& q, 
+                                 const Vec3& v_F0M0, Vector& u) const override {
     Vec3::updAs(&u[uIndex]) = v_F0M0;
 }
 

--- a/Simbody/src/RigidBodyNode_Weld.cpp
+++ b/Simbody/src/RigidBodyNode_Weld.cpp
@@ -120,12 +120,6 @@ public:
 
     void convertToEulerAngles(const Vector& inputQ, Vector& outputQ) const {}
     void convertToQuaternions(const Vector& inputQ, Vector& outputQ) const {}
-
-    void setVelFromSVel(
-        const SBTreePositionCache&  pc, 
-        const SBTreeVelocityCache&  vc,
-        const SpatialVec&           sVel, 
-        Vector&                     u) const {}
 };
 
 /**
@@ -343,7 +337,7 @@ public:
 
     void calcEquivalentJointForces(
         const SBTreePositionCache&  pc,
-        const SBDynamicsCache&,
+        const SBTreeVelocityCache&,
         const SpatialVec*           bodyForces,
         SpatialVec*                 allZ,
         Real*                       jointForces) const 
@@ -675,7 +669,7 @@ public:
 
     void calcEquivalentJointForces(
         const SBTreePositionCache&  pc,
-        const SBDynamicsCache&      dc,
+        const SBTreeVelocityCache&  vc,
         const SpatialVec*           bodyForces,
         SpatialVec*                 allZ,
         Real*                       jointForces) const 
@@ -685,7 +679,7 @@ public:
 
         // Centrifugal forces are MA+b where M is body spatial inertia,
         // A is total coriolis acceleration, and b is gyroscopic force.
-        z = myBodyForce - getTotalCentrifugalForces(dc);
+        z = myBodyForce - getTotalCentrifugalForces(vc);
 
         for (int i=0 ; i<(int)children.size() ; i++) {
             const SpatialVec& zChild    = allZ[children[i]->getNodeNum()];

--- a/Simbody/src/RigidBodyNode_Weld.cpp
+++ b/Simbody/src/RigidBodyNode_Weld.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
  * Contributors:                                                              *
  *    Charles Schwieters (NIH): wrote the public domain IVM code from which   *
@@ -51,31 +51,36 @@
  */
 class ImmobileRigidBodyNode : public RigidBodyNode {
 public:
-    ImmobileRigidBodyNode(const MassProperties& mProps_B, const Transform& X_PF, const Transform& X_BM,
-        const UIndex& uIx, const USquaredIndex& usqIx, const QIndex& qIx)
-    :   RigidBodyNode(mProps_B, X_PF, X_BM, QDotIsAlwaysTheSameAsU, QuaternionIsNeverUsed) 
+    ImmobileRigidBodyNode(const MassProperties& mProps_B, const Transform& X_PF,
+                          const Transform& X_BM, const UIndex& uIx, 
+                          const USquaredIndex& usqIx, const QIndex& qIx)
+    :   RigidBodyNode(mProps_B, X_PF, X_BM, 
+                      QDotIsAlwaysTheSameAsU, QuaternionIsNeverUsed) 
     {
         uIndex   = uIx;
         uSqIndex = usqIx;
         qIndex   = qIx;
     }
-    ~ImmobileRigidBodyNode() {}
-
-    int  getDOF()   const {return 0;}
-    int  getMaxNQ() const {return 0;}
-    int  getNUInUse(const SBModelVars&) const {return 0;}
-    int  getNQInUse(const SBModelVars&) const {return 0;}
-    bool isUsingQuaternion(const SBStateDigest&, MobilizerQIndex& ix) const
-    {   ix.invalidate(); return false; }
     int getPosPoolSize(const SBStateDigest&) const {return 0;}
     int getVelPoolSize(const SBStateDigest&) const {return 0;}
 
-    int calcQPoolSize(const SBModelVars&) const {return 0;}
+    ~ImmobileRigidBodyNode() override = default;
+
+    int  getDOF()   const override {return 0;}
+    int  getMaxNQ() const override {return 0;}
+    int  getNQInUse(const SBModelVars&) const override {return 0;}
+    int  getNUInUse(const SBModelVars&) const override {return 0;}
+    bool isUsingQuaternion(const SBStateDigest&, 
+                           MobilizerQIndex& ix) const override
+    {   ix.invalidate(); return false; }
+
+
+    int calcQPoolSize(const SBModelVars&) const override {return 0;}
 
     void performQPrecalculations(const SBStateDigest& sbs,
                                  const Real* q, int nq,
                                  Real* qCache,  int nQCache,
-                                 Real* qErr,    int nQErr) const
+                                 Real* qErr,    int nQErr) const override
     {   assert(nq==0 && nQCache==0 && nQErr==0); }
 
 
@@ -84,48 +89,53 @@ public:
     void calcX_FM(const SBStateDigest& sbs,
                   const Real* q,      int nq,
                   const Real* qCache, int nQCache,
-                  Transform&  X_FM) const
+                  Transform&  X_FM) const override
     {   assert(nq==0 && nQCache==0);
         X_FM.setToZero(); }
 
-    void setQToFitTransformImpl
-       (const SBStateDigest& sbs, const Transform& X_FM, Vector& q) const {}
-    void setQToFitRotationImpl
-       (const SBStateDigest& sbs, const Rotation& R_FM, Vector& q) const {}
-    void setQToFitTranslationImpl
-       (const SBStateDigest& sbs, const Vec3& p_FM, Vector& q) const {}
+    void setQToFitTransformImpl(const SBStateDigest& sbs, const Transform& X_FM, 
+                                Vector& q) const override {}
+    void setQToFitRotationImpl(const SBStateDigest& sbs, const Rotation& R_FM, 
+                               Vector& q) const override {}
+    void setQToFitTranslationImpl(const SBStateDigest& sbs, const Vec3& p_FM, 
+                                  Vector& q) const override {}
 
     void setUToFitVelocityImpl
-       (const SBStateDigest& sbs, const Vector& q, const SpatialVec& V_FM, Vector& u) const {}
+       (const SBStateDigest& sbs, const Vector& q, const SpatialVec& V_FM, 
+        Vector& u) const override {}
     void setUToFitAngularVelocityImpl
-       (const SBStateDigest& sbs, const Vector& q, const Vec3& w_FM, Vector& u) const {}
+       (const SBStateDigest& sbs, const Vector& q, const Vec3& w_FM, 
+        Vector& u) const override {}
     void setUToFitLinearVelocityImpl
-       (const SBStateDigest& sbs, const Vector& q, const Vec3& v_FM, Vector& u) const {}
+       (const SBStateDigest& sbs, const Vector& q, const Vec3& v_FM, 
+        Vector& u) const override {}
 
     
     void multiplyByN(const SBStateDigest&, bool matrixOnRight, 
-                     const Real* in, Real* out) const {}
+                     const Real* in, Real* out) const override {}
     void multiplyByNInv(const SBStateDigest&, bool matrixOnRight,
-                        const Real* in, Real* out) const {}
+                        const Real* in, Real* out) const override {}
     void multiplyByNDot(const SBStateDigest&, bool matrixOnRight,
-                        const Real* in, Real* out) const {}
+                        const Real* in, Real* out) const override {}
 
-    void calcQDot(const SBStateDigest&, const Real* udot, Real* qdotdot) const {}
-    void calcQDotDot(const SBStateDigest&, const Real* udot, Real* qdotdot) const {}
+    void calcQDot(const SBStateDigest&, const Real* udot, 
+                  Real* qdotdot) const override {}
+    void calcQDotDot(const SBStateDigest&, const Real* udot, 
+                     Real* qdotdot) const override {}
 
     bool enforceQuaternionConstraints(
         const SBStateDigest& sbs,
         Vector&             q,
-        Vector&             qErrest) const {return false;}
+        Vector&             qErrest) const override {return false;}
 
-    void convertToEulerAngles(const Vector& inputQ, Vector& outputQ) const {}
-    void convertToQuaternions(const Vector& inputQ, Vector& outputQ) const {}
+    void convertToEulerAngles(const Vector& inputQ, 
+                              Vector&       outputQ) const override {}
+    void convertToQuaternions(const Vector& inputQ, 
+                              Vector&       outputQ) const override {}
 };
 
-/**
- * This is the distinguished body representing the immobile ground frame. Other bodies may
- * be fixed to this one, but only this is the actual Ground.
- */
+/* This is the distinguished body representing the immobile ground frame. Other 
+bodies may be fixed to this one, but only this is the actual Ground. */
 class RBGroundBody : public ImmobileRigidBodyNode {
 public:
     RBGroundBody()
@@ -133,11 +143,11 @@ public:
                               Transform(), Transform(),
                               UIndex(0), USquaredIndex(0), QIndex(0)) {}
 
-    const char* type() const { return "ground"; }
+    const char* type() const override { return "ground"; }
 
     // TODO: should ground set the various cache entries here?
-    void realizeModel   (SBStateDigest&) const {}
-    void realizeInstance(const SBStateDigest& sbs) const {
+    void realizeModel   (SBStateDigest&) const override {}
+    void realizeInstance(const SBStateDigest& sbs) const override {
         // Initialize cache entries that will never be changed at later stages.
         
         SBTreeVelocityCache& vc = sbs.updTreeVelocityCache();
@@ -146,18 +156,18 @@ public:
         updY(dc) = SpatialMat(Mat33(0));
         updA_GB(ac) = 0;
     }
-    void realizePosition(const SBStateDigest&) const {}
-    void realizeVelocity(const SBStateDigest&) const {}
-    void realizeDynamics(const SBArticulatedBodyInertiaCache&, const SBStateDigest&) const {}
+    void realizePosition(const SBStateDigest&) const override {}
+    void realizeVelocity(const SBStateDigest&) const override {}
+    void realizeDynamics(const SBStateDigest&) const override {}
     // There is no realizeAcceleration().
-    void realizeReport  (const SBStateDigest&) const {}
+    void realizeReport  (const SBStateDigest&) const override {}
 
     // Ground's "composite" body inertia is still the infinite mass
     // and inertia it started with; no need to look at the children.
     // This overrides the base class default implementation.
     void calcCompositeBodyInertiasInward(
         const SBTreePositionCache&                  pc,
-        Array_<SpatialInertia,MobilizedBodyIndex>&  R) const
+        Array_<SpatialInertia,MobilizedBodyIndex>&  R) const override
     {   R[GroundIndex] = SpatialInertia(Infinity, Vec3(0), UnitInertia(1)); }
 
     // Ground's "articulated" body inertia is still the infinite mass and
@@ -165,7 +175,7 @@ public:
     void realizeArticulatedBodyInertiasInward(
         const SBInstanceCache&,
         const SBTreePositionCache&,
-        SBArticulatedBodyInertiaCache& abc) const 
+        SBArticulatedBodyInertiaCache& abc) const override 
     {   ArticulatedInertia& P = updP(abc);
         P = ArticulatedInertia(SymMat33(Infinity), Mat33(Infinity), 
                                        SymMat33(0)); 
@@ -176,7 +186,7 @@ public:
         const SBInstanceCache&,
         const SBTreePositionCache&,
         const SBArticulatedBodyInertiaCache&,
-        SBDynamicsCache&                        dc) const
+        SBDynamicsCache&                        dc) const override
     {
     }
 
@@ -188,13 +198,13 @@ public:
         const SBInstanceCache&     ic,
         const SBTreePositionCache& pc,
         const SBArticulatedBodyInertiaCache&,
-        const SBDynamicsCache&,
+        const SBArticulatedBodyVelocityCache&,
         const Real*                jointForces,
         const SpatialVec*          bodyForces,
         const Real*                allUDot,
         SpatialVec*                allZ,
         SpatialVec*                allZPlus,
-        Real*                      allEpsilon) const
+        Real*                      allEpsilon) const override
     {
         const SpatialVec& F            = bodyForces[0];
         SpatialVec&       z            = allZ[0];
@@ -220,7 +230,7 @@ public:
         const Real*                epsilonTmp,
         SpatialVec*                allA_GB,
         Real*                      allUDot,
-        Real*                      allTau) const
+        Real*                      allTau) const override
     {
         allA_GB[0] = 0;
     }
@@ -256,7 +266,7 @@ public:
         const SBTreePositionCache&  pc,
         const SBTreeVelocityCache&  vc,
         const Real*                 allUDot,
-        SpatialVec*                 allA_GB) const 
+        SpatialVec*                 allA_GB) const override
     {
         allA_GB[0] = 0;
     }
@@ -271,7 +281,7 @@ public:
         const Real*                 jointForces,
         const SpatialVec*           bodyForces,
         SpatialVec*                 allF,
-        Real*                       allTau) const
+        Real*                       allTau) const override
     {
         allF[0] = -bodyForces[0];
 
@@ -288,7 +298,7 @@ public:
     void multiplyByMPass1Outward(
         const SBTreePositionCache&  pc,
         const Real*                 allUDot,
-        SpatialVec*                 allA_GB) const
+        SpatialVec*                 allA_GB) const override
     {
         allA_GB[0] = 0;
     }
@@ -297,7 +307,7 @@ public:
         const SBTreePositionCache&  pc,
         const SpatialVec*           allA_GB,
         SpatialVec*                 allF,
-        Real*                       allTau) const
+        Real*                       allTau) const override
     {
         allF[0] = 0;
 
@@ -315,7 +325,7 @@ public:
     void multiplyBySystemJacobian(
         const SBTreePositionCache&  pc,
         const Real*                 v,
-        SpatialVec*                 Jv) const    
+        SpatialVec*                 Jv) const override    
     {
         Jv[0] = SpatialVec(Vec3(0));
     }
@@ -324,7 +334,7 @@ public:
         const SBTreePositionCache&  pc, 
         SpatialVec*                 zTmp,
         const SpatialVec*           X, 
-        Real*                       JtX) const 
+        Real*                       JtX) const override 
     {
         zTmp[0] = X[0];
         for (unsigned i=0; i<children.size(); ++i) {
@@ -340,7 +350,7 @@ public:
         const SBTreeVelocityCache&,
         const SpatialVec*           bodyForces,
         SpatialVec*                 allZ,
-        Real*                       jointForces) const 
+        Real*                       jointForces) const override 
     { 
         allZ[0] = bodyForces[0];
         for (unsigned i=0; i<children.size(); ++i) {
@@ -358,14 +368,15 @@ public:
 // but has no q's and no u's.
 class RBNodeWeld : public ImmobileRigidBodyNode {
 public:
-    RBNodeWeld(const MassProperties& mProps_B, const Transform& X_PF, const Transform& X_BM,
-        const UIndex& uIx, const USquaredIndex& usqIx, const QIndex& qIx)
+    RBNodeWeld(const MassProperties& mProps_B, const Transform& X_PF, 
+               const Transform& X_BM, const UIndex& uIx, 
+               const USquaredIndex& usqIx, const QIndex& qIx)
     :   ImmobileRigidBodyNode(mProps_B, X_PF, X_BM, uIx, usqIx, qIx) {}
 
-    const char* type() { return "weld"; }
+    const char* type() const override { return "weld"; }
 
-    void realizeModel(SBStateDigest& sbs) const {}
-    void realizeInstance(const SBStateDigest& sbs) const {
+    void realizeModel(SBStateDigest& sbs) const override {}
+    void realizeInstance(const SBStateDigest& sbs) const override {
         // Initialize cache entries that will never be changed at later stages.
         
         SBTreeVelocityCache& vc = sbs.updTreeVelocityCache();
@@ -375,7 +386,7 @@ public:
         updVD_PB_G(vc) = 0;
     }
 
-    void realizePosition(const SBStateDigest& sbs) const {
+    void realizePosition(const SBStateDigest& sbs) const override {
         SBTreePositionCache& pc = sbs.updTreePositionCache();
 
         const Transform& X_MB = getX_MB();   // fixed
@@ -411,26 +422,18 @@ public:
         updMk_G(pc) = SpatialInertia(getMass(), p_BBc_G, G_Bo_G);
     }
     
-    void realizeVelocity(const SBStateDigest& sbs) const {
+    void realizeVelocity(const SBStateDigest& sbs) const override {
         const SBTreePositionCache& pc = sbs.getTreePositionCache();
         SBTreeVelocityCache& vc = sbs.updTreeVelocityCache();
         calcJointIndependentKinematicsVel(pc,vc);
     }
 
-    void realizeDynamics(const SBArticulatedBodyInertiaCache&   abc,
-                         const SBStateDigest&                   sbs) const {
-        // Mobilizer-specific.
-        const SBTreePositionCache&  pc = sbs.getTreePositionCache();
-        const SBTreeVelocityCache&  vc = sbs.getTreeVelocityCache();
-        SBDynamicsCache&            dc = sbs.updDynamicsCache();
-        
-        // Mobilizer independent.
-        calcJointIndependentDynamicsVel(pc,abc,vc,dc);
+    void realizeDynamics(const SBStateDigest&) const override {
     }
 
     // There is no realizeAcceleration().
 
-    void realizeReport(const SBStateDigest& sbs) const {}
+    void realizeReport(const SBStateDigest& sbs) const override {}
 
     // Weld uses base class implementation of calcCompositeBodyInertiasInward() since
     // that is independent of mobilities.
@@ -438,7 +441,7 @@ public:
     void realizeArticulatedBodyInertiasInward
        (const SBInstanceCache&          ic,
         const SBTreePositionCache&      pc, 
-        SBArticulatedBodyInertiaCache&  abc) const 
+        SBArticulatedBodyInertiaCache&  abc) const override 
     {
         ArticulatedInertia& P = updP(abc);
         P = ArticulatedInertia(getMk_G(pc));
@@ -456,10 +459,10 @@ public:
         const SBInstanceCache&,
         const SBTreePositionCache&              pc,
         const SBArticulatedBodyInertiaCache&    abc,
-        SBDynamicsCache&                        dc) const
+        SBDynamicsCache&                        dc) const override
     {
-        // This psi actually has the wrong sign, but it doesn't matter since we multiply
-        // by it twice.
+        // This psi actually has the wrong sign, but it doesn't matter since we 
+        // multiply by it twice.
 
         SpatialMat psi = getPhi(pc).toSpatialMat();
         updY(dc) = ~psi * parent->getY(dc) * psi;
@@ -467,22 +470,22 @@ public:
 
     
     void calcUDotPass1Inward(
-        const SBInstanceCache&      ic,
-        const SBTreePositionCache&  pc,
+        const SBInstanceCache&,
+        const SBTreePositionCache&              pc,
         const SBArticulatedBodyInertiaCache&,
-        const SBDynamicsCache&      dc,
-        const Real*                 jointForces,
-        const SpatialVec*           bodyForces,
-        const Real*                 allUDot,
-        SpatialVec*                 allZ,
-        SpatialVec*                 allZPlus,
-        Real*                       allEpsilon) const 
+        const SBArticulatedBodyVelocityCache&   abvc,
+        const Real*,
+        const SpatialVec*                       bodyForces,
+        const Real*,
+        SpatialVec*                             allZ,
+        SpatialVec*                             allZPlus,
+        Real*) const override 
     {
         const SpatialVec& myBodyForce  = bodyForces[nodeNum];
         SpatialVec&       z            = allZ[nodeNum];
         SpatialVec&       zPlus        = allZPlus[nodeNum];
 
-        z = getMobilizerCentrifugalForces(dc) - myBodyForce;
+        z = getArticulatedBodyCentrifugalForces(abvc) - myBodyForce;
 
         for (unsigned i=0; i<children.size(); ++i) {
             const PhiMatrix&  phiChild   = children[i]->getPhi(pc);
@@ -503,7 +506,7 @@ public:
         const Real*                 allEpsilon,
         SpatialVec*                 allA_GB,
         Real*                       allUDot,
-        Real*                       allTau) const
+        Real*                       allTau) const override
     {
         SpatialVec& A_GB = allA_GB[nodeNum];
 
@@ -566,7 +569,7 @@ public:
         const SBTreePositionCache&  pc,
         const SBTreeVelocityCache&  vc,
         const Real*                 allUDot,
-        SpatialVec*                 allA_GB) const 
+        SpatialVec*                 allA_GB) const override 
     {
         SpatialVec& A_GB = allA_GB[nodeNum];
 
@@ -583,7 +586,7 @@ public:
         const Real*                 jointForces,
         const SpatialVec*           bodyForces,
         SpatialVec*                 allF,
-        Real*                       allTau) const
+        Real*                       allTau) const override
     {
         const SpatialVec& myBodyForce   = bodyForces[nodeNum];
         const SpatialVec& A_GB          = allA_GB[nodeNum];
@@ -607,7 +610,7 @@ public:
     void multiplyByMPass1Outward(
         const SBTreePositionCache&  pc,
         const Real*                 allUDot,
-        SpatialVec*                 allA_GB) const
+        SpatialVec*                 allA_GB) const override
     {
         SpatialVec& A_GB = allA_GB[nodeNum];
 
@@ -621,7 +624,7 @@ public:
         const SBTreePositionCache&  pc,
         const SpatialVec*           allA_GB,
         SpatialVec*                 allF,   // temp
-        Real*                       allTau) const 
+        Real*                       allTau) const override
     {
         const SpatialVec& A_GB  = allA_GB[nodeNum];
         SpatialVec&       F     = allF[nodeNum];
@@ -638,7 +641,7 @@ public:
     void multiplyBySystemJacobian(
         const SBTreePositionCache&  pc,
         const Real*                 v,
-        SpatialVec*                 Jv) const    
+        SpatialVec*                 Jv) const override    
     {
         SpatialVec& out = Jv[nodeNum];
 
@@ -652,7 +655,7 @@ public:
         const SBTreePositionCache&  pc, 
         SpatialVec*                 zTmp,
         const SpatialVec*           X, 
-        Real*                       JtX) const
+        Real*                       JtX) const override
     {
         const SpatialVec& in  = X[getNodeNum()];
         SpatialVec&       z   = zTmp[getNodeNum()];
@@ -672,7 +675,7 @@ public:
         const SBTreeVelocityCache&  vc,
         const SpatialVec*           bodyForces,
         SpatialVec*                 allZ,
-        Real*                       jointForces) const 
+        Real*                       jointForces) const override 
     {
         const SpatialVec& myBodyForce  = bodyForces[nodeNum];
         SpatialVec&       z            = allZ[nodeNum];

--- a/Simbody/src/SimbodyMatterSubsystem.cpp
+++ b/Simbody/src/SimbodyMatterSubsystem.cpp
@@ -2027,6 +2027,22 @@ invalidateArticulatedBodyVelocity(const State& s) const {
     getRep().invalidateArticulatedBodyVelocity(s);
 }
 
+bool SimbodyMatterSubsystem::
+isPositionKinematicsRealized(const State& state) const
+{   return getRep().isPositionKinematicsRealized(state); }
+bool SimbodyMatterSubsystem::
+isVelocityKinematicsRealized(const State& state) const
+{   return getRep().isVelocityKinematicsRealized(state); }
+bool SimbodyMatterSubsystem::
+isCompositeBodyInertiasRealized(const State& state) const
+{   return getRep().isCompositeBodyInertiasRealized(state); }
+bool SimbodyMatterSubsystem::
+isArticulatedBodyInertiasRealized(const State& state) const
+{   return getRep().isArticulatedBodyInertiasRealized(state); }
+bool SimbodyMatterSubsystem::
+isArticulatedBodyVelocityRealized(const State& state) const
+{   return getRep().isArticulatedBodyVelocityRealized(state); }
+
 const Array_<QIndex>& SimbodyMatterSubsystem::
 getFreeQIndex(const State& state) const
 {   return getRep().getFreeQIndex(state); }

--- a/Simbody/src/SimbodyMatterSubsystem.cpp
+++ b/Simbody/src/SimbodyMatterSubsystem.cpp
@@ -501,12 +501,6 @@ void SimbodyMatterSubsystem::calcPq(const State& s, Matrix& Pq) const
 void SimbodyMatterSubsystem::calcPqTranspose(const State& s, Matrix& Pqt) const 
 {   getRep().calcPqTranspose(s,Pqt); }
 
-// OBSOLETE
-void SimbodyMatterSubsystem::
-calcPNInv(const State& s, Matrix& PNInv) const {
-    return getRep().calcHolonomicConstraintMatrixPNInv(s,PNInv);
-}
-
 void SimbodyMatterSubsystem::
 calcP(const State& s, Matrix& P) const {
     return getRep().calcHolonomicVelocityConstraintMatrixP(s,P);
@@ -856,32 +850,6 @@ calcBiasForMultiplyByPq(const State& state,
         getRep().calcBiasForMultiplyByPVA(state, true, false, false, tmpbias);
         biasp = tmpbias;
     }
-}
-
-
-
-
-//==============================================================================
-//             CALC Gt -- OBSOLETE, use calcGTranspose()
-//==============================================================================
-void SimbodyMatterSubsystem::
-calcGt(const State& s, Matrix& Gt) const {
-    const SimbodyMatterSubsystemRep& rep = getRep();
-    const int mHolo    = rep.getNumHolonomicConstraintEquationsInUse(s);
-    const int mNonholo = rep.getNumNonholonomicConstraintEquationsInUse(s);
-    const int mAccOnly = rep.getNumAccelerationOnlyConstraintEquationsInUse(s);
-    const int m  = mHolo+mNonholo+mAccOnly;
-    const int nu = rep.getNU(s);
-
-    Gt.resize(nu,m);
-
-    if (m==0 || nu==0)
-        return;
-
-    // Fill in all the columns of Gt
-    rep.calcHolonomicVelocityConstraintMatrixPt(s, Gt(0,     0,          nu, mHolo));
-    rep.calcNonholonomicConstraintMatrixVt     (s, Gt(0,   mHolo,        nu, mNonholo));
-    rep.calcAccelerationOnlyConstraintMatrixAt (s, Gt(0, mHolo+mNonholo, nu, mAccOnly));
 }
 
 
@@ -1964,14 +1932,19 @@ const SpatialVec&
 SimbodyMatterSubsystem::getGyroscopicForce(const State& s, MobilizedBodyIndex body) const {
     return getRep().getGyroscopicForce(s,body);
 }
-const SpatialVec&
-SimbodyMatterSubsystem::getMobilizerCentrifugalForces(const State& s, MobilizedBodyIndex body) const {
-    return getRep().getMobilizerCentrifugalForces(s,body);
-}
+
 const SpatialVec&
 SimbodyMatterSubsystem::getTotalCentrifugalForces(const State& s, MobilizedBodyIndex body) const {
     return getRep().getTotalCentrifugalForces(s,body);
 }
+
+//TODO: user access to this quantity is deprecated in Simbody 3.6.
+const SpatialVec&
+SimbodyMatterSubsystem::getMobilizerCentrifugalForces(const State& s, MobilizedBodyIndex body) const {
+    return getRep().getArticulatedBodyCentrifugalForces(s,body);
+}
+
+
 const Vector& 
 SimbodyMatterSubsystem::getAllParticleMasses(const State& s) const { 
     return getRep().getAllParticleMasses(s); 
@@ -2003,21 +1976,30 @@ void SimbodyMatterSubsystem::addInStationForce(const State& s, MobilizedBodyInde
     bodyForces[body] += SpatialVec((R_GB*stationInB) % forceInG, forceInG);
 }
 
-void SimbodyMatterSubsystem::realizePositionKinematics(const State& s) const {
+void SimbodyMatterSubsystem::
+realizePositionKinematics(const State& s) const {
     getRep().realizePositionKinematics(s);
 }
 
 
-void SimbodyMatterSubsystem::realizeVelocityKinematics(const State& s) const {
+void SimbodyMatterSubsystem::
+realizeVelocityKinematics(const State& s) const {
     getRep().realizeVelocityKinematics(s);
 }
 
-void SimbodyMatterSubsystem::realizeCompositeBodyInertias(const State& s) const {
+void SimbodyMatterSubsystem::
+realizeCompositeBodyInertias(const State& s) const {
     getRep().realizeCompositeBodyInertias(s);
 }
 
-void SimbodyMatterSubsystem::realizeArticulatedBodyInertias(const State& s) const {
+void SimbodyMatterSubsystem::
+realizeArticulatedBodyInertias(const State& s) const {
     getRep().realizeArticulatedBodyInertias(s);
+}
+
+void SimbodyMatterSubsystem::
+realizeArticulatedBodyVelocity(const State& s) const {
+    getRep().realizeArticulatedBodyVelocity(s);
 }
 
 void SimbodyMatterSubsystem::
@@ -2040,6 +2022,10 @@ invalidateArticulatedBodyInertias(const State& s) const {
     getRep().invalidateArticulatedBodyInertias(s);
 }
 
+void SimbodyMatterSubsystem::
+invalidateArticulatedBodyVelocity(const State& s) const {
+    getRep().invalidateArticulatedBodyVelocity(s);
+}
 
 const Array_<QIndex>& SimbodyMatterSubsystem::
 getFreeQIndex(const State& state) const

--- a/Simbody/src/SimbodyMatterSubsystemRep.cpp
+++ b/Simbody/src/SimbodyMatterSubsystemRep.cpp
@@ -235,13 +235,14 @@ SimbodyMatterSubsystemRep::getGyroscopicForce(const State& s, MobilizedBodyIndex
   return getRigidBodyNode(body).getGyroscopicForce(getTreeVelocityCache(s));
 }
 const SpatialVec&
+SimbodyMatterSubsystemRep::getTotalCentrifugalForces(const State& s, MobilizedBodyIndex body) const {
+  return getRigidBodyNode(body).getTotalCentrifugalForces(getTreeVelocityCache(s));
+}
+const SpatialVec&
 SimbodyMatterSubsystemRep::getMobilizerCentrifugalForces(const State& s, MobilizedBodyIndex body) const {
   return getRigidBodyNode(body).getMobilizerCentrifugalForces(getDynamicsCache(s));
 }
-const SpatialVec&
-SimbodyMatterSubsystemRep::getTotalCentrifugalForces(const State& s, MobilizedBodyIndex body) const {
-  return getRigidBodyNode(body).getTotalCentrifugalForces(getDynamicsCache(s));
-}
+
 
 
 
@@ -6221,7 +6222,7 @@ void SimbodyMatterSubsystemRep::calcTreeEquivalentMobilityForces(const State& s,
     Vector&                    mobilityForces) const
 {
     const SBTreePositionCache&  tpc = getTreePositionCache(s);
-    const SBDynamicsCache&      dc  = getDynamicsCache(s);
+    const SBTreeVelocityCache&  tvc = getTreeVelocityCache(s);
 
     assert(bodyForces.size() == getNumBodies());
     mobilityForces.resize(getTotalDOF());
@@ -6238,7 +6239,7 @@ void SimbodyMatterSubsystemRep::calcTreeEquivalentMobilityForces(const State& s,
     for (int i=rbNodeLevels.size()-1 ; i>0 ; i--) 
         for (int j=0 ; j<(int)rbNodeLevels[i].size() ; j++) {
             const RigidBodyNode& node = *rbNodeLevels[i][j];
-            node.calcEquivalentJointForces(tpc,dc,
+            node.calcEquivalentJointForces(tpc,tvc,
                 bodyForcePtr, zPtr,
                 mobilityForcePtr);
         }

--- a/Simbody/src/SimbodyMatterSubsystemRep.cpp
+++ b/Simbody/src/SimbodyMatterSubsystemRep.cpp
@@ -21,10 +21,7 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-/**@file
- *
- * Implementation of SimbodyMatterSubsystemRep.
- */
+/* Implementation of SimbodyMatterSubsystemRep. */
 
 #include "SimTKcommon.h"
 #include "SimTKmath.h"
@@ -42,8 +39,9 @@
 #include <iostream>
 using std::cout; using std::endl;
 
-SimbodyMatterSubsystemRep::SimbodyMatterSubsystemRep(const SimbodyMatterSubsystemRep& src)
-  : SimTK::Subsystem::Guts("SimbodyMatterSubsystemRep", "X.X.X")
+SimbodyMatterSubsystemRep::SimbodyMatterSubsystemRep
+   (const SimbodyMatterSubsystemRep& src)
+:   SimTK::Subsystem::Guts("SimbodyMatterSubsystemRep", "X.X.X")
 {
     assert(!"SimbodyMatterSubsystemRep copy constructor ... TODO!");
 }
@@ -238,9 +236,10 @@ const SpatialVec&
 SimbodyMatterSubsystemRep::getTotalCentrifugalForces(const State& s, MobilizedBodyIndex body) const {
   return getRigidBodyNode(body).getTotalCentrifugalForces(getTreeVelocityCache(s));
 }
-const SpatialVec&
-SimbodyMatterSubsystemRep::getMobilizerCentrifugalForces(const State& s, MobilizedBodyIndex body) const {
-  return getRigidBodyNode(body).getMobilizerCentrifugalForces(getDynamicsCache(s));
+const SpatialVec& SimbodyMatterSubsystemRep::
+getArticulatedBodyCentrifugalForces(const State& s, MobodIndex body) const {
+  return getRigidBodyNode(body).getArticulatedBodyCentrifugalForces
+                                        (getArticulatedBodyVelocityCache(s));
 }
 
 
@@ -402,19 +401,23 @@ int SimbodyMatterSubsystemRep::realizeSubsystemTopologyImpl(State& s) const {
         allocateLazyCacheEntry(s, Stage::Time,
                                new Value<SBConstrainedPositionCache>());
 
-    // Composite body inertias *can* be calculated any time after Position
-    // stage but we want to put them off as long as possible since
-    // they may never be needed. These will only be valid if they are 
-    // explicitly realized at some point.
-    tc.compositeBodyInertiaCacheIndex =
-        allocateLazyCacheEntry(s, Stage::Position,
-                               new Value<SBCompositeBodyInertiaCache>());
+    // Composite body inertias *can* be calculated any time after 
+    // PositionKinematics are available, but they aren't ever needed internally
+    // so we won't compute them unless explicitly requested.
+    tc.compositeBodyInertiaCacheIndex = s.allocateCacheEntryWithPrerequisites
+       (getMySubsystemIndex(), Stage::Instance, Stage::Infinity,
+        false /*q*/, false /*u*/, false /*z*/, {} /*dv*/, 
+        {CacheEntryKey(getMySubsystemIndex(), tc.treePositionCacheIndex)},
+        new Value<SBCompositeBodyInertiaCache>());
 
-    // Articulated body inertias *can* be calculated any time after Position 
-    // stage but we want to put them off until Dynamics stage if possible.
-    tc.articulatedBodyInertiaCacheIndex =
-        allocateCacheEntry(s, Stage::Position, Stage::Dynamics, 
-                           new Value<SBArticulatedBodyInertiaCache>());
+    // Articulated body inertias *can* be calculated any time after 
+    // PositionKinematics are available but we want to put them off until 
+    // Acceleration stage if possible.
+    tc.articulatedBodyInertiaCacheIndex = s.allocateCacheEntryWithPrerequisites
+       (getMySubsystemIndex(), Stage::Instance, Stage::Acceleration,
+        false /*q*/, false /*u*/, false /*z*/, {} /*dv*/, 
+        {CacheEntryKey(getMySubsystemIndex(), tc.treePositionCacheIndex)},
+        new Value<SBArticulatedBodyInertiaCache>());
 
     // Basic tree velocity kinematics can be calculated any time after Instance
     // stage, provided PositionKinematics have been realized, or unconditionally
@@ -439,6 +442,19 @@ int SimbodyMatterSubsystemRep::realizeSubsystemTopologyImpl(State& s) const {
     tc.constrainedVelocityCacheIndex = 
         allocateLazyCacheEntry(s, Stage::Position,
                                new Value<SBConstrainedVelocityCache>());
+
+    // Articulated body velocity calculations *can* be calculated any time after 
+    // VelocityKinematics and articulated body inertias are available but we 
+    // want to put them off until Acceleration stage if possible.
+    tc.articulatedBodyVelocityCacheIndex = s.allocateCacheEntryWithPrerequisites
+       (getMySubsystemIndex(), Stage::Instance, Stage::Acceleration,
+        false /*q*/, false /*u*/, false /*z*/, {} /*dv*/, 
+        {CacheEntryKey(getMySubsystemIndex(), 
+                       tc.treeVelocityCacheIndex),
+         CacheEntryKey(getMySubsystemIndex(), 
+                       tc.articulatedBodyInertiaCacheIndex)},
+        new Value<SBArticulatedBodyVelocityCache>());
+
     tc.dynamicsCacheIndex = 
         allocateCacheEntry(s, Stage::Dynamics, 
                            new Value<SBDynamicsCache>());
@@ -980,6 +996,7 @@ realizeSubsystemInstanceImpl(const State& s) const {
     updArticulatedBodyInertiaCache(s).allocate(topologyCache, mc, ic);
     updTreeVelocityCache(s).allocate(topologyCache, mc, ic);
     updConstrainedVelocityCache(s).allocate(topologyCache, mc, ic);
+    updArticulatedBodyVelocityCache(s).allocate(topologyCache, mc, ic);
     updDynamicsCache(s).allocate(topologyCache, mc, ic);
     updTreeAccelerationCache(s).allocate(topologyCache, mc, ic);
     updConstrainedAccelerationCache(s).allocate(topologyCache, mc, ic);
@@ -1126,12 +1143,16 @@ realizePositionKinematics(const State& state) const {
     markCacheValueRealized(state, tpcx);
 }
 
+// Position kinematics is realized only if 
+//  - we are currently at Stage::Position or later
+//      OR
+//  - position kinematics was previously realized since the most recent change 
+//    to Stage::Instance and the generalized coordinates q.
 bool SimbodyMatterSubsystemRep::
 isPositionKinematicsRealized(const State&  state) const {
     const CacheEntryIndex tpcx = topologyCache.treePositionCacheIndex;
     return isCacheValueRealized(state, tpcx);
 }
-
 
 void SimbodyMatterSubsystemRep::
 invalidatePositionKinematics(const State& state) const {
@@ -1145,26 +1166,46 @@ invalidatePositionKinematics(const State& state) const {
 //==============================================================================
 //                      REALIZE COMPOSITE BODY INERTIAS
 //==============================================================================
-void SimbodyMatterSubsystemRep::realizeCompositeBodyInertias(const State& state) const {
+void SimbodyMatterSubsystemRep::
+realizeCompositeBodyInertias(const State& state) const {
     const CacheEntryIndex cbx = topologyCache.compositeBodyInertiaCacheIndex;
 
     if (isCacheValueRealized(state, cbx))
         return; // already realized
 
-    SimTK_STAGECHECK_GE_ALWAYS(getStage(state), Stage::Position, 
-        "SimbodyMatterSubsystem::realizeCompositeBodyInertias()");
+    // Composite body inertias have not been realized. We don't want to realize 
+    // position kinematics implicitly here so we'll fail if that hasn't been 
+    // done already (typically by realize(Position)).
 
-    SBCompositeBodyInertiaCache& cbc = 
-        Value<SBCompositeBodyInertiaCache>::updDowncast(updCacheEntry(state, cbx));
+    SimTK_ERRCHK_ALWAYS(isPositionKinematicsRealized(state), 
+        "SimbodyMatterSubsystem::realizeCompositeBodyInertias()",
+        "Composite body inertias cannot be realized unless the state has been "
+        "realized to Stage::Position or realizePositionKinematics() has been "
+        "called explicitly.");
+
+    // OK, we have everything we'll need to compute CBIs.
+
+    SBCompositeBodyInertiaCache& cbc = Value<SBCompositeBodyInertiaCache>::
+                                        updDowncast(updCacheEntry(state, cbx));
 
     calcCompositeBodyInertias(state, cbc.compositeBodyInertia);
     markCacheValueRealized(state, cbx);
 }
 
+// Composite body inertias are realized only if
+//  - they were last realized since any change to Stage::Instance,
+//    PositionKinematics, and generalized coordinates q.
+bool SimbodyMatterSubsystemRep::
+isCompositeBodyInertiasRealized(const State& state) const {
+    const CacheEntryIndex cbx = topologyCache.compositeBodyInertiaCacheIndex;
+    return isCacheValueRealized(state, cbx);
+}
+
 void SimbodyMatterSubsystemRep::
 invalidateCompositeBodyInertias(const State& state) const {
-    const CacheEntryIndex cbx = 
-        topologyCache.compositeBodyInertiaCacheIndex;
+    // There is no stage at which CBIs are guaranteed to have been computed
+    // so we don't need to invalidate a stage here.
+    const CacheEntryIndex cbx = topologyCache.compositeBodyInertiaCacheIndex;
     markCacheValueNotRealized(state, cbx);
 }
 
@@ -1175,14 +1216,22 @@ invalidateCompositeBodyInertias(const State& state) const {
 //==============================================================================
 void SimbodyMatterSubsystemRep::
 realizeArticulatedBodyInertias(const State& state) const {
-    const CacheEntryIndex abx = 
-        topologyCache.articulatedBodyInertiaCacheIndex;
+    const CacheEntryIndex abx = topologyCache.articulatedBodyInertiaCacheIndex;
 
     if (isCacheValueRealized(state, abx))
         return; // already realized
 
-    SimTK_STAGECHECK_GE_ALWAYS(getStage(state), Stage::Position, 
-        "SimbodyMatterSubsystem::realizeArticulatedBodyInertias()");
+    // Articulated body inertias have not been realized. We don't want to 
+    // realize position kinematics implicitly here so we'll fail if that hasn't 
+    // been done already (typically by realize(Position)).
+
+    SimTK_ERRCHK_ALWAYS(isPositionKinematicsRealized(state), 
+    "SimbodyMatterSubsystem::realizeArticulatedBodyInertias()",
+    "Articulated body inertias cannot be realized unless the state has been "
+    "realized to Stage::Position or realizePositionKinematics() has been "
+    "called explicitly.");
+
+    // OK, we have everything we'll need to compute ABIs.
 
     const SBInstanceCache&          ic  = getInstanceCache(state);
     const SBTreePositionCache&      tpc = getTreePositionCache(state);
@@ -1196,13 +1245,24 @@ realizeArticulatedBodyInertias(const State& state) const {
     markCacheValueRealized(state, abx);
 }
 
-void SimbodyMatterSubsystemRep::
-invalidateArticulatedBodyInertias(const State& state) const {
-    // ABIs are assumed calculated at Dynamics stage, regardless of the 
-    // flag in the cache entry.
-    state.invalidateAllCacheAtOrAbove(Stage::Dynamics);
+// Articulated body inertias are realized only if
+//  - we're already at Stage::Acceleration
+//          OR
+//  - they were last realized since any change to Stage::Instance,
+//    PositionKinematics, and generalized coordinates q.
+bool SimbodyMatterSubsystemRep::
+isArticulatedBodyInertiasRealized(const State& state) const {
     const CacheEntryIndex abx = 
         topologyCache.articulatedBodyInertiaCacheIndex;
+    return isCacheValueRealized(state, abx);
+}
+
+void SimbodyMatterSubsystemRep::
+invalidateArticulatedBodyInertias(const State& state) const {
+    // ABIs are assumed calculated at Acceleration stage, regardless of the 
+    // flag in the cache entry.
+    state.invalidateAllCacheAtOrAbove(Stage::Acceleration);
+    const CacheEntryIndex abx = topologyCache.articulatedBodyInertiaCacheIndex;
     markCacheValueNotRealized(state, abx);
 }
 
@@ -1329,9 +1389,11 @@ realizeVelocityKinematics(const State& state) const {
 }
 
 
-// Velocity kinematics is realized only if position kinematics is realized,
-// AND the stage version of the position kinematics cache entry is unchanged
-// since we last computed velocity kinematics, AND the u's are also unchanged.
+// Velocity kinematics is realized only if
+//  - we're at Stage::Velocity or later
+//          OR
+//  - velocity kinematics was last realized since any change to Stage::Instance,
+//    PositionKinematics, and generalized speeds u.
 bool SimbodyMatterSubsystemRep::
 isVelocityKinematicsRealized(const State& state) const {
     const CacheEntryIndex velx = topologyCache.treeVelocityCacheIndex;
@@ -1347,6 +1409,82 @@ invalidateVelocityKinematics(const State& state) const {
     markCacheValueNotRealized(state, tvcx);
 }
 
+
+
+
+//==============================================================================
+//                 REALIZE ARTICULATED BODY VELOCITY CACHE
+//==============================================================================
+void SimbodyMatterSubsystemRep::
+realizeArticulatedBodyVelocity(const State& state) const {
+    const CacheEntryIndex abvx = 
+        topologyCache.articulatedBodyVelocityCacheIndex;
+
+    if (isCacheValueRealized(state, abvx))
+        return; // already realized
+
+    // Articulated body velocity computations have not been realized. We don't 
+    // want to realize velocity kinematics or articulated body inertias 
+    // implicitly here so we'll fail if they haven't been realized already.
+    // Although velocity kinematics is available after Stage::Velocity, usually
+    // ABIs are not calculated until Stage::Acceleration.
+
+    SimTK_ERRCHK_ALWAYS(isVelocityKinematicsRealized(state), 
+    "SimbodyMatterSubsystem::realizeArticulatedBodyVelocity()",
+    "Articulated body velocity calculations cannot be realized unless "
+    "velocity kinematics have already been realized, either by realizing the "
+    "state to Stage::Velocity or by calling realizeVelocityKinematics() "
+    "explicitly.");
+
+    SimTK_ERRCHK_ALWAYS(isArticulatedBodyInertiasRealized(state), 
+    "SimbodyMatterSubsystem::realizeArticulatedBodyVelocity()",
+    "Articulated body velocity calculations cannot be realized unless "
+    "articulated body inertias have already been realized, implicitly "
+    "or by calling realizeArticulatedBodyInertias() explicitly.");
+
+    // OK, we have everything we'll need to compute ABIs.
+
+    const SBTreePositionCache&  tpc = getTreePositionCache(state);
+    const SBTreeVelocityCache&  tvc = getTreeVelocityCache(state);
+    const SBArticulatedBodyInertiaCache& 
+                                abc = getArticulatedBodyInertiaCache(state);
+    SBArticulatedBodyVelocityCache& 
+                                abvc = updArticulatedBodyVelocityCache(state);
+
+    // Order doesn't matter for this calculation. Ground's entries are
+    // precalculated so start at level 1.
+    for (int i=1 ; i<(int)rbNodeLevels.size() ; i++) 
+        for (int j=0 ; j<(int)rbNodeLevels[i].size() ; j++)
+            rbNodeLevels[i][j]->realizeArticulatedBodyVelocityCache
+                                                            (tpc,tvc,abc,abvc);
+
+    markCacheValueRealized(state, abvx);
+}
+
+// Articulated body velocity computations are realized only if
+//  - we're already at Stage::Acceleration
+//          OR
+//  - they were last realized since any change to Stage::Instance,
+//    PositionKinematics, VelocityKinematics, ArticulatedBodyInertias,
+//    and generalized coordinates and speeds q and u.
+bool SimbodyMatterSubsystemRep::
+isArticulatedBodyVelocityRealized(const State& state) const {
+    const CacheEntryIndex abvx = 
+        topologyCache.articulatedBodyVelocityCacheIndex;
+    return isCacheValueRealized(state, abvx);
+}
+
+void SimbodyMatterSubsystemRep::
+invalidateArticulatedBodyVelocity(const State& state) const {
+    // AB velocity computations are assumed done at Acceleration stage, 
+    // regardless of the flag in the cache entry.
+    state.invalidateAllCacheAtOrAbove(Stage::Acceleration);
+    const CacheEntryIndex abvx = 
+        topologyCache.articulatedBodyVelocityCacheIndex;
+    markCacheValueNotRealized(state, abvx);
+}
+
+
 //==============================================================================
 //                               REALIZE DYNAMICS
 //==============================================================================
@@ -1358,20 +1496,15 @@ int SimbodyMatterSubsystemRep::realizeSubsystemDynamicsImpl(const State& s)  con
     SimTK_STAGECHECK_GE_ALWAYS(getStage(s), Stage(Stage::Dynamics).prev(), 
         "SimbodyMatterSubsystem::realizeDynamics()");
 
-    // tip-to-base calculation
-    realizeArticulatedBodyInertias(s); // (may already have been realized)
-    const SBArticulatedBodyInertiaCache& abc = getArticulatedBodyInertiaCache(s);
-
     SBStateDigest stateDigest(s, *this, Stage::Dynamics);
 
     // Get the Dynamics-stage cache; it was already allocated at Instance stage.
     SBDynamicsCache& dc = stateDigest.updDynamicsCache();
 
-    // Realize velocity-dependent articulated body quantities needed for 
-    // dynamics: base-to-tip.
+    // Probably nothing to do here.
     for (int i=0; i < (int)rbNodeLevels.size(); ++i)
         for (int j=0; j < (int)rbNodeLevels[i].size(); ++j)
-            rbNodeLevels[i][j]->realizeDynamics(abc, stateDigest);
+            rbNodeLevels[i][j]->realizeDynamics(stateDigest);
 
     // MobilizedBodies
     // This will include writing the prescribed accelerations into
@@ -1395,14 +1528,9 @@ int SimbodyMatterSubsystemRep::realizeSubsystemAccelerationImpl(const State& s) 
     SimTK_STAGECHECK_GE_ALWAYS(getStage(s), Stage(Stage::Acceleration).prev(), 
         "SimbodyMatterSubsystem::realizeAcceleration()");
 
-    SBStateDigest stateDigest(s, *this, Stage::Acceleration);
-
-    // Get the Acceleration-stage cache entries. They were all allocated by
-    // the end of Instance stage.
-    Vector&                         udot    = stateDigest.updUDot();
-    Vector&                         qdotdot = stateDigest.updQDotDot();
-    SBTreeAccelerationCache&        tac     = stateDigest.updTreeAccelerationCache();
-    SBConstrainedAccelerationCache& cac     = stateDigest.updConstrainedAccelerationCache();
+    // Articulated body inertias and velocity will be realized if necessary
+    // when realizeLoopForwardDynamics() is called, fulfilling our propose that
+    // those will be calculated by Stage::Accleration.
 
     // We ask our containing MultibodySystem for a reference to the cached 
     // forces accumulated from all the force subsystems. We use these to 
@@ -1412,6 +1540,8 @@ int SimbodyMatterSubsystemRep::realizeSubsystemAccelerationImpl(const State& s) 
         mbs.getMobilityForces(s, Stage::Dynamics),
         mbs.getParticleForces(s, Stage::Dynamics),
         mbs.getRigidBodyForces(s, Stage::Dynamics));
+
+    SBStateDigest stateDigest(s, *this, Stage::Acceleration);
 
     // MobilizedBodies
     for (MobilizedBodyIndex mbx(0); mbx < mobilizedBodies.size(); ++mbx)
@@ -5121,9 +5251,10 @@ Real SimbodyMatterSubsystemRep::calcKineticEnergy(const State& s) const {
 //                          CALC TREE ACCELERATIONS
 //==============================================================================
 // Operator for open-loop forward dynamics.
-// This Subsystem must have already been realized to Dynamics stage so that 
-// coriolis terms are available, and articulated body inertias should have been
-// realized. All vectors must use contiguous storage.
+// This Subsystem must have already realized VelocityKinematics so that 
+// Coriolis terms are available, and articulated body inertias and articulated
+// body velocities are realized here if necessary. All vectors must use 
+// contiguous storage.
 void SimbodyMatterSubsystemRep::calcTreeAccelerations(const State& s,
     const Vector&              mobilityForces,
     const Vector_<SpatialVec>& bodyForces,
@@ -5136,8 +5267,17 @@ void SimbodyMatterSubsystemRep::calcTreeAccelerations(const State& s,
     Vector&                    qdotdot,
     Vector&                    tau) const 
 {
+    // Note that realize(Acceleration) depends on getting here to fulfill the
+    // promise of these cache entries' computed-by stage.
+    realizeArticulatedBodyInertias(s); // might already be done
+    realizeArticulatedBodyVelocity(s);
+
+    const SBArticulatedBodyInertiaCache& abc = 
+        getArticulatedBodyInertiaCache(s);
+    const SBArticulatedBodyVelocityCache& abvc = 
+        getArticulatedBodyVelocityCache(s);
+
     SBStateDigest sbs(s, *this, Stage::Acceleration);
-    const SBArticulatedBodyInertiaCache& abc = getArticulatedBodyInertiaCache(s);
 
     const SBInstanceCache&      ic  = sbs.getInstanceCache();
     const SBTreePositionCache&  tpc = sbs.getTreePositionCache();
@@ -5164,15 +5304,15 @@ void SimbodyMatterSubsystemRep::calcTreeAccelerations(const State& s,
     assert(tau.hasContiguousData());
 
     const Real*       mobilityForcePtr = mobilityForces.size() 
-                                            ? &mobilityForces[0] : NULL;
+                                            ? &mobilityForces[0] : nullptr;
     const SpatialVec* bodyForcePtr     = bodyForces.size() 
-                                            ? &bodyForces[0] : NULL;
+                                            ? &bodyForces[0] : nullptr;
     Real*             hingeForcePtr    = netHingeForces.size() 
-                                            ? &netHingeForces[0] : NULL;
-    SpatialVec*       aPtr             = A_GB.size()    ? &A_GB[0] : NULL;
-    Real*             udotPtr          = udot.size()    ? &udot[0] : NULL;
-    Real*             qdotdotPtr       = qdotdot.size() ? &qdotdot[0] : NULL;
-    Real*             tauPtr           = tau.size()     ? &tau[0] : NULL;
+                                            ? &netHingeForces[0] : nullptr;
+    SpatialVec*       aPtr             = A_GB.size()    ? &A_GB[0] : nullptr;
+    Real*             udotPtr          = udot.size()    ? &udot[0] : nullptr;
+    Real*             qdotdotPtr       = qdotdot.size() ? &qdotdot[0] : nullptr;
+    Real*             tauPtr           = tau.size()     ? &tau[0] : nullptr;
     SpatialVec*       zPtr             = allZ.begin();    
     SpatialVec*       zPlusPtr         = allZPlus.begin(); 
 
@@ -5187,7 +5327,7 @@ void SimbodyMatterSubsystemRep::calcTreeAccelerations(const State& s,
     for (int i=rbNodeLevels.size()-1 ; i>=0 ; i--) 
         for (int j=0 ; j<(int)rbNodeLevels[i].size() ; j++) {
             const RigidBodyNode& node = *rbNodeLevels[i][j];
-            node.calcUDotPass1Inward(ic,tpc,abc,dc,
+            node.calcUDotPass1Inward(ic,tpc,abc,abvc,
                 mobilityForcePtr, bodyForcePtr, udotPtr, zPtr, zPlusPtr,
                 hingeForcePtr);
         }
@@ -5210,8 +5350,9 @@ void SimbodyMatterSubsystemRep::calcTreeAccelerations(const State& s,
 //==============================================================================
 // Calculate udot = M^-1 f. We also get spatial accelerations A_GB for 
 // each body as a side effect.
-// This Subsystem must already be realized through Position stage; we'll 
-// realize articulated body inertias if necessary.
+// This Subsystem must already be realized through Position stage or at
+// least have PositionKinematics already available; we'll 
+// realize articulated body inertias here if necessary.
 // All vectors must use contiguous storage.
 void SimbodyMatterSubsystemRep::multiplyByMInv(const State& s,
     const Vector&                                           f,

--- a/Simbody/src/SimbodyMatterSubsystemRep.h
+++ b/Simbody/src/SimbodyMatterSubsystemRep.h
@@ -930,9 +930,6 @@ public:
         const Vector_<Real>&        qdotdot,
         Vector&                     pvaerr) const;
 
-    // This is a solver which generates internal velocities from spatial ones.
-    void velFromCartesian(const Vector& pos, Vector& vel) {assert(false);/*TODO*/}
-
     void enforcePositionConstraints(State& s, Real consAccuracy, const Vector& yWeights,
                                     const Vector& ooTols, Vector& yErrest, ProjectOptions) const;
     void enforceVelocityConstraints(State& s, Real consAccuracy, const Vector& yWeights,

--- a/Simbody/src/SimbodyMatterSubsystemRep.h
+++ b/Simbody/src/SimbodyMatterSubsystemRep.h
@@ -410,11 +410,39 @@ public:
     }
 
     // velocity dependent
-    const SpatialVec& getMobilizerCoriolisAcceleration(const State&, MobilizedBodyIndex) const;
-    const SpatialVec& getTotalCoriolisAcceleration    (const State&, MobilizedBodyIndex) const;
-    const SpatialVec& getGyroscopicForce              (const State&, MobilizedBodyIndex) const;
-    const SpatialVec& getMobilizerCentrifugalForces   (const State&, MobilizedBodyIndex) const;
-    const SpatialVec& getTotalCentrifugalForces       (const State&, MobilizedBodyIndex) const;
+    const SpatialVec& 
+    getMobilizerCoriolisAcceleration(const State&, MobilizedBodyIndex) const;
+    const SpatialVec& 
+    getTotalCoriolisAcceleration(const State&, MobilizedBodyIndex) const;
+    const SpatialVec& 
+    getGyroscopicForce(const State&, MobilizedBodyIndex) const;
+    const SpatialVec& 
+    getTotalCentrifugalForces(const State&, MobilizedBodyIndex) const;
+
+    /* [I'm not exposing this in the API any more so the detailed comment is
+    here rather than in SimbodyMatterSubsystem (where it used to be called
+    getMobilizerCentrifugalForces().]
+    This is part of the rotational velocity-dependent forces acting on a
+    particular mobilized body B, accounting for gyroscopic forces plus Coriolis 
+    forces due only to the *cross-mobilizer* velocity; this ignores the parent's 
+    velocity and is not useful except as an intermediate term in acceleration 
+    calculations -- see getTotalCentrifugalForces() instead. This is 
+    `F=P*A+b` where `P` is mobod B's articulated body inertia (ABI), `A` is its 
+    cross-mobilizer Coriolis acceleration (as returned by 
+    getMobilizerCoriolisAcceleration()), and `b` is the (rotational 
+    velocity-dependent) spatial gyroscopic force acting on B, as returned by
+    getGyroscopicForce().
+
+    Although this computation depends only on position and velocity kinematics, 
+    we won't calculate it until the first time it is needed, generally during 
+    realize(Acceleration). You can get it earlier if you have already realized 
+    velocity kinematics *and* ABIs, either by an explicit call to 
+    realizeArticulatedBodyInertias() or implicitly by asking for an ABI
+    using getArticulatedBodyInertia(). This method will not initiate ABI 
+    calculation automatically but will throw an exception instead if they are 
+    not available. */
+    const SpatialVec& 
+    getArticulatedBodyCentrifugalForces(const State&, MobilizedBodyIndex) const;
 
     // PARTICLES TODO
 
@@ -465,26 +493,38 @@ public:
         // REALIZATIONS //
 
 
-    // Call at Instance Stage or later.
+    // Call at Instance Stage or later. Depends on q; automatically realized
+    // at Stage::Position.
     void realizePositionKinematics(const State&) const;
 
-    // Call at Instance + PositionKinematics Stage or later.
+    // Call at Instance + PositionKinematics Stage or later. Depends on u;
+    // automatically realized at Stage::Velocity.
     void realizeVelocityKinematics(const State&) const;
 
-    // Call at Position Stage or later.
+    // Call at Instance + PositionKinematics Stage or later. Never realized
+    // automatically.
     void realizeCompositeBodyInertias(const State&) const;
 
-    // Call at Position Stage or later.
+    // Call at Instance + PositionKinematics Stage or later. Automatically
+    // realized at Stage::Acceleration.
     void realizeArticulatedBodyInertias(const State&) const;
+
+    // Call at Instance + VelocityKinematics + ArticulatedBodyInertias;
+    // automatically realized at Stage::Acceleration.
+    void realizeArticulatedBodyVelocity(const State&) const;
 
     bool isPositionKinematicsRealized(const State&) const;
     bool isVelocityKinematicsRealized(const State&) const;
+    bool isCompositeBodyInertiasRealized(const State&) const;
+    bool isArticulatedBodyInertiasRealized(const State&) const;
+    bool isArticulatedBodyVelocityRealized(const State&) const;
 
     // These are just used in timing tests.
     void invalidatePositionKinematics(const State&) const;
     void invalidateVelocityKinematics(const State&) const;
     void invalidateCompositeBodyInertias(const State&) const;
     void invalidateArticulatedBodyInertias(const State&) const;
+    void invalidateArticulatedBodyVelocity(const State&) const;
 
         // OPERATORS //
 
@@ -1054,6 +1094,20 @@ public:
     SBConstrainedVelocityCache& updConstrainedVelocityCache(const State& s) const { //mutable
         return Value<SBConstrainedVelocityCache>::downcast
             (s.updCacheEntry(getMySubsystemIndex(),topologyCache.constrainedVelocityCacheIndex)).upd();
+    }
+
+    const SBArticulatedBodyVelocityCache& 
+    getArticulatedBodyVelocityCache(const State& state) const {
+        return Value<SBArticulatedBodyVelocityCache>::downcast
+           (state.getCacheEntry(getMySubsystemIndex(),
+                topologyCache.articulatedBodyVelocityCacheIndex)).get();
+    }
+
+    SBArticulatedBodyVelocityCache& 
+    updArticulatedBodyVelocityCache(const State& state) const { //mutable
+        return Value<SBArticulatedBodyVelocityCache>::downcast
+            (state.updCacheEntry(getMySubsystemIndex(),
+                topologyCache.articulatedBodyVelocityCacheIndex)).upd();
     }
 
     const SBDynamicsCache& getDynamicsCache(const State& s, bool realizingDynamics=false) const {

--- a/Simbody/tests/TestMassMatrix.cpp
+++ b/Simbody/tests/TestMassMatrix.cpp
@@ -982,7 +982,7 @@ void testConstrainedSystem() {
 
 
 
-void testCompositeInertia() {
+void testCompositeBodyInertia() {
     MultibodySystem         mbs;
     SimbodyMatterSubsystem  pend(mbs);
 
@@ -1026,18 +1026,121 @@ void testCompositeInertia() {
     SpatialInertia cbi = pend.getCompositeBodyInertia(state, body1);
 
     body2.setAngle(state, Pi/4);
-    // This is not allowed until Position stage.
+    // This is not allowed until PositionKinematics stage.
     SimTK_TEST_MUST_THROW(pend.getCompositeBodyInertia(state, body1));
     mbs.realize(state, Stage::Position);
     // Now it should be OK.
     cbi = pend.getCompositeBodyInertia(state, body1);
 
-    mbs.realize(state, Stage::Acceleration);
-    //cout << "udots=" << state.getUDot() << endl;
+    body2.setAngle(state, Pi/5);
+    pend.realizePositionKinematics(state);
+    SimTK_TEST(state.getSystemStage() == Stage::Time);
+    SimTK_TEST(!pend.isCompositeBodyInertiasRealized(state));
+    pend.realizeCompositeBodyInertias(state);
+    SimTK_TEST(pend.isCompositeBodyInertiasRealized(state));
+    pend.invalidateCompositeBodyInertias(state);
+    SimTK_TEST(!pend.isCompositeBodyInertiasRealized(state));
+}
 
-    body1.setRate(state, 27);
+// Currently just testing validity/invalidation, not correctness.
+void testArticulatedBodyInertia() {
+    MultibodySystem mbs;
+    MyForceImpl* frcp;
+    makeSystem(true, mbs, frcp);
+    const SimbodyMatterSubsystem& matter = mbs.getMatterSubsystem();
+
+    const MobodIndex body1(1), body2(2);
+
+
+    State state = mbs.realizeTopology();
+    mbs.realize(state, Stage::Position);
+
+    // This should force realization of the articulated body inertias.
+    ArticulatedInertia abi = matter.getArticulatedBodyInertia(state, body1);
+    SimTK_TEST(matter.isArticulatedBodyInertiasRealized(state));
+    matter.invalidateArticulatedBodyInertias(state);
+    SimTK_TEST(!matter.isArticulatedBodyInertiasRealized(state));
+    matter.realizeArticulatedBodyInertias(state);
+    SimTK_TEST(matter.isArticulatedBodyInertiasRealized(state));
+
+    state.updQ()=0.1; 
+    SimTK_TEST(state.getSystemStage()==Stage::Time);
+    SimTK_TEST(!matter.isArticulatedBodyInertiasRealized(state));
+    // This is not allowed until PositionKinematics stage.
+    SimTK_TEST_MUST_THROW(matter.getArticulatedBodyInertia(state, body2));
+    mbs.realize(state, Stage::Position);
+    // Now it should be OK.
+    abi = matter.getArticulatedBodyInertia(state, body1);
+
+    matter.invalidatePositionKinematics(state); // a prerequisite
+    SimTK_TEST(!matter.isArticulatedBodyInertiasRealized(state));
+    matter.realizePositionKinematics(state);
+    matter.getArticulatedBodyInertia(state, body2); // ok; implicit realization
+    SimTK_TEST(matter.isArticulatedBodyInertiasRealized(state));
+    SimTK_TEST(state.getSystemStage()==Stage::Time);
+    state.updQ()=0.2; 
+    SimTK_TEST(!matter.isArticulatedBodyInertiasRealized(state));
+
+    mbs.realize(state, Stage::Acceleration); // implicit realization of abis
+    SimTK_TEST(matter.isArticulatedBodyInertiasRealized(state));
+
+    state.updTime()=1.; // shouldn't affect time-independent stuff
+    SimTK_TEST(state.getSystemStage()==Stage::Instance);
+    SimTK_TEST(matter.isPositionKinematicsRealized(state));
+    SimTK_TEST(matter.isArticulatedBodyInertiasRealized(state));
+}
+
+// Currently just testing validity/invalidation, not correctness.
+void testArticulatedBodyVelocity() {
+    MultibodySystem mbs;
+    MyForceImpl* frcp;
+    makeSystem(true, mbs, frcp);
+    const SimbodyMatterSubsystem& matter = mbs.getMatterSubsystem();
+
+    const MobodIndex body1(1), body2(2);
+
+
+    State state = mbs.realizeTopology();
+    mbs.realize(state, Stage::Position);
+
+    // Neither ABIs nor VelocityKinematics valid.
+    SimTK_TEST_MUST_THROW(matter.realizeArticulatedBodyVelocity(state));
+
+    mbs.realize(state, Stage::Velocity);
+    // ABIs still not valid.
+    SimTK_TEST_MUST_THROW(matter.realizeArticulatedBodyVelocity(state));
+
+    matter.realizeArticulatedBodyInertias(state);
+    matter.realizeArticulatedBodyVelocity(state); // OK now
+
+    state.updU()=0.1; // invalidates VelocityKinematics
+    SimTK_TEST(state.getSystemStage()==Stage::Position);
+    SimTK_TEST(!matter.isArticulatedBodyVelocityRealized(state));
+
+    mbs.realize(state, Stage::Dynamics); // not enough
+    SimTK_TEST(!matter.isArticulatedBodyVelocityRealized(state));
+
+    mbs.realize(state, Stage::Acceleration); // that should do it!
+    SimTK_TEST(matter.isArticulatedBodyVelocityRealized(state));
+
+    matter.invalidateArticulatedBodyInertias(state); // a prerequisite
+    SimTK_TEST(!matter.isArticulatedBodyVelocityRealized(state));
+
     mbs.realize(state, Stage::Acceleration);
-    //cout << "udots=" << state.getUDot() << endl;
+    SimTK_TEST(matter.isArticulatedBodyVelocityRealized(state));
+
+    matter.invalidateVelocityKinematics(state); // another prerequisite
+    SimTK_TEST(!matter.isArticulatedBodyVelocityRealized(state));
+
+    mbs.realize(state, Stage::Acceleration);
+    SimTK_TEST(matter.isArticulatedBodyVelocityRealized(state));
+
+    state.updTime()=1.; // shouldn't affect time-independent stuff
+    SimTK_TEST(state.getSystemStage()==Stage::Instance);
+    SimTK_TEST(matter.isPositionKinematicsRealized(state));
+    SimTK_TEST(matter.isVelocityKinematicsRealized(state));
+    SimTK_TEST(matter.isArticulatedBodyInertiasRealized(state));
+    SimTK_TEST(matter.isArticulatedBodyVelocityRealized(state));
 }
 
 void testTaskJacobians() {
@@ -1384,7 +1487,9 @@ int main() {
         SimTK_SUBTEST(testVelocityKinematics);
         SimTK_SUBTEST(testRel2Cart);
         SimTK_SUBTEST(testJacobianBiasTerms);
-        SimTK_SUBTEST(testCompositeInertia);
+        SimTK_SUBTEST(testCompositeBodyInertia);
+        SimTK_SUBTEST(testArticulatedBodyInertia);
+        SimTK_SUBTEST(testArticulatedBodyVelocity);
         SimTK_SUBTEST(testUnconstrainedSystem);
         SimTK_SUBTEST(testConstrainedSystem);
         SimTK_SUBTEST(testTaskJacobians);

--- a/Simbody/tests/TestMassMatrix.cpp
+++ b/Simbody/tests/TestMassMatrix.cpp
@@ -1081,6 +1081,9 @@ void testArticulatedBodyInertia() {
     state.updQ()=0.2; 
     SimTK_TEST(!matter.isArticulatedBodyInertiasRealized(state));
 
+    mbs.realize(state, Stage::Dynamics); // not high enough
+    SimTK_TEST(!matter.isArticulatedBodyInertiasRealized(state));
+
     mbs.realize(state, Stage::Acceleration); // implicit realization of abis
     SimTK_TEST(matter.isArticulatedBodyInertiasRealized(state));
 

--- a/Simbody/tests/adhoc/TestMultibodyPerformance.cpp
+++ b/Simbody/tests/adhoc/TestMultibodyPerformance.cpp
@@ -6,7 +6,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2011-12 Stanford University and the Authors.        *
+ * Portions copyright (c) 2011-15 Stanford University and the Authors.        *
  * Authors: Peter Eastman                                                     *
  * Contributors: Michael Sherman                                              *
  *                                                                            *
@@ -79,6 +79,12 @@ void doRealizeArticulatedBodyInertias(MultibodySystem& system, State& state) {
     const SimbodyMatterSubsystem& matter = system.getMatterSubsystem();
     matter.invalidateArticulatedBodyInertias(state);
     matter.realizeArticulatedBodyInertias(state);
+}
+
+void doRealizeArticulatedBodyVelocity(MultibodySystem& system, State& state) {
+    const SimbodyMatterSubsystem& matter = system.getMatterSubsystem();
+    matter.invalidateArticulatedBodyVelocity(state);
+    matter.realizeArticulatedBodyVelocity(state);
 }
 
 void doRealizeDynamics(MultibodySystem& system, State& state) {
@@ -202,6 +208,7 @@ void runAllTests(MultibodySystem& system, bool useEulerAngles=false) {
     timeComputation(system, doRealizeVelocityKinematics, "realizeVelocityKinematics", 5000, useEulerAngles);
     timeComputation(system, doRealizeVelocity, "realizeVelocity", 5000, useEulerAngles);
     timeComputation(system, doRealizeArticulatedBodyInertias, "doRealizeArticulatedBodyInertias", 3000, useEulerAngles);
+    timeComputation(system, doRealizeArticulatedBodyVelocity, "doRealizeArticulatedBodyVelocity", 5000, useEulerAngles);
     timeComputation(system, doRealizeDynamics, "realizeDynamics", 5000, useEulerAngles);
     timeComputation(system, doRealizeAcceleration, "realizeAcceleration", 5000, useEulerAngles);
     timeComputation(system, doRealizeDynamics2Acceleration, "doRealizeDynamics2Acceleration", 5000, useEulerAngles);


### PR DESCRIPTION
This is a follow-on to PR #432 that uses the new facility introduced there to fix the problem described in issue #370, and opensim-org/opensim-core#429. Now a model with zero mass properties can be realized to `Stage::Dynamics` without causing a singular mass matrix error; that error will not occur unless the model is realized to `Stage::Acceleration` where the mass matrix *must* be inverted to calculate accelerations.

Three more cache entries now use the "prerequisites" feature: 
- CompositeBodyInertias (depends on position kinematics from PR #432; never valid unless explicitly requested), 
- ArticulatedBodyInertias (also depends on position kinematics; automatically valid at `Stage::Acceleration`), and 
- ArticulatedBodyVelocity (depends on velocity kinematics from PR #432; automatically valid at `Stage::Acceleration`. 

[Technical note: So in addition to the last two being deferred to `Stage::Acceleration`, all three are now correctly understood as time-independent; changing time does not invalidate them. Any of them can be realized any time after `Stage::Instance`.]

Reviewers: you can probably ignore the changes to `RigidBodyNode_...` files. Those were very ugly and I couldn't resist cleaning them up. The real changes there are just to pass in the right cache entries for the data that got moved around. It might make sense to start with the test cases I added to the now inadequately-named TestMassMatrix regression.

/cc @chrisdembia, @tkuchida, @aymanhab, @aseth1