### PR TITLE
Canonicalize NiceTypeName and add XML-friendly version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,9 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" = "linux" && "$CXX" = "g++" ]]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
   
   # CMake 2.8.11 on Ubuntu.
-  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:kalakris/cmake -y; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get --yes update -qq; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get --yes install cmake; fi
+  #- if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:kalakris/cmake -y; fi
+  #- if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get --yes update -qq; fi
+  #- if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get --yes install cmake; fi
 
 install:
   - mkdir ~/simbody-build && cd ~/simbody-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 # This script is used by the Travis-CI (continuous integration) testing
 # framework to run Simbody's tests with every GitHub push or pull-request.
+#
+# Ask for Ubuntu "trusty" (14.04) to pick up newer compilers. Still have
+# to upgrade gcc from trusty's 4.8 to 4.9 though, because 4.8 didn't support
+# C++11 regular expressions.
+sudo: required
+dist: trusty
 language: cpp
     
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then if grep --recursive --include={*.cpp,*.c,*.h,*.md,*.yml,*.cmake.*.xml,*.html,*.in,*.txt} -P "\t" . ; then echo "Tabs found in the lines shown above. See CONTRIBUTING.md about tabs."; false; else echo "Repo passed no-tabs check."; fi; else echo "No-tabs check not performed."; fi
   
   ## Dependencies for Simbody.
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get update; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install liblapack-dev; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install freeglut3-dev libxi-dev libxmu-dev; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get --yes update; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get --yes install liblapack-dev; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get --yes install freeglut3-dev libxi-dev libxmu-dev; fi
 
   # C++11 on Ubuntu. Update to gcc 4.9, which provides full C++11 support.  We
   # use this script because if building Simbody with C++11, we need gcc-4.9,
@@ -45,14 +45,14 @@ before_install:
   # building with Clang, we need the newer libstdc++ that we get by updating to
   # gcc-4.9.  See https://github.com/travis-ci/travis-ci/issues/979.
   - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get update -qq; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get install -qq g++-4.9; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get --yes update -qq; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get --yes install -qq g++-4.9; fi
   - if [[ "$TRAVIS_OS_NAME" = "linux" && "$CXX" = "g++" ]]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
   
   # CMake 2.8.11 on Ubuntu.
   - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:kalakris/cmake -y; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get update -qq; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get install cmake; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get --yes update -qq; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get --yes install cmake; fi
 
 install:
   - mkdir ~/simbody-build && cd ~/simbody-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,15 @@ before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install liblapack-dev; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get install freeglut3-dev libxi-dev libxmu-dev; fi
 
-  # C++11 on Ubuntu. Update to gcc 4.8, which provides full C++11 support.  We
-  # use this script because if building Simbody with C++11, we need gcc-4.8,
+  # C++11 on Ubuntu. Update to gcc 4.9, which provides full C++11 support.  We
+  # use this script because if building Simbody with C++11, we need gcc-4.9,
   # and the Travis Ubuntu 12.04 machines have an older version of gcc. Even if
   # building with Clang, we need the newer libstdc++ that we get by updating to
-  # gcc-4.8.  See https://github.com/travis-ci/travis-ci/issues/979.
+  # gcc-4.9.  See https://github.com/travis-ci/travis-ci/issues/979.
   - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y; fi
   - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get update -qq; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get install -qq g++-4.8; fi
-  - if [[ "$TRAVIS_OS_NAME" = "linux" && "$CXX" = "g++" ]]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo apt-get install -qq g++-4.9; fi
+  - if [[ "$TRAVIS_OS_NAME" = "linux" && "$CXX" = "g++" ]]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
   
   # CMake 2.8.11 on Ubuntu.
   - if [[ "$TRAVIS_OS_NAME" = "linux" ]]; then sudo add-apt-repository ppa:kalakris/cmake -y; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,11 @@ to ParallelExecutor, mutex state lock.
   must be removed or replaced with `using namespace SimTK::Xml` or
   `using SimTK::Xml::Document` depending on the intent. 
   [PR #460](https://github.com/simbody/simbody/pull/460)
+* Improved `NiceTypeName<T>::namestr()` to produce a canonicalized name that is
+  the same on all platforms (with a few exceptions). Added `xmlstr()` method to
+  make an XML-friendly modification of `namestr()` that replaces angle brackets
+  with curly braces. Added a new regression test to verify that the names come
+  out right. [PR #461](https://github.com/simbody/simbody/pull/460)
 * (There are more that haven't been added yet)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ to ParallelExecutor, mutex state lock.
   the same on all platforms (with a few exceptions). Added `xmlstr()` method to
   make an XML-friendly modification of `namestr()` that replaces angle brackets
   with curly braces. Added a new regression test to verify that the names come
-  out right. [PR #461](https://github.com/simbody/simbody/pull/460)
+  out right. [PR #461](https://github.com/simbody/simbody/pull/461)
 * (There are more that haven't been added yet)
 
 

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -843,7 +843,7 @@ inline std::string decodeXMLTypeName(const std::string& xmlTypeName)
 
 /** Obtain human-readable and XML-usable names for arbitrarily-complicated
 C++ types. Three methods `name()`, `namestr()`, and `xmlstr()` are provided
-giving respectively the raw, compiler-dependent output from `typeid(T).%name()`, 
+giving respectively the compiler-dependent output from `typeid(T).%name()`, 
 a canonicalized human-readable string, and the canonicalized string with
 XML-forbidden angle brackets replaced by curly braces. The default 
 implementation is usable for most types, but if you don't like the result you 

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -796,21 +796,86 @@ typedef Is64BitHelper<Is64BitPlatform>::Result Is64BitPlatformType;
 
 /** Attempt to demangle a type name as returned by typeid.name(), with the
 result hopefully suitable for meaningful display to a human. Behavior is 
-compiler-dependent. **/
-SimTK_SimTKCOMMON_EXPORT std::string demangle(const char* name);
+compiler-dependent. 
+@relates SimTK::NiceTypeName **/
+SimTK_SimTKCOMMON_EXPORT 
+std::string demangle(const char* name);
 
-/** In case you don't like the name you get from typeid(), you can specialize
-this class to provide a nicer name. This class is typically used for error 
-messages and testing. **/
+/** Given a compiler-dependent demangled type name string as returned by 
+SimTK::demangle(), attempt to form a canonicalized representation that will be
+the same for any compiler. Unnecessary spaces and superfluous keywords like
+"class" and "struct" are removed. The `namestr()` method of NiceTypeName\<T>
+uses this function to produce a human-friendly type name that is the same on any
+platform. The input argument is left empty. 
+@relates SimTK::NiceTypeName **/
+SimTK_SimTKCOMMON_EXPORT 
+std::string canonicalizeTypeName(std::string&& demangledTypeName);
+
+/** Same, but takes an lvalue reference so has to copy the input. 
+@relates SimTK::NiceTypeName **/
+inline std::string canonicalizeTypeName(const std::string& demangledTypeName)
+{   return canonicalizeTypeName(std::string(demangledTypeName)); }
+
+/** Given a canonicalized type name, produce a modified version that is 
+better-suited to use as an XML attribute. This means replacing the angle
+brackets with curly braces to avoid trouble. The input argument is left
+empty. 
+@relates SimTK::NiceTypeName **/
+SimTK_SimTKCOMMON_EXPORT
+std::string encodeTypeNameForXML(std::string&& canonicalizedTypeName);
+
+/** Same, but takes an lvalue reference so has to copy the input. 
+@relates SimTK::NiceTypeName **/
+inline std::string encodeTypeNameForXML(const std::string& niceTypeName)
+{   return encodeTypeNameForXML(std::string(niceTypeName)); }
+
+/** Given a type name that was encoded for XML by SimTK::encodeTypeNameForXML(),
+restore it to its canonicalized form. This means replacing curly braces by
+angle brackets. The input argument is left empty. 
+@relates SimTK::NiceTypeName **/
+SimTK_SimTKCOMMON_EXPORT
+std::string decodeXMLTypeName(std::string&& xmlTypeName);
+
+/** Same, but takes an lvalue reference so has to copy the input. 
+@relates SimTK::NiceTypeName **/
+inline std::string decodeXMLTypeName(const std::string& xmlTypeName)
+{   return decodeXMLTypeName(std::string(xmlTypeName)); }
+
+/** Obtain human-readable and XML-usable names for arbitrarily-complicated
+C++ types. Three methods `name()`, `namestr()`, and `xmlstr()` are provided
+giving respectively the raw, compiler-dependent output from `typeid(T).%name()`, 
+a canonicalized human-readable string, and the canonicalized string with
+XML-forbidden angle brackets replaced by curly braces. The default 
+implementation is usable for most types, but if you don't like the result you 
+can specialize to provide nicer names. For example, you may prefer SimTK::Vec3 
+to SimTK::Vec\<3,double,1>.
+
+@warning Don't expect usable names for types that are defined in an anonymous 
+namespace or for function-local types. Names will still be produced but they 
+won't be unique and won't necessarily be compiler-independent.
+
+The output of `namestr()` is typically used for error messages and testing;
+`xmlstr()` is used for type tags in XML for use in deserializing. **/
 template <class T> struct NiceTypeName {
     /** The default implementation of name() here returns the raw result from
-    typeid(T).name() which will be fast but may be a mangled name in some 
+    `typeid(T).%name()` which will be fast but may be a mangled name in some 
     compilers (gcc and clang included). **/
     static const char* name() {return typeid(T).name();}
     /** The default implementation of namestr() attempts to return a nicely
-    demangled type name on all platforms, using the SimTK::demangle() method
-    defined above. Don't expect this to be fast. **/
-    static std::string namestr() {return demangle(name());}
+    demangled and canonicalized type name on all platforms, using the 
+    SimTK::demangle() and SimTK::canonicalizeTypeName() methods. This is an
+    expensive operation but is only done once. **/
+    static const std::string& namestr() {
+        static const std::string canonical = 
+            canonicalizeTypeName(demangle(name()));
+        return canonical;
+    }
+    /** The default implementation of xmlstr() takes the output of namestr()
+    and invokes SimTK::encodeTypeNameForXML() on it. **/
+    static const std::string& xmlstr() {
+        static const std::string xml = encodeTypeNameForXML(namestr());
+        return xml;
+    }
 };
 
 } // namespace SimTK
@@ -821,12 +886,19 @@ from resolution of typedefs, default template arguments, etc. Note that this
 macro generates a template specialization that must be done in the SimTK
 namespace; consequently it opens and closes namespace SimTK and must not
 be invoked if you already have that namespace open. **/
-#define SimTK_NICETYPENAME_LITERAL(T)               \
-namespace SimTK {                                   \
-    template <> struct NiceTypeName< T > {          \
-        static std::string namestr() { return #T; } \
-        static const char* name() { return #T; }    \
-    };                                              \
+#define SimTK_NICETYPENAME_LITERAL(T)                                   \
+namespace SimTK {                                                       \
+template <> struct NiceTypeName< T > {                                  \
+    static const char* name() { return #T; }                            \
+    static const std::string& namestr() {                               \
+        static const std::string str(#T);                               \
+        return str;                                                     \
+    }                                                                   \
+    static const std::string& xmlstr() {                                \
+        static const std::string xml = encodeTypeNameForXML(namestr()); \
+        return xml;                                                     \
+    }                                                                   \
+};                                                                      \
 }
 
 // Some types for which we'd like to see nice type names.

--- a/SimTKcommon/src/NiceTypeName.cpp
+++ b/SimTKcommon/src/NiceTypeName.cpp
@@ -54,7 +54,6 @@ std::string demangle(const char* name) {
 // indpendence. We'll remove Microsoft's "class ", "struct ", etc.
 // designations, and get rid of all unnecessary spaces.
 std::string canonicalizeTypeName(std::string&& demangled) {
-    std::cout << "canonicalizing " << demangled << std::endl;
     using SPair = std::pair<std::regex,std::string>;
     // These are applied in this order.
     static const std::array<SPair,7> subs{
@@ -75,7 +74,6 @@ std::string canonicalizeTypeName(std::string&& demangled) {
     std::string canonical(std::move(demangled));
     for (const auto& sp : subs) {
         canonical = std::regex_replace(canonical, sp.first, sp.second);
-        std::cout << "now " << canonical << std::endl;
     }
     return canonical;
 }

--- a/SimTKcommon/src/NiceTypeName.cpp
+++ b/SimTKcommon/src/NiceTypeName.cpp
@@ -56,7 +56,7 @@ std::string demangle(const char* name) {
 std::string canonicalizeTypeName(std::string&& demangled) {
     using SPair = std::pair<std::regex,std::string>;
     // These are applied in this order.
-    static const std::array<SPair,8> subs{
+    static const std::array<SPair,9> subs{
         // Remove unwanted keywords and following space.
         SPair(std::regex("\\b(class|struct|enum|union) "),      ""),
         // Standardize "unsigned int" -> "unsigned".
@@ -67,6 +67,8 @@ std::string canonicalizeTypeName(std::string&& demangled) {
         SPair(std::regex("\\bsigned char\\b"),                  "signed!char"),
         SPair(std::regex("\\banonymous namespace\\b"),  "anonymous!namespace"),
         SPair(std::regex(" "), ""), // Delete unwanted spaces.
+        // OSX clang throws in extra namespaces like "__1". Delete them.
+        SPair(std::regex("\\b__[0-9]+::"), ""),
         SPair(std::regex("!"), " ") // Restore wanted spaces.
     };
     std::string canonical(std::move(demangled));

--- a/SimTKcommon/tests/TestArray.cpp
+++ b/SimTKcommon/tests/TestArray.cpp
@@ -112,7 +112,9 @@ private:
 namespace SimTK {
 template <> struct NiceTypeName<SmallIx> {
     static const char* name() {return "SmallIx";}
-    static std::string namestr() {return "SmallIx";}
+    static const std::string& namestr() 
+    {   static const std::string ns(name()); return ns; }
+    static const std::string& xmlstr() {return namestr();}
 };
 }
 
@@ -768,9 +770,12 @@ void testNiceTypeName() {
         << NiceTypeName<ArrayIndexPackType<unsigned long long>::packed_size_type>::name() << endl;
     cout << "Array_<String,char> using name(): " 
          << NiceTypeName< Array_<String,char> >::name() << endl;
-    // Check demangling on GCC/Clang.
+    // Check demangling/canonicalizing.
     cout << "Array_<String,char> using namestr(): " 
          << NiceTypeName< Array_<String,char> >::namestr() << endl;
+    // Check removing angle brackets for XML.
+    cout << "Array_<String,char> using xmlstr(): " 
+         << NiceTypeName< Array_<String,char> >::xmlstr() << endl;
 }
 
 // The Array_ class is supposed to make better use of memory than does

--- a/SimTKcommon/tests/TestNiceTypeName.cpp
+++ b/SimTKcommon/tests/TestNiceTypeName.cpp
@@ -257,6 +257,9 @@ void testArrayNames() {
 void testSTLNames() {
     SimTK_TEST(NiceTypeName<std::string>::namestr()
                 == "std::string");
+    // Temporary for debugging failure on Apple clang
+    std::cout << "std::vector<int>" 
+              << NiceTypeName<std::vector<int>>::namestr() << std::endl;
     SimTK_TEST((NiceTypeName<std::vector<int>>::namestr()
                 == "std::vector<int,std::allocator<int>>"));
 }

--- a/SimTKcommon/tests/TestNiceTypeName.cpp
+++ b/SimTKcommon/tests/TestNiceTypeName.cpp
@@ -150,6 +150,22 @@ template <class T> Counter Count<T>::initAssign;
 template <class T> Counter Count<T>::copyAssign;
 template <class T> Counter Count<T>::dtor;
 
+// Standalone tests of the method that is used by NiceTypeName<T>::namestr()
+// to clean up the demangled names on various platforms.
+void testCanonicalize() {
+    // Standardize "unsigned int" to "unsigned"; get rid of extra spaces.
+    SimTK_TEST(canonicalizeTypeName("class std :: vector < unsigned int >")
+               == "std::vector<unsigned>");
+    // OSX's stl like to throw in these extra namespaces.
+    SimTK_TEST(canonicalizeTypeName("std:: __1 :: __23 :: set<T>")
+               == "std::set<T>");
+
+    // Shouldn't recognize special strings when they aren't whole words.
+    SimTK_TEST(canonicalizeTypeName("unsigned longing")=="unsignedlonging");
+    SimTK_TEST(canonicalizeTypeName("std::my__1::__23x::resigned char")
+               == "std::my__1::__23x::resignedchar");
+}
+
 void testBuiltins() {
     SimTK_TEST(NiceTypeName<bool>::namestr() == "bool");
     SimTK_TEST(NiceTypeName<signed char>::namestr() == "signed char");
@@ -257,9 +273,6 @@ void testArrayNames() {
 void testSTLNames() {
     SimTK_TEST(NiceTypeName<std::string>::namestr()
                 == "std::string");
-    // Temporary for debugging failure on Apple clang
-    std::cout << "std::vector<int>" 
-              << NiceTypeName<std::vector<int>>::namestr() << std::endl;
     SimTK_TEST((NiceTypeName<std::vector<int>>::namestr()
                 == "std::vector<int,std::allocator<int>>"));
 }
@@ -292,6 +305,7 @@ int main() {
 
     SimTK_START_TEST("TestArray");
 
+        SimTK_SUBTEST(testCanonicalize);
         SimTK_SUBTEST(testBuiltins);
         SimTK_SUBTEST(testEnums);
         SimTK_SUBTEST(testArrayNames);

--- a/SimTKcommon/tests/TestNiceTypeName.cpp
+++ b/SimTKcommon/tests/TestNiceTypeName.cpp
@@ -160,10 +160,11 @@ void testCanonicalize() {
     SimTK_TEST(canonicalizeTypeName("std:: __1 :: __23 :: set<T>")
                == "std::set<T>");
 
-    // Shouldn't recognize special strings when they aren't whole words.
-    SimTK_TEST(canonicalizeTypeName("unsigned longing")=="unsignedlonging");
+    // Should leaves spaces between words.
+    SimTK_TEST(canonicalizeTypeName("lunch bucket")=="lunch bucket");
+    // And keep funny looking namespaces if they aren't __digits.
     SimTK_TEST(canonicalizeTypeName("std::my__1::__23x::resigned char")
-               == "std::my__1::__23x::resignedchar");
+               == "std::my__1::__23x::resigned char");
 }
 
 void testBuiltins() {

--- a/SimTKcommon/tests/TestNiceTypeName.cpp
+++ b/SimTKcommon/tests/TestNiceTypeName.cpp
@@ -1,0 +1,300 @@
+/* -------------------------------------------------------------------------- *
+ *                       Simbody(tm): SimTKcommon                             *
+ * -------------------------------------------------------------------------- *
+ * This is part of the SimTK biosimulation toolkit originating from           *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
+ *                                                                            *
+ * Portions copyright (c) 2016 Stanford University and the Authors.           *
+ * Authors: Michael Sherman                                                   *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+/*
+ * These are regression tests for the SimTK::NiceTypeName<T> class.
+ */
+
+#include "SimTKcommon.h"
+#include "SimTKcommon/Testing.h"
+
+#include <vector>
+#include <sstream>
+#include <iterator>
+#include <iostream>
+#include <utility>
+#include <memory>
+using std::cout;
+using std::endl;
+using std::cin;
+
+
+using namespace SimTK;
+
+template <class T>
+class OtherArray_ : public Array_<T> {
+public:
+    typedef typename Array_<T>::size_type size_type;
+
+    OtherArray_() : Array_<T>() {}
+    OtherArray_(size_type n, const T& v) : Array_<T>(n,v) {}
+};
+
+SimTK_DEFINE_UNIQUE_INDEX_TYPE(TestIx);
+
+// This index type has a max size of 4 for testing out-of-space
+// checks.
+class SmallIx {
+public:
+    SmallIx() : ix(0xff) {}
+    explicit SmallIx(unsigned char i) : ix(i) {}
+
+    SmallIx& operator++() 
+    {   assert(ix<max_size()); ++ix; return *this;}
+    SmallIx operator++(int) 
+    {   assert(ix<max_size()); const SmallIx x=*this; ++ix; return x;}
+    SmallIx& operator--() 
+    {   assert(ix>0); --ix; return *this;}
+    SmallIx operator--(int) 
+    {   assert(ix>0); const SmallIx x=*this; ++ix; return x;}
+
+    // These are required for any class to be used an index type.
+    operator              unsigned char() const {return ix;}
+    typedef unsigned char size_type;
+    typedef signed char   difference_type;
+    static size_type      max_size() {return 4;}
+private:
+    unsigned char ix;
+};
+
+
+class Counter {
+public:
+    Counter() : count(0) {}
+    Counter& operator=(int i) {count=i; return *this;}
+    Counter& operator++() {++count; return *this;}
+    Counter operator++(int) {const Counter c=*this; ++count; return c;}
+    Counter& reset() {count=0; return *this;}
+    operator int() const {return count;}
+private:
+    mutable int count;
+};
+inline std::ostream&
+operator<<(std::ostream& o, const Counter& c) {
+    return o << (int)c;
+} 
+
+// This class is a T but augmented with counters that track the number
+// of calls to constructors, assignment, and the destructor.
+template <class T>
+struct Count {
+    Count() {++defCtor;}
+    Count(const Count& c) : val(c.val) {++copyCtor;}
+    Count& operator=(const Count& c) {val=c.val; ++copyAssign; return *this;}
+    ~Count() {++dtor;}
+
+    // Conversion from T.
+    Count(const T& t) : val(t) {++initCtor;}
+    // Assign from T.
+    Count& operator=(const T& t) {val=t; ++initAssign; return *this;}
+
+    enum Color {Red,Green,Blue};
+    enum class Letter {A,B,C};
+
+
+    bool operator==(const Count& other) const {return val==other.val;}
+    bool operator!=(const Count& other) const {return val!=other.val;}
+
+    static void dumpCounts(const char* msg) {
+        cout << msg << ":";
+        cout << " defCtor=" << Count<int>::defCtor;
+        cout << " initCtor=" << Count<int>::initCtor;
+        cout << " copyCtor=" << Count<int>::copyCtor;
+        cout << " initAssign=" << Count<int>::initAssign;
+        cout << " copyAssign=" << Count<int>::copyAssign;
+        cout << " dtor=" << Count<int>::dtor;
+        cout << endl;
+    }
+
+    static bool isReset() 
+    {   return !(defCtor||initCtor||copyCtor||initAssign||copyAssign||dtor); }
+
+    T val;
+
+    static void reset() {defCtor=initCtor=copyCtor=initAssign=copyAssign=dtor=0;}
+    static Counter defCtor;
+    static Counter initCtor;
+    static Counter copyCtor;
+    static Counter initAssign;
+    static Counter copyAssign;
+    static Counter dtor;
+};
+template <class T> inline std::ostream&
+operator<<(std::ostream& o, const Count<T>& c) {
+    return o << c.val;
+} 
+template <class T> Counter Count<T>::defCtor;
+template <class T> Counter Count<T>::initCtor;
+template <class T> Counter Count<T>::copyCtor;
+template <class T> Counter Count<T>::initAssign;
+template <class T> Counter Count<T>::copyAssign;
+template <class T> Counter Count<T>::dtor;
+
+void testBuiltins() {
+    SimTK_TEST(NiceTypeName<bool>::namestr() == "bool");
+    SimTK_TEST(NiceTypeName<signed char>::namestr() == "signed char");
+    SimTK_TEST(NiceTypeName<unsigned char>::namestr() == "unsigned char");
+    SimTK_TEST(NiceTypeName<short>::namestr() == "short");
+    SimTK_TEST(NiceTypeName<unsigned short>::namestr() == "unsigned short");
+    SimTK_TEST(NiceTypeName<int>::namestr() == "int");
+    SimTK_TEST(NiceTypeName<unsigned int>::namestr() == "unsigned"); // abbr
+    SimTK_TEST(NiceTypeName<unsigned>::namestr() == "unsigned");
+    SimTK_TEST(NiceTypeName<long>::namestr() == "long");
+    SimTK_TEST(NiceTypeName<unsigned long>::namestr() == "unsigned long");
+    SimTK_TEST(NiceTypeName<long long>::namestr() == "long long");
+    SimTK_TEST(NiceTypeName<unsigned long long>::namestr() 
+               == "unsigned long long");
+    SimTK_TEST(NiceTypeName<float>::namestr() == "float");
+    SimTK_TEST(NiceTypeName<double>::namestr() == "double");
+    SimTK_TEST(NiceTypeName<long double>::namestr() == "long double");
+    SimTK_TEST(NiceTypeName<std::complex<float>>::namestr() 
+               == "std::complex<float>");
+    SimTK_TEST(NiceTypeName<std::complex<double>>::namestr() 
+               == "std::complex<double>");
+    SimTK_TEST(NiceTypeName<std::complex<long double>>::namestr() 
+               == "std::complex<long double>");
+
+    // xmlstr should be the same as namestr for non-templatized types
+    SimTK_TEST(NiceTypeName<bool>::xmlstr() == NiceTypeName<bool>::namestr()); 
+    SimTK_TEST(NiceTypeName<unsigned int>::xmlstr() 
+               == NiceTypeName<unsigned int>::namestr());
+    SimTK_TEST(NiceTypeName<long long>::xmlstr() 
+               == NiceTypeName<long long>::namestr());
+
+    // xmlstr should replace the brackets for templatized types
+    SimTK_TEST(NiceTypeName<std::complex<float>>::xmlstr() 
+               == "std::complex{float}");
+    SimTK_TEST(NiceTypeName<std::complex<double>>::xmlstr() 
+               == "std::complex{double}");
+    SimTK_TEST(NiceTypeName<std::complex<long double>>::xmlstr() 
+               == "std::complex{long double}");
+
+}
+
+namespace LocalNS {
+enum MyEnum {One,Two};
+enum class YourEnumClass {Three,Four};
+}
+
+void testEnums() {
+    using namespace LocalNS;
+
+    SimTK_TEST(NiceTypeName<MyEnum>::namestr() == "LocalNS::MyEnum");
+    SimTK_TEST(NiceTypeName<YourEnumClass>::namestr() 
+               == "LocalNS::YourEnumClass");
+
+    SimTK_TEST(NiceTypeName<Count<double>>::namestr() == "Count<double>");
+    SimTK_TEST(NiceTypeName<Count<double>::Color>::namestr() 
+               == "Count<double>::Color");
+    SimTK_TEST(NiceTypeName<Count<double>::Letter>::namestr() 
+               == "Count<double>::Letter");
+}
+
+// Custom NiceTypeName for SmallIx: CustomSmallIxName
+namespace SimTK {
+template <> struct NiceTypeName<SmallIx> {
+    static const char* name() {return "CustomSmallIxName";}
+    static const std::string& namestr() 
+    {   static const std::string ns(name()); return ns; }
+    static const std::string& xmlstr() {return namestr();}
+};
+
+template <class T> 
+struct NiceTypeName<OtherArray_<T>> {
+    static const char* name() {return typeid(OtherArray_<T>).name();}
+    static const std::string& namestr() 
+    {   static const std::string ns
+            ("OtherArray_<" + NiceTypeName<T>::namestr() + ">");
+        return ns; }
+    static const std::string& xmlstr() 
+    {   static const std::string xs = encodeTypeNameForXML(namestr());
+        return xs; }
+};
+}
+
+void testArrayNames() {
+    SimTK_TEST((NiceTypeName<Array_<String,char>>::namestr()
+                == "SimTK::Array_<SimTK::String,char>"));
+    SimTK_TEST((NiceTypeName<Array_<String,char>>::xmlstr()
+                == "SimTK::Array_{SimTK::String,char}"));
+    SimTK_TEST((NiceTypeName<ArrayView_<int>>::namestr()
+                == "SimTK::ArrayView_<int,unsigned>"));
+    SimTK_TEST((NiceTypeName<ArrayViewConst_<char>>::namestr()
+                == "SimTK::ArrayViewConst_<char,unsigned>"));
+    SimTK_TEST((NiceTypeName<Array_< Count<int> > >::namestr()
+                == "SimTK::Array_<Count<int>,unsigned>"));
+    SimTK_TEST((NiceTypeName<Array_< Count<int> > >::xmlstr()
+                == "SimTK::Array_{Count{int},unsigned}"));
+    SimTK_TEST((NiceTypeName<SmallIx>::namestr()
+                == "CustomSmallIxName")); 
+    SimTK_TEST((NiceTypeName<OtherArray_<int>>::namestr()
+                == "OtherArray_<int>"));
+    SimTK_TEST((NiceTypeName<OtherArray_<SmallIx>>::namestr()
+                == "OtherArray_<CustomSmallIxName>"));
+    SimTK_TEST(NiceTypeName<TestIx>::namestr() == "TestIx");
+}
+
+void testSTLNames() {
+    SimTK_TEST(NiceTypeName<std::string>::namestr()
+                == "std::string");
+    SimTK_TEST((NiceTypeName<std::vector<int>>::namestr()
+                == "std::vector<int,std::allocator<int>>"));
+}
+
+
+namespace {
+// This is implicitly convertible to TextIx.
+class SubTestIx : public TestIx {
+public: explicit SubTestIx(int ix) : TestIx(ix) {}
+};
+}
+
+// Output for anonymous or function-local type won't necessarily be platform 
+// independent (and may be ugly), so we'll just write them out here for 
+// inspection.
+void testAnonymous() {
+    cout << "These won't be nice:\n";
+    cout << "(1) anonymous::SubTestIx gives " 
+         << NiceTypeName<SubTestIx>::namestr() << endl;
+
+    struct MyLocalType {
+        int i;
+    };
+
+    cout << "(2) function local::MyLocalType gives " 
+         << NiceTypeName<MyLocalType>::namestr() << endl;
+}
+
+int main() {
+
+    SimTK_START_TEST("TestArray");
+
+        SimTK_SUBTEST(testBuiltins);
+        SimTK_SUBTEST(testEnums);
+        SimTK_SUBTEST(testArrayNames);
+        SimTK_SUBTEST(testSTLNames);
+        SimTK_SUBTEST(testAnonymous);
+
+    SimTK_END_TEST();
+}
+


### PR DESCRIPTION
For serializing arbitrary user-defined templated types as is necessary to resolve issue #305 (State serialization), we need a unique, persistent, platform-independent, human-readable, XML-compatible string to represent the type. That string can then be written to the XML file, and then used as a key during deserialization to find the correct registered deserializer for that type.

Simbody's `NiceTypeName<T>` class is the right idea, but was not producing canonicalized names. This PR modifies its `namestr()` method to produce cleaned-up names, and adds an `xmlstr()` method that processes the clean name to replace XML-unfriendly angle brackets with curly braces; that is then suited as the registration key.

There are some SimTK namespace free functions introduced for doing the string processing, which requires the C++11 `<regex>` facility. That in turn requires at least gcc 4.9, so this PR modifies the Travis installation to use that. This will affect the minimum supported Ubuntu level for Simbody except for users who are willing to upgrade compilers.

Known limitations: types that are in an anonymous namespace or are function-local still produce ugly names that are not platform-independent. These must not be used as types for serialization. 

@klshrinidhi, @chrisdembia please let me know if you can find flaws with this -- the State serializer will be counting on these type names to be reliable registration keys.