### PR TITLE
Added a check on MSVC compiler with C++ 2011 features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,17 @@ endif(COMMAND cmake_policy)
 
 project(Simbody)
 
+if(MSVC)
+    if(MSVC_VERSION LESS 1800 OR MSVC_VERSION EQUAL 1800)
+        message(FATAL_ERROR "\nMSVC does not support C++ 2011 features, for "
+                            "example 'constexpr'. Update to at least MSVC 2015 "
+                            "or use a MinGW version on Windows.\nLook at the "
+                            "README.md for more information.\nIf you have the"
+                            " 'Visual C++ Compiler Nov 2013 CTP (CTP_Nov2013)'"
+                            " comment this test and configure normally.")
+    endif()
+endif()
+
 # At this point CMake will have set CMAKE_INSTALL_PREFIX to /usr/local on Linux
 # or appropriate ProgramFiles directory on Windows, for example
 # C:/Program Files/Simbody, C:/Program Files (x86)/Simbody, or the local

--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -19,6 +19,25 @@ if(WIN32 AND NOT CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
  return()
 endif()
 
+# With MSVC, we check that the compiler supports C++ 2011.
+# We can check the value of MSVC_VERSION with a test like this:
+#   if(MSVC_VERSION LESS 1800 OR MSVC_VERSION EQUAL 1800)
+#   endif()
+# However, there is a special version of MSVC 2013 (CTP) that supports C++ 2011
+# features, so we make a test to see if compiler supports C++ 2011.
+if(MSVC)
+    include(CheckCXXSourceCompiles)
+    CHECK_CXX_SOURCE_COMPILES("constexpr int f() { return 0; }\nint main(){f();return 0;}" MSVC_SUPPORTS_CONSTEXPR)
+    if(NOT MSVC_SUPPORTS_CONSTEXPR)
+        message(FATAL_ERROR "\nMSVC does not support C++ 2011 features, for "
+                            "example 'constexpr'. Update to at leaset MSVC 2015 "
+                            "or use a MinGW version on Windows.\nLook at the "
+                            "README.md for more information\nIf you have the"
+                            " 'Visual C++ Compiler Nov 2013 CTP (CTP_Nov2013)'"
+                            " comment this test and configure normally.")
+    endif()
+endif()
+
 if(MINGW)
     # Caution: No cross-compiling is taken into account:
     # If we use a 32 bit compiler, we will get a 32 executable.

--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -19,20 +19,28 @@ if(WIN32 AND NOT CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
  return()
 endif()
 
-# With MSVC, we check that the compiler supports C++ 2011.
-# We can check the value of MSVC_VERSION with a test like this:
-#   if(MSVC_VERSION LESS 1800 OR MSVC_VERSION EQUAL 1800)
-#   endif()
-# However, there is a special version of MSVC 2013 (CTP) that supports C++ 2011
-# features, so we make a test to see if compiler supports C++ 2011.
 if(MSVC)
-    include(CheckCXXSourceCompiles)
-    CHECK_CXX_SOURCE_COMPILES("constexpr int f() { return 0; }\nint main(){f();return 0;}" MSVC_SUPPORTS_CONSTEXPR)
-    if(NOT MSVC_SUPPORTS_CONSTEXPR)
+    # With MSVC, we check that the compiler supports C++ 2011.
+    # To do so, we can check:
+    #   - the value of MSVC_VERSION with a test like this:
+    #       include(CheckCXXSourceCompiles)
+    #       check_cxx_source_compiles(
+    #           "constexpr int f() { return 0; }\nint main(){f();return 0;}"
+    #           MSVC_SUPPORTS_CONSTEXPR)
+    #       if(NOT MSVC_SUPPORTS_CONSTEXPR)
+    #           message(FATAL_ERROR "MSVC does not support C++ 2011 features")
+    #       endif()
+    #   - the value of MSVC_VERSION
+    #       if(MSVC_VERSION LESS 1800 OR MSVC_VERSION EQUAL 1800)
+    #       endif()
+    #
+    # If you use a special version of MSVC 2013 (CTP) that supports C++ 2011
+    # features, so you should comment the following block.
+    if(MSVC_VERSION LESS 1800 OR MSVC_VERSION EQUAL 1800)
         message(FATAL_ERROR "\nMSVC does not support C++ 2011 features, for "
-                            "example 'constexpr'. Update to at leaset MSVC 2015 "
+                            "example 'constexpr'. Update to at least MSVC 2015 "
                             "or use a MinGW version on Windows.\nLook at the "
-                            "README.md for more information\nIf you have the"
+                            "README.md for more information.\nIf you have the"
                             " 'Visual C++ Compiler Nov 2013 CTP (CTP_Nov2013)'"
                             " comment this test and configure normally.")
     endif()

--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -19,33 +19,6 @@ if(WIN32 AND NOT CMAKE_HOST_SYSTEM_NAME MATCHES Windows)
  return()
 endif()
 
-if(MSVC)
-    # With MSVC, we check that the compiler supports C++ 2011.
-    # To do so, we can check:
-    #   - the value of MSVC_VERSION with a test like this:
-    #       include(CheckCXXSourceCompiles)
-    #       check_cxx_source_compiles(
-    #           "constexpr int f() { return 0; }\nint main(){f();return 0;}"
-    #           MSVC_SUPPORTS_CONSTEXPR)
-    #       if(NOT MSVC_SUPPORTS_CONSTEXPR)
-    #           message(FATAL_ERROR "MSVC does not support C++ 2011 features")
-    #       endif()
-    #   - the value of MSVC_VERSION
-    #       if(MSVC_VERSION LESS 1800 OR MSVC_VERSION EQUAL 1800)
-    #       endif()
-    #
-    # If you use a special version of MSVC 2013 (CTP) that supports C++ 2011
-    # features, so you should comment the following block.
-    if(MSVC_VERSION LESS 1800 OR MSVC_VERSION EQUAL 1800)
-        message(FATAL_ERROR "\nMSVC does not support C++ 2011 features, for "
-                            "example 'constexpr'. Update to at least MSVC 2015 "
-                            "or use a MinGW version on Windows.\nLook at the "
-                            "README.md for more information.\nIf you have the"
-                            " 'Visual C++ Compiler Nov 2013 CTP (CTP_Nov2013)'"
-                            " comment this test and configure normally.")
-    endif()
-endif()
-
 if(MINGW)
     # Caution: No cross-compiling is taken into account:
     # If we use a 32 bit compiler, we will get a 32 executable.


### PR DESCRIPTION
This PR adds a CMake check on the MSVC compilation. If C++ 2011 feature like `constexpr` is not supported, we stop configuration. 

I have used MSVC2013 and I only discovered at compilation time that this compiler did not support all C++ 2011 features. This is why I propose this PR