### PR TITLE
Have NiceTypeName put anonymous namespace in parens rather than curlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   
   ## Dependencies for Simbody.
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get --yes update; fi
-  # - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get --yes install liblapack-dev; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get --yes install liblapack-dev; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get --yes install freeglut3-dev libxi-dev libxmu-dev; fi
 
   # C++11 on Ubuntu. Update to gcc 4.9, which provides full C++11 support.  We

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
   
   ## Dependencies for Simbody.
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get --yes update; fi
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get --yes install liblapack-dev; fi
+  # - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get --yes install liblapack-dev; fi
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get --yes install freeglut3-dev libxi-dev libxmu-dev; fi
 
   # C++11 on Ubuntu. Update to gcc 4.9, which provides full C++11 support.  We

--- a/SimTKcommon/src/NiceTypeName.cpp
+++ b/SimTKcommon/src/NiceTypeName.cpp
@@ -59,8 +59,8 @@ std::string canonicalizeTypeName(std::string&& demangled) {
     static const std::array<SPair,7> subs{
         // Remove unwanted keywords and following space.
         SPair(std::regex("\\b(class|struct|enum|union) "),      ""),
-        // Tidy up anonymous namespace, without output like boost.
-        SPair(std::regex("[`(]anonymous namespace[')]"),        "{anonymous}"),
+        // Tidy up anonymous namespace.
+        SPair(std::regex("[`(]anonymous namespace[')]"),        "(anonymous)"),
         // Standardize "unsigned int" -> "unsigned".
         SPair(std::regex("\\bunsigned int\\b"),                 "unsigned"),
         // Temporarily replace spaces we want to keep with "!". (\w is 


### PR DESCRIPTION
I changed my mind about using boost-like `{anonymous}` as a representation for anonymous namespaces in NiceTypeName; this changes the representation to `(anonymous)`. I was worried that this cosmetic choice would cause trouble with the XML mapping I'm using that turns angle brackets into curly braces to avoid XML's prohibition on literal angle brackets. There is a routine that maps that back to angle brackets and I didn't want to end up with `<anonymous>` by accident. 

Parens are used anyway by the gcc/clang demangler (they produce `(anonymous namespace)`) so this isn't too weird of a choice.