### PR TITLE
Fixed a bug detecting if file is DLL

### DIFF
--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -137,7 +137,6 @@ set_target_properties(PlatformFiles
 
 foreach(LIBF ${LIB_FILES})
     get_filename_component(LIBF_ROOT ${LIBF} NAME)
-    get_filename_component(LIBF_SUFFIX ${LIBF} EXT)
     set(COPIED_LIBF "${BUILD_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${LIBF_ROOT}")
     if(MINGW)
         set(LIBF_SRC ${LIBF})
@@ -147,7 +146,8 @@ foreach(LIBF ${LIB_FILES})
         file(TO_NATIVE_PATH "${COPIED_LIBF}" LIBF_DEST)
     endif()
 
-    if(LIBF_SUFFIX STREQUAL ".dll")
+    string(REGEX MATCH "[.][dD][lL][lL]$" isFileADll ${LIBF})
+    if(isFileADll)
         # Only the runtime libraries (.dll) are needed next to the
         # executables/tests; import libraries (.lib) are linked through
         # target_link_libraries.
@@ -158,7 +158,7 @@ foreach(LIBF ${LIB_FILES})
             VERBATIM)
     endif()
 
-    if(LIBF_SUFFIX STREQUAL ".dll")
+    if(isFileADll)
         install(FILES ${LIBF}
         PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE
                 GROUP_READ GROUP_WRITE GROUP_EXECUTE


### PR DESCRIPTION
Before this fix, CMake get_filename_component ext function returns 0.dll
for "lapack-3.5.0.dll", which is not the expected result

This fix proposes to test the end of the filename to see if file is a dll

Below is a CMakeLists.txt that exposes the problem

    cmake_minimum_required(VERSION 2.8.8)
    project(test)
    set(LIBF "lapack-3.5.0.dll")
    
    get_filename_component(LIBF_SUFFIX ${LIBF} EXT)
    if(LIBF_SUFFIX STREQUAL ".dll")
        MESSAGE(STATUS "File is a DLL")
    else()
        MESSAGE(STATUS "File was not detected as a DLL -> PROBLEM with get_filename_component")
    endif()
    
    string(REGEX MATCH "[.][dD][lL][lL]$" isFileADll ${LIBF})
    IF(isFileADll)
        MESSAGE(STATUS "File is a DLL -> OK")
    ELSE()
        MESSAGE(STATUS "File was not detected as a DLL -> It should have been detected such")
    ENDIF()
    
    set(LIBF "lapack-3.5.0.DLL")
    string(REGEX MATCH "[.][dD][lL][lL]$" isFileADll ${LIBF})
    IF(isFileADll)
        MESSAGE(STATUS "File is a DLL -> OK")
    ELSE()
        MESSAGE(STATUS "File was not detected as a DLL -> It should have been detected such")
    ENDIF()