### PR TITLE
Minor fixes in support for upcoming state serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ to ParallelExecutor, mutex state lock.
   explicitly with new methods `realizePositionKinematics()` and
   `realizeVelocityKinematics()`. They are invalidated by a change to q or
   to u, respectively. 
+* Modified floating point-to-String conversions to use lossless number of 
+  digits by default. An attempt to use the default type-to-String conversion 
+  when no stream insertion operator is available is now a runtime rather than
+  compile time error. [PR #459](https://github.com/simbody/simbody/pull/459).
 * (There are more that haven't been added yet)
 
 

--- a/SimTKcommon/Simulation/src/System.cpp
+++ b/SimTKcommon/Simulation/src/System.cpp
@@ -1066,7 +1066,7 @@ public:
 class DefaultSystemSubsystem::Guts : public Subsystem::Guts {
 public:
 
-    Guts() : Subsystem::Guts("DefaultSystemSubsystem::Guts", "0.0.1") { }
+    Guts() : Subsystem::Guts("DefaultSystemSubsystem", "0.0.1") { }
     
     ~Guts() {
         for (int i = 0; i < (int)scheduledEventHandlers.size(); ++i)

--- a/SimTKcommon/include/SimTKcommon/internal/Serialize.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Serialize.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2012 Stanford University and the Authors.           *
+ * Portions copyright (c) 2015 Stanford University and the Authors.           *
  * Authors: Michael Sherman                                                   *
  * Contributors:                                                              *
  *                                                                            *
@@ -68,40 +68,28 @@ work correctly too. **/
 /** The default implementation of writeUnformatted\<T> converts the object to
 a String using the templatized String constructor, and then writes that
 string to the stream using String::operator<<(). This is suitable for use
-with any of the built-in types. Note that bool will be output "true" or
-"false" and non-finite floating point values are written as NaN, Inf,
-or -Inf as appropriate. **/
+with any of the built-in types. Bool will be output "true" or "false", floating
+point values will be written with enough digits to be read back unchanged,
+and non-finite floating point values are written as NaN, Inf, or -Inf as 
+appropriate (Matlab compatible). **/
 template <class T> inline void
 writeUnformatted(std::ostream& o, const T& v) {
     o << String(v);
 }
 
-/** Specialize for float to help some compilers with template matching. **/
-template <class T> inline void
-writeUnformatted(std::ostream& o, const float& v)  
-{   writeUnformatted<float>(o,v); }
-/** Specialize for double to help some compilers with template matching. **/
-template <class T> inline void
-writeUnformatted(std::ostream& o, const double& v) 
-{   writeUnformatted<double>(o,v); }
-/** Specialize for long double to help some compilers with template 
-matching. **/
-template <class T> inline void
-writeUnformatted(std::ostream& o, const long double& v) 
-{   writeUnformatted<long double>(o,v); }
-
-/** Specialize for SimTK::negator\<T>: convert to T and write. **/
+/** Partial specialization for SimTK::negator\<T>: convert to T and write. **/
 template <class T> inline void
 writeUnformatted(std::ostream& o, const negator<T>& v) 
 {   writeUnformatted(o, T(v)); }
 
-/** Specialize for std::complex\<T>: just write two T's separated by a space;
-no parentheses or comma. **/
+/** Partial specialization for std::complex\<T>: just write two T's separated by
+a space; no parentheses or comma. **/
 template <class T> inline void
 writeUnformatted(std::ostream& o, const std::complex<T>& v) 
 {   writeUnformatted(o, v.real()); o << " "; writeUnformatted(o, v.imag()); }
 
-/** Specialize for SimTK::conjugate\<T>: same as std::complex\<T>. **/
+/** Partial specialization for SimTK::conjugate\<T>: same as 
+std::complex\<T>. **/
 template <class T> inline void
 writeUnformatted(std::ostream& o, const conjugate<T>& v) 
 {   writeUnformatted(o, std::complex<T>(v)); }
@@ -192,20 +180,6 @@ readUnformatted(std::istream& in, T& v) {
     {   in.setstate(std::ios::failbit); return false; }
     return true;
 }
-
-/** Specialize for float to help some compilers with template matching. **/
-template <class T> inline bool
-readUnformatted(std::istream& in, float& v) 
-{   return readUnformatted<float>(in,v); }
-/** Specialize for double to help some compilers with template matching. **/
-template <class T> inline bool
-readUnformatted(std::istream& in, double& v) 
-{   return readUnformatted<double>(in,v); }
-/** Specialize for long double to help some compilers with template 
-matching. **/
-template <class T> inline bool
-readUnformatted(std::istream& in, long double& v) 
-{   return readUnformatted<long double>(in,v); }
 
 /** Specialization for negator<T>: read as type T and convert. **/
 template <class T> inline bool

--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -136,33 +136,39 @@ explicit String(unsigned long long s, const char* fmt="%llu")
 {   char buf[64]; sprintf(buf,fmt,s); (*this)=buf; }
 
 /** Format a float as a printable %String. Nonfinite values are formatted as
-NaN, Inf, or -Inf as appropriate (Matlab compatible). **/
-SimTK_SimTKCOMMON_EXPORT explicit String(float r, const char* fmt="%.7g");
+NaN, Inf, or -Inf as appropriate (Matlab compatible). The default format
+specification includes enough digits so that the identical value will be
+recovered if the string is converted back to float. **/
+SimTK_SimTKCOMMON_EXPORT explicit String(float r, const char* fmt="%.9g");
 
 /** Format a double as a printable %String. Nonfinite values are formatted as
-NaN, Inf, or -Inf as appropriate (Matlab compatible). **/
-SimTK_SimTKCOMMON_EXPORT explicit String(double r, const char* fmt="%.15g");
+NaN, Inf, or -Inf as appropriate (Matlab compatible). The default format
+specification includes enough digits so that the identical value will be
+recovered if the string is converted back to double. **/
+SimTK_SimTKCOMMON_EXPORT explicit String(double r, const char* fmt="%.17g");
 
-/** Format a long double as a printable %String. Nonfinite values are 
-formatted as NaN, Inf, or -Inf as appropriate (Matlab compatible). **/
+/** Format a long double as a printable %String. Nonfinite values are formatted 
+as NaN, Inf, or -Inf as appropriate (Matlab compatible). The default format
+specification includes enough digits so that the identical value will be
+recovered if the string is converted back to long double. **/
 SimTK_SimTKCOMMON_EXPORT explicit String(long double r, 
-                                         const char* fmt="%.20Lg");
+                                         const char* fmt="%.21Lg");
 
 /** Format a complex\<float> as a printable %String (real,imag) with parentheses
 and a comma as shown. The format string should be for a single float and will 
 be used twice; the default format is the same as for float. **/
-explicit String(std::complex<float> r, const char* fmt="%.7g")
+explicit String(std::complex<float> r, const char* fmt="%.9g")
 {   (*this)="(" + String(r.real(),fmt) + "," + String(r.imag(),fmt) + ")"; }
 /** Format a complex\<double> as a printable %String (real,imag) with 
 parentheses and a comma as shown. The format string should be for a single 
 double and will be used twice; the default format is the same as for double. **/
-explicit String(std::complex<double> r, const char* fmt="%.15g")    
+explicit String(std::complex<double> r, const char* fmt="%.17g")    
 {   (*this)="(" + String(r.real(),fmt) + "," + String(r.imag(),fmt) + ")"; }
 /** Format a complex\<long double> as a printable %String (real,imag) with 
 parentheses and a comma as shown. The format string should be for a single long
 double and will be used twice; the default format is the same as for long
 double. **/
-explicit String(std::complex<long double> r, const char* fmt="%.20Lg")    
+explicit String(std::complex<long double> r, const char* fmt="%.21Lg")    
 {   (*this)="(" + String(r.real(),fmt) + "," + String(r.imag(),fmt) + ")"; }
 
 /** Format a bool as a printable %String "true" or "false"; if you want "1"
@@ -329,13 +335,54 @@ String& replaceAllChar(const std::string& in, char oldChar, char newChar)
 // to worry about binary compatibility issues that can arise when passing 
 // streams through the API.
 
-/** Generic templatized %String constructor uses T::operator<<() to generate
-the %String when no specialization is available. **/ 
+/** @cond **/ // Hide from Doxygen
+template <class T> inline
+auto stringStreamInsertHelper(std::ostringstream& os, const T& t, bool)
+    -> decltype(static_cast<std::ostringstream&>(os << t)) {
+    os << t;
+    return os;
+}
+
+
+template <class T> inline
+auto stringStreamInsertHelper(std::ostringstream& os, const T& t, int)
+                                                    -> std::ostringstream& {
+    SimTK_ERRCHK1_ALWAYS(!"no stream insertion operator", "String::String(T)", 
+        "Type T=%s has no stream insertion operator<<(T) and there "
+        "is no specialized String(T) constructor.", 
+        NiceTypeName<T>::namestr().c_str());
+    return os;
+}
+
+template <class T> inline
+auto stringStreamExtractHelper(std::istringstream& is, T& t, bool)
+    -> decltype(static_cast<std::istringstream&>(is >> t)) {
+    is >> t;
+    return is;
+}
+
+template <class T> inline
+auto stringStreamExtractHelper(std::istringstream& is, T& t, int)
+                                                    -> std::istringstream& {
+    SimTK_ERRCHK1_ALWAYS(!"no stream extraction operator", 
+        "String::tryConvertTo<T>()", 
+        "Type T=%s has no stream extraction operator>>(T) and there "
+        "is no specialized tryConvertTo<T>() constructor.", 
+        NiceTypeName<T>::namestr().c_str());
+    return is;
+}
+
+/** @endcond **/
+
+/** Generic templatized %String constructor uses stream insertion 
+`operator<<(T)` to generate the %String when no specialization of this
+constructor is available. A *runtime* error is thrown if this method is
+invoked and neither a specialization nor stream insertion operator is 
+available. **/ 
 template <class T> inline
 String::String(const T& t) {
-    std::ostringstream stream;
-    stream << t;
-    *this = stream.str();
+    std::ostringstream os;
+    *this = stringStreamInsertHelper(os, t, true).str();
 }
 
 
@@ -346,7 +393,8 @@ String::String(const T& t) {
 template <class T> inline static
 bool tryConvertStringTo(const String& value, T& out) {
     std::istringstream sstream(value);
-    sstream >> out; if (sstream.fail()) return false;
+    stringStreamExtractHelper(sstream, out, true);
+    if (sstream.fail()) return false;
     if (sstream.eof()) return true;
     // Successful conversion but didn't use all the characters. Maybe the
     // rest is just whitespace?


### PR DESCRIPTION
A few miscellaneous changes needed for issue #305:

- Modify default floating point-to-String conversions to use lossless number of digits.
- Make lack of type-to-String conversion a runtime rather than compile time error to avoid overly strict requirements on types that never actually get serialized.
- Remove some unwarranted code from existing serialization collection.