### PR TITLE
Added test cases for elastic foundation theory

### DIFF
--- a/Simbody/tests/TestElasticFoundationForce.cpp
+++ b/Simbody/tests/TestElasticFoundationForce.cpp
@@ -49,7 +49,7 @@ void testForces() {
 
     // Create a triangle mesh in the shape of a pyramid, with the
     // square base having area 1 (split into two triangles).
-    
+
     vector<Vec3> vertices;
     vertices.push_back(Vec3(0, 0, 0));
     vertices.push_back(Vec3(1, 0, 0));
@@ -57,14 +57,14 @@ void testForces() {
     vertices.push_back(Vec3(0, 0, 1));
     vertices.push_back(Vec3(0.5, 1, 0.5));
     vector<int> faceIndices;
-    int faces[6][3] = {{0, 1, 2}, {0, 2, 3}, {1, 0, 4}, 
+    int faces[6][3] = {{0, 1, 2}, {0, 2, 3}, {1, 0, 4},
                        {2, 1, 4}, {3, 2, 4}, {0, 3, 4}};
     for (int i = 0; i < 6; i++)
         for (int j = 0; j < 3; j++)
             faceIndices.push_back(faces[i][j]);
 
     // Create the mobilized bodies and configure the contact model.
-    
+
     Body::Rigid body(MassProperties(1.0, Vec3(0), Inertia(1)));
     ContactSetIndex setIndex = contacts.createContactSet();
     MobilizedBody::Translation mesh(matter.updGround(), Transform(), body, Transform());
@@ -76,10 +76,10 @@ void testForces() {
     ef.setTransitionVelocity(vt);
     ASSERT(ef.getTransitionVelocity() == vt);
     State state = system.realizeTopology();
-    
-    // Position the pyramid at a variety of positions and check the normal 
+
+    // Position the pyramid at a variety of positions and check the normal
     // force.
-    
+
     for (Real depth = -0.1; depth < 0.1; depth += 0.01) {
         mesh.setQToFitTranslation(state, Vec3(0, -depth, 0));
         system.realize(state, Stage::Dynamics);
@@ -89,7 +89,7 @@ void testForces() {
         assertEqual(system.getRigidBodyForces(state, Stage::Dynamics)[mesh.getMobilizedBodyIndex()][1], Vec3(0, f, 0));
         assertEqual(system.getRigidBodyForces(state, Stage::Dynamics)[matter.getGround().getMobilizedBodyIndex()][1], Vec3(0, -f, 0));
     }
-    
+
     // Now do it with a vertical velocity and see if the dissipation force is correct.
 
     for (Real depth = -0.105; depth < 0.1; depth += 0.01) {
@@ -103,7 +103,7 @@ void testForces() {
             assertEqual(system.getRigidBodyForces(state, Stage::Dynamics)[mesh.getMobilizedBodyIndex()][1], Vec3(0, f, 0));
         }
     }
-    
+
     // Do it with a horizontal velocity and see if the friction force is correct.
 
     Vector_<SpatialVec> expectedForce(matter.getNumBodies());

--- a/Simbody/tests/TestElasticFoundationForce.cpp
+++ b/Simbody/tests/TestElasticFoundationForce.cpp
@@ -7,7 +7,7 @@
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
  * Portions copyright (c) 2008-12 Stanford University and the Authors.        *
- * Authors: Peter Eastman                                                     *
+ * Authors: Peter Eastman, Guillaume Jacquenot                                *
  * Contributors:                                                              *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *


### PR DESCRIPTION
I have added two test cases for the elastic foundation problem of a sphere on a plane (old and new formulation). For this problem, an analytical solution can be computed: the resulting force corresponds to the product of the spherical cap volume of intersection with the stiffness.

For the different penetration values, I have set a tolerance in %. For some penetrations, we are very close to the analytical solution. (Less than 0.5%). For other, tolerance may be higher (15%)

 - For the old formulation, I have understood that we declare the contact property taking into account the properties of the material. It is fine.

 - For the new formulation, we declare material properties and the code computes global stiffness. I would have liked to have the possibility to declare an infinitely rigid ground. I had to split the stiffness between the material, which for this test case is not ideal.
Moreover, I did not understand why with this formulation, I had to declare a thickness. In the old formulation, I did not have to do so...


