### PR TITLE
Use Value::updDowncast() rather than downcast() to avoid deprecated warnings

### DIFF
--- a/SimTKcommon/Simulation/src/System.cpp
+++ b/SimTKcommon/Simulation/src/System.cpp
@@ -1125,7 +1125,7 @@ public:
     }
     
     CachedEventInfo& updCachedEventInfo(const State& s) const {
-        return Value<CachedEventInfo>::downcast
+        return Value<CachedEventInfo>::updDowncast
            (updCacheEntry(s, cachedEventInfoIndex)).upd();
     }
 

--- a/SimTKcommon/tests/StateTest.cpp
+++ b/SimTKcommon/tests/StateTest.cpp
@@ -382,7 +382,7 @@ void testMisc() {
     s.advanceSubsystemToStage(SubsystemIndex(0), Stage::Model);
         //long dv2 = s.allocateDiscreteVariable(SubsystemIndex(0), Stage::Position, new Value<int>(5));
 
-    Value<int>::downcast(s.updDiscreteVariable(SubsystemIndex(0), dv)) = 71;
+    Value<int>::updDowncast(s.updDiscreteVariable(SubsystemIndex(0), dv)) = 71;
     cout << s.getDiscreteVariable(SubsystemIndex(0), dv) << endl;
 
 

--- a/SimTKcommon/tests/TestSimulation.cpp
+++ b/SimTKcommon/tests/TestSimulation.cpp
@@ -118,7 +118,7 @@ public:
         return Value<EventRegistry>::downcast(getCacheEntry(s, eventRegistry)); }
     EventRegistry& updEventRegistry(const State& s) const
     {   assert(eventRegistry >= 0);
-        return Value<EventRegistry>::downcast(updCacheEntry(s, eventRegistry)); }
+        return Value<EventRegistry>::updDowncast(updCacheEntry(s, eventRegistry)); }
 
     // implementations of Subsystem::Guts virtuals
     SystemSubsystemGuts* cloneImpl() const override
@@ -278,8 +278,6 @@ class TestSubsystemGuts : public Subsystem::Guts {
         CacheEntryIndex qSumCacheIx, uSumCacheIx;
         EventTriggerByStageIndex timeTriggerIx, velTriggerIx;
     };
-    friend std::ostream& operator<<(std::ostream& o, const CacheEntries&);
-    friend std::ostream& operator<<(std::ostream& o, const StateVars&);
 public:
     TestSubsystemGuts() {}
 
@@ -384,8 +382,8 @@ private:
     Vec3& updQDot3(const State& s) const {return Vec3::updAs(&updQDot(s)[getStateVars(s).myQs]);}
     Vec3& updUDot3(const State& s) const {return Vec3::updAs(&updUDot(s)[getStateVars(s).myUs]);}
     Vec3& updQDotDot3(const State& s) const {return Vec3::updAs(&updQDotDot(s)[getStateVars(s).myQs]);}
-    Real& updQSum(const State& s) const {return Value<Real>::downcast(updCacheEntry(s,getCacheEntries(s).qSumCacheIx));}
-    Real& updUSum(const State& s) const {return Value<Real>::downcast(updCacheEntry(s,getCacheEntries(s).uSumCacheIx));}
+    Real& updQSum(const State& s) const {return Value<Real>::updDowncast(updCacheEntry(s,getCacheEntries(s).qSumCacheIx));}
+    Real& updUSum(const State& s) const {return Value<Real>::updDowncast(updCacheEntry(s,getCacheEntries(s).uSumCacheIx));}
     Real& updTimeTrigger1(const State& s) const {return updEventTriggersByStage(s, Stage::Time)[getCacheEntries(s).timeTriggerIx];}
     Real& updTimeTrigger2(const State& s) const {return updEventTriggersByStage(s, Stage::Time)[getCacheEntries(s).timeTriggerIx+1];}
     Real& updVelTrigger(const State& s) const {return updEventTriggersByStage(s, Stage::Velocity)[getCacheEntries(s).velTriggerIx];}
@@ -398,10 +396,10 @@ private:
         return Value<CacheEntries>::downcast(getCacheEntry(s,myCacheEntries)); }
     StateVars& updStateVars   (const State& s) const 
     {   assert(myStateVars >= 0);
-        return Value<StateVars>::downcast(updCacheEntry(s,myStateVars)); }
+        return Value<StateVars>::updDowncast(updCacheEntry(s,myStateVars)); }
     CacheEntries& updCacheEntries(const State& s) const
     {   assert(myCacheEntries >= 0);
-        return Value<CacheEntries>::downcast(updCacheEntry(s,myCacheEntries)); }
+        return Value<CacheEntries>::updDowncast(updCacheEntry(s,myCacheEntries)); }
 
     const TestSystem& getTestSystem() const {return TestSystem::getAs(getSystem());}
     TestSystem& updTestSystem() {return TestSystem::updAs(updSystem());}

--- a/SimTKmath/tests/IntegratorTest.cpp
+++ b/SimTKmath/tests/IntegratorTest.cpp
@@ -584,7 +584,8 @@ int MyPendulumGuts::realizeDynamicsImpl(const State& s) const {
     const Real m  = getMyPendulum().getMass(s);
     const Real g  = getMyPendulum().getGravity(s);
 
-    Real& mg = Value<Real>::downcast(s.updCacheEntry(subsysIndex, mgForceIndex)).upd();
+    Real& mg = Value<Real>::updDowncast
+                            (s.updCacheEntry(subsysIndex, mgForceIndex)).upd();
     // Calculate the force due to gravity.
     mg = m*g;
     System::Guts::realizeDynamicsImpl(s);
@@ -595,7 +596,7 @@ int MyPendulumGuts::realizeAccelerationImpl(const State& s) const {
     const Real m  = getMyPendulum().getMass(s);
     const Real g  = getMyPendulum().getGravity(s);
     // we're pretending we couldn't calculate this here!
-    const Real mg = Value<Real>::downcast
+    const Real mg = Value<Real>::updDowncast
                        (s.updCacheEntry(subsysIndex, mgForceIndex)).get();
 
     const Vector& q    = s.getQ(subsysIndex);

--- a/SimTKmath/tests/PendulumSystem.h
+++ b/SimTKmath/tests/PendulumSystem.h
@@ -272,7 +272,8 @@ int PendulumSystemGuts::realizeDynamicsImpl(const State& s) const {
     const Real m  = getPendulumSystem().getMass(s);
     const Real g  = getPendulumSystem().getGravity(s);
 
-    Real& mg = Value<Real>::downcast(s.updCacheEntry(subsysIndex, mgForceIndex)).upd();
+    Real& mg = Value<Real>::updDowncast
+                            (s.updCacheEntry(subsysIndex, mgForceIndex)).upd();
     // Calculate the force due to gravity.
     mg = m*g;
     System::Guts::realizeDynamicsImpl(s);
@@ -283,7 +284,7 @@ int PendulumSystemGuts::realizeAccelerationImpl(const State& s) const {
     const Real m  = getPendulumSystem().getMass(s);
     const Real g  = getPendulumSystem().getGravity(s);
     // we're pretending we couldn't calculate this here!
-    const Real mg = Value<Real>::downcast
+    const Real mg = Value<Real>::updDowncast
                        (s.updCacheEntry(subsysIndex, mgForceIndex)).get();
 
     const Vector& q    = s.getQ(subsysIndex);

--- a/Simbody/src/ContactTrackerSubsystem.cpp
+++ b/Simbody/src/ContactTrackerSubsystem.cpp
@@ -199,12 +199,12 @@ const ContactSnapshot& getNextPredictedContacts(const State& state) const {
     return contacts;
 }
 ContactSnapshot& updNextActiveContacts(const State& state) const {
-    ContactSnapshot& contacts = Value<ContactSnapshot>::downcast
+    ContactSnapshot& contacts = Value<ContactSnapshot>::updDowncast
         (updDiscreteVarUpdateValue(state, m_activeContactsIx));
     return contacts;
 }
 ContactSnapshot& updNextPredictedContacts(const State& state) const {
-    ContactSnapshot& contacts = Value<ContactSnapshot>::downcast
+    ContactSnapshot& contacts = Value<ContactSnapshot>::updDowncast
         (updDiscreteVarUpdateValue(state, m_predictedContactsIx));
     return contacts;
 }

--- a/Simbody/src/ElasticFoundationForce.cpp
+++ b/Simbody/src/ElasticFoundationForce.cpp
@@ -94,7 +94,7 @@ void ElasticFoundationForceImpl::calcForce
     Vector_<Vec3>& particleForces, Vector& mobilityForces) const 
 {
     const Array_<Contact>& contacts = subsystem.getContacts(state, set);
-    Real& pe = Value<Real>::downcast
+    Real& pe = Value<Real>::updDowncast
                 (subsystem.updCacheEntry(state, energyCacheIndex));
     pe = 0.0;
     for (int i = 0; i < (int) contacts.size(); i++) {

--- a/Simbody/src/GeneralContactSubsystem.cpp
+++ b/Simbody/src/GeneralContactSubsystem.cpp
@@ -129,7 +129,7 @@ public:
     const Array_<Contact>& getContacts(const State& state, ContactSetIndex set) const {
         assert(set >= 0 && set < sets.size());
         SimTK_STAGECHECK_GE_ALWAYS(state.getSubsystemStage(getMySubsystemIndex()), Stage::Dynamics, "GeneralContactSubsystemImpl::getContacts()");
-        Array_<Array_<Contact> >& contacts = Value<Array_<Array_<Contact> > >::downcast(updCacheEntry(state, contactsCacheIndex)).upd();
+        Array_<Array_<Contact> >& contacts = Value<Array_<Array_<Contact> > >::updDowncast(updCacheEntry(state, contactsCacheIndex)).upd();
         return contacts[set];
     }
     
@@ -150,15 +150,15 @@ public:
     }
 
     int realizeSubsystemPositionImpl(const State& state) const override {
-        Value<bool>::downcast(state.updCacheEntry(getMySubsystemIndex(), contactsValidCacheIndex)).upd() = false;
+        Value<bool>::updDowncast(state.updCacheEntry(getMySubsystemIndex(), contactsValidCacheIndex)).upd() = false;
         return 0;
     }
 
     int realizeSubsystemDynamicsImpl(const State& state) const override {
-        bool& contactsValid = Value<bool>::downcast(state.updCacheEntry(getMySubsystemIndex(), contactsValidCacheIndex)).upd();
+        bool& contactsValid = Value<bool>::updDowncast(state.updCacheEntry(getMySubsystemIndex(), contactsValidCacheIndex)).upd();
         if (contactsValid)
             return 0;
-        Array_<Array_<Contact> >& contacts = Value<Array_<Array_<Contact> > >::downcast(updCacheEntry(state, contactsCacheIndex)).upd();
+        Array_<Array_<Contact> >& contacts = Value<Array_<Array_<Contact> > >::updDowncast(updCacheEntry(state, contactsCacheIndex)).upd();
         int numSets = getNumContactSets();
         contacts.resize(numSets);
         

--- a/Simbody/src/GeneralForceSubsystem.cpp
+++ b/Simbody/src/GeneralForceSubsystem.cpp
@@ -711,9 +711,9 @@ public:
         const Array_<bool>& forceEnabled = Value< Array_<bool> >::downcast
                                     (getDiscreteVariable(s, forceEnabledIndex));
         Array_<Force*>& enabledNonParallelForces = Value< Array_<Force*> >::
-                       downcast(updCacheEntry(s,enabledNonParallelForcesIndex));
+                    updDowncast(updCacheEntry(s,enabledNonParallelForcesIndex));
         Array_<Force*>& enabledParallelForces = Value< Array_<Force*> >::
-                          downcast(updCacheEntry(s,enabledParallelForcesIndex));
+                    updDowncast(updCacheEntry(s,enabledParallelForcesIndex));
 
         // Avoid repeatedly allocating memory.
         enabledParallelForces.resize(0);
@@ -807,17 +807,17 @@ public:
 
         // OK, we're doing some caching. This is a little messier.
         // Get access to subsystem force cache entries.
-        bool& cachedForcesAreValid = Value<bool>::downcast
+        bool& cachedForcesAreValid = Value<bool>::updDowncast
                           (updCacheEntry(s, cachedForcesAreValidCacheIndex));
 
         Vector_<SpatialVec>&
-            rigidBodyForceCache = Value<Vector_<SpatialVec> >::downcast
+            rigidBodyForceCache = Value<Vector_<SpatialVec> >::updDowncast
                                  (updCacheEntry(s, rigidBodyForceCacheIndex));
         Vector_<Vec3>&
-            particleForceCache  = Value<Vector_<Vec3> >::downcast
+            particleForceCache  = Value<Vector_<Vec3> >::updDowncast
                                  (updCacheEntry(s, particleForceCacheIndex));
         Vector&
-            mobilityForceCache  = Value<Vector>::downcast
+            mobilityForceCache  = Value<Vector>::updDowncast
                                  (updCacheEntry(s, mobilityForceCacheIndex));
 
 

--- a/Simbody/src/HuntCrossleyContact.cpp
+++ b/Simbody/src/HuntCrossleyContact.cpp
@@ -198,7 +198,7 @@ private:
     }
     Parameters& updParameters(State& s) const {
         assert(subsystemTopologyHasBeenRealized());
-        return Value<Parameters>::downcast(
+        return Value<Parameters>::updDowncast(
             updDiscreteVariable(s,instanceVarsIndex)).upd();
     }
 
@@ -302,7 +302,7 @@ int HuntCrossleyContactRep::realizeSubsystemDynamicsImpl(const State& s) const
 
     const MultibodySystem&        mbs    = getMultibodySystem(); // my owner
     const SimbodyMatterSubsystem& matter = mbs.getMatterSubsystem();
-    Real& pe = Value<Real>::downcast(s.updCacheEntry(getMySubsystemIndex(), energyCacheIndex)).upd();
+    Real& pe = Value<Real>::updDowncast(s.updCacheEntry(getMySubsystemIndex(), energyCacheIndex)).upd();
     pe = 0;
 
     // Get access to system-global cache entries.

--- a/Simbody/src/HuntCrossleyForce.cpp
+++ b/Simbody/src/HuntCrossleyForce.cpp
@@ -101,7 +101,7 @@ void HuntCrossleyForceImpl::setTransitionVelocity(Real v) {
 void HuntCrossleyForceImpl::calcForce(const State& state, Vector_<SpatialVec>& bodyForces, 
                                       Vector_<Vec3>& particleForces, Vector& mobilityForces) const {
     const Array_<Contact>& contacts = subsystem.getContacts(state, set);
-    Real& pe = Value<Real>::downcast(state.updCacheEntry(subsystem.getMySubsystemIndex(), energyCacheIndex)).upd();
+    Real& pe = Value<Real>::updDowncast(state.updCacheEntry(subsystem.getMySubsystemIndex(), energyCacheIndex)).upd();
     pe = 0.0;
     for (int i = 0; i < (int) contacts.size(); i++) {
         if (!PointContact::isInstance(contacts[i]))

--- a/Simbody/src/MobilizedBodyImpl.h
+++ b/Simbody/src/MobilizedBodyImpl.h
@@ -1281,7 +1281,7 @@ public:
         switch (nu) {
             case 1: {
                 // Check that the H  matrices in the cache are valid
-                if (!(Value<CacheInfo<1> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
+                if (!(Value<CacheInfo<1>>::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
                     updateH(s);
 
                 Mat<2,1,Vec3> h = Value<CacheInfo<1> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().h;
@@ -1289,7 +1289,7 @@ public:
             }
             case 2: {
                 // Check that the H  matrices in the cache are valid
-                if (!(Value<CacheInfo<2> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
+                if (!(Value<CacheInfo<2> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
                     updateH(s);
                 
                 Mat<2,2,Vec3> h = Value<CacheInfo<2> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().h;
@@ -1297,7 +1297,7 @@ public:
             }
             case 3: {
                 // Check that the H  matrices in the cache are valid
-                if (!(Value<CacheInfo<3> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
+                if (!(Value<CacheInfo<3> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
                     updateH(s);
 
                 Mat<2,3,Vec3> h = Value<CacheInfo<3> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().h;
@@ -1305,7 +1305,7 @@ public:
             }
             case 4: {
                 // Check that the H  matrices in the cache are valid
-                if (!(Value<CacheInfo<4> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
+                if (!(Value<CacheInfo<4> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
                     updateH(s);
 
                 Mat<2,4,Vec3> h = Value<CacheInfo<4> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().h;
@@ -1313,7 +1313,7 @@ public:
             }
             case 5: {
                 // Check that the H matrices in the cache are valid
-                if (!(Value<CacheInfo<5> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
+                if (!(Value<CacheInfo<5> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
                     updateH(s);
 
                 Mat<2,5,Vec3> h = Value<CacheInfo<5> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().h;
@@ -1321,7 +1321,7 @@ public:
             }
             case 6: {
                 // Check that the H  matrices in the cache are valid
-                if (!(Value<CacheInfo<6> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
+                if (!(Value<CacheInfo<6> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
                     updateH(s);
 
                 Mat<2,6,Vec3> h = Value<CacheInfo<6> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().h;
@@ -1336,7 +1336,7 @@ public:
         switch (nu) {
             case 1: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<1> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
+                if (!(Value<CacheInfo<1> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
                     updateH(s);
 
                 Mat<2,1,Vec3> h = Value<CacheInfo<1> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().h;
@@ -1345,7 +1345,7 @@ public:
             }
             case 2: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<2> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
+                if (!(Value<CacheInfo<2> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
                     updateH(s);
 
                 Mat<2,2,Vec3> h = Value<CacheInfo<2> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().h;
@@ -1354,7 +1354,7 @@ public:
             }
             case 3: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<3> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
+                if (!(Value<CacheInfo<3> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
                     updateH(s);
 
                 Mat<2,3,Vec3> h = Value<CacheInfo<3> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().h;
@@ -1363,7 +1363,7 @@ public:
             }
             case 4: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<4> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
+                if (!(Value<CacheInfo<4> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
                     updateH(s);
 
                 Mat<2,4,Vec3> h = Value<CacheInfo<4> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().h;
@@ -1372,7 +1372,7 @@ public:
             }
             case 5: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<5> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
+                if (!(Value<CacheInfo<5> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
                     updateH(s);
 
                 Mat<2,5,Vec3> h = Value<CacheInfo<5> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().h;
@@ -1381,7 +1381,7 @@ public:
             }
             case 6: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<6> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
+                if (!(Value<CacheInfo<6> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH))
                     updateH(s);
 
                 Mat<2,6,Vec3> h = Value<CacheInfo<6> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().h;
@@ -1397,7 +1397,7 @@ public:
         switch (nu) {
             case 1: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<1> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
+                if (!(Value<CacheInfo<1> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
                     updateHdot(s);
 
                 Mat<2,1,Vec3> hdot = Value<CacheInfo<1> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().hdot;
@@ -1405,7 +1405,7 @@ public:
             }
             case 2: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<2> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
+                if (!(Value<CacheInfo<2> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
                     updateHdot(s);
 
                 Mat<2,2,Vec3> hdot = Value<CacheInfo<2> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().hdot;
@@ -1413,7 +1413,7 @@ public:
             }
             case 3: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<3> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
+                if (!(Value<CacheInfo<3> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
                     updateHdot(s);
 
                 Mat<2,3,Vec3> hdot = Value<CacheInfo<3> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().hdot;
@@ -1421,7 +1421,7 @@ public:
             }
             case 4: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<4> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
+                if (!(Value<CacheInfo<4> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
                     updateHdot(s);
 
                 Mat<2,4,Vec3> hdot = Value<CacheInfo<4> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().hdot;
@@ -1429,7 +1429,7 @@ public:
             }
             case 5: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<5> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
+                if (!(Value<CacheInfo<5> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
                     updateHdot(s);
 
                 Mat<2,5,Vec3> hdot = Value<CacheInfo<5> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().hdot;
@@ -1437,7 +1437,7 @@ public:
             }
             case 6: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<6> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
+                if (!(Value<CacheInfo<6> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
                     updateHdot(s);
 
                 Mat<2,6,Vec3> hdot = Value<CacheInfo<6> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().hdot;
@@ -1452,7 +1452,7 @@ public:
         switch (nu) {
             case 1: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<1> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
+                if (!(Value<CacheInfo<1> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
                     updateHdot(s);
 
                 Mat<2,1,Vec3> hdot = Value<CacheInfo<1> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().hdot;
@@ -1461,7 +1461,7 @@ public:
             }
             case 2: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<2> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
+                if (!(Value<CacheInfo<2> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
                     updateHdot(s);
 
                 Mat<2,2,Vec3> hdot = Value<CacheInfo<2> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().hdot;
@@ -1470,7 +1470,7 @@ public:
             }
             case 3: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<3> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
+                if (!(Value<CacheInfo<3> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
                     updateHdot(s);
 
                 Mat<2,3,Vec3> hdot = Value<CacheInfo<3> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().hdot;
@@ -1479,7 +1479,7 @@ public:
             }
             case 4: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<4> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
+                if (!(Value<CacheInfo<4> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
                     updateHdot(s);
 
                 Mat<2,4,Vec3> hdot = Value<CacheInfo<4> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().hdot;
@@ -1488,7 +1488,7 @@ public:
             }
             case 5: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<5> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
+                if (!(Value<CacheInfo<5> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
                     updateHdot(s);
 
                 Mat<2,5,Vec3> hdot = Value<CacheInfo<5> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().hdot;
@@ -1497,7 +1497,7 @@ public:
             }
             case 6: {
                 // Check that the H and Hdot matrices in the cache are valid
-                if (!(Value<CacheInfo<6> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
+                if (!(Value<CacheInfo<6> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot))
                     updateHdot(s);
 
                 Mat<2,6,Vec3> hdot = Value<CacheInfo<6> >::downcast(s.getCacheEntry(subsystem, cacheIndex)).get().hdot;
@@ -1535,32 +1535,32 @@ public:
         switch (nu) {
             case 1: {
                 // invalidate H and Hdot matrices
-                Value<CacheInfo<1> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH = false;
+                Value<CacheInfo<1> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH = false;
                 break;
             }
             case 2: {
                 // invalidate H and Hdot matrices
-                Value<CacheInfo<2> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH = false;
+                Value<CacheInfo<2> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH = false;
                 break;
             }
             case 3: {
                 // invalidate H and Hdot matrices
-                Value<CacheInfo<3> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH = false;
+                Value<CacheInfo<3> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH = false;
                 break;
             }
             case 4: {
                 // invalidate H and Hdot matrices
-                Value<CacheInfo<4> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH = false;
+                Value<CacheInfo<4> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH = false;
                 break;
             }
             case 5: {
                 // invalidate H and Hdot matrices
-                Value<CacheInfo<5> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH = false;
+                Value<CacheInfo<5> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH = false;
                 break;
             }
             case 6: {
                 // invalidate H and Hdot matrices
-                Value<CacheInfo<6> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH = false;
+                Value<CacheInfo<6> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidH = false;
                 break;
             }
         }
@@ -1570,32 +1570,32 @@ public:
         switch (nu) {
             case 1: {
                 // invalidate H and Hdot matrices
-                Value<CacheInfo<1> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot = false;
+                Value<CacheInfo<1> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot = false;
                 break;
             }
             case 2: {
                 // invalidate H and Hdot matrices
-                Value<CacheInfo<2> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot = false;
+                Value<CacheInfo<2> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot = false;
                 break;
             }
             case 3: {
                 // invalidate H and Hdot matrices
-                Value<CacheInfo<3> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot = false;
+                Value<CacheInfo<3> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot = false;
                 break;
             }
             case 4: {
                 // invalidate H and Hdot matrices
-                Value<CacheInfo<4> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot = false;
+                Value<CacheInfo<4> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot = false;
                 break;
             }
             case 5: {
                 // invalidate H and Hdot matrices
-                Value<CacheInfo<5> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot = false;
+                Value<CacheInfo<5> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot = false;
                 break;
             }
             case 6: {
                 // invalidate H and Hdot matrices
-                Value<CacheInfo<6> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot = false;
+                Value<CacheInfo<6> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd().isValidHdot = false;
                 break;
             }
         }
@@ -1607,42 +1607,42 @@ public:
         Vector u = getU(s);
         switch (nu) {
             case 1: {
-                CacheInfo<1>& cache = Value<CacheInfo<1> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd();
+                CacheInfo<1>& cache = Value<CacheInfo<1> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd();
                 cache.buildH(q, u, getMobilizerTransform(s), functions, coordIndices, Arot, Atrans);
                 // H matrix is now valid 
                 cache.isValidH = true;
                 break;
             }
             case 2: {
-                CacheInfo<2>& cache = Value<CacheInfo<2> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd();
+                CacheInfo<2>& cache = Value<CacheInfo<2> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd();
                 cache.buildH(q, u, getMobilizerTransform(s), functions, coordIndices, Arot, Atrans);
                 // H matrix is now valid 
                 cache.isValidH = true;
                 break;
             }
             case 3: {
-                CacheInfo<3>& cache = Value<CacheInfo<3> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd();
+                CacheInfo<3>& cache = Value<CacheInfo<3> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd();
                 cache.buildH(q, u, getMobilizerTransform(s), functions, coordIndices, Arot, Atrans);
                 // H matrix is now valid  
                 cache.isValidH = true;
                 break;
             }
             case 4: {
-                CacheInfo<4>& cache = Value<CacheInfo<4> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd();
+                CacheInfo<4>& cache = Value<CacheInfo<4> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd();
                 cache.buildH(q, u, getMobilizerTransform(s), functions, coordIndices, Arot, Atrans);
                 // H matrix is now valid 
                 cache.isValidH = true;
                 break;
             }
             case 5: {
-                CacheInfo<5>& cache = Value<CacheInfo<5> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd();
+                CacheInfo<5>& cache = Value<CacheInfo<5> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd();
                 cache.buildH(q, u, getMobilizerTransform(s), functions, coordIndices, Arot, Atrans);
                 // H matrix is now valid  
                 cache.isValidH = true;
                 break;
             }
             case 6: {
-                CacheInfo<6>& cache = Value<CacheInfo<6> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd();
+                CacheInfo<6>& cache = Value<CacheInfo<6> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd();
                 cache.buildH(q, u, getMobilizerTransform(s), functions, coordIndices, Arot, Atrans);
                 // H matrix is now valid 
                 cache.isValidH = true;
@@ -1657,42 +1657,42 @@ public:
         Vector u = getU(s);
         switch (nu) {
             case 1: {
-                CacheInfo<1>& cache = Value<CacheInfo<1> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd();
+                CacheInfo<1>& cache = Value<CacheInfo<1> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd();
                 cache.buildHdot(q, u, getMobilizerTransform(s), functions, coordIndices, Arot, Atrans);
                 // Hdot matrix is now valid 
                 cache.isValidHdot = true;
                 break;
             }
             case 2: {
-                CacheInfo<2>& cache = Value<CacheInfo<2> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd();
+                CacheInfo<2>& cache = Value<CacheInfo<2> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd();
                 cache.buildHdot(q, u, getMobilizerTransform(s), functions, coordIndices, Arot, Atrans);
                 // Hdot matrix is now valid 
                 cache.isValidHdot = true;
                 break;
             }
             case 3: {
-                CacheInfo<3>& cache = Value<CacheInfo<3> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd();
+                CacheInfo<3>& cache = Value<CacheInfo<3> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd();
                 cache.buildHdot(q, u, getMobilizerTransform(s), functions, coordIndices, Arot, Atrans);
                 // Hdot matrix is now valid  
                 cache.isValidHdot = true;
                 break;
             }
             case 4: {
-                CacheInfo<4>& cache = Value<CacheInfo<4> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd();
+                CacheInfo<4>& cache = Value<CacheInfo<4> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd();
                 cache.buildHdot(q, u, getMobilizerTransform(s), functions, coordIndices, Arot, Atrans);
                 // Hdot matrix is now valid 
                 cache.isValidHdot = true;
                 break;
             }
             case 5: {
-                CacheInfo<5>& cache = Value<CacheInfo<5> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd();
+                CacheInfo<5>& cache = Value<CacheInfo<5> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd();
                 cache.buildHdot(q, u, getMobilizerTransform(s), functions, coordIndices, Arot, Atrans);
                 // Hdot matrix is now valid 
                 cache.isValidHdot = true;
                 break;
             }
             case 6: {
-                CacheInfo<6>& cache = Value<CacheInfo<6> >::downcast(s.updCacheEntry(subsystem, cacheIndex)).upd();
+                CacheInfo<6>& cache = Value<CacheInfo<6> >::updDowncast(s.updCacheEntry(subsystem, cacheIndex)).upd();
                 cache.buildHdot(q, u, getMobilizerTransform(s), functions, coordIndices, Arot, Atrans);
                 // Hdot matrix is now valid 
                 cache.isValidHdot = true;

--- a/Simbody/src/MultibodySystemRep.h
+++ b/Simbody/src/MultibodySystemRep.h
@@ -123,7 +123,7 @@ class MultibodySystemGlobalSubsystemRep : public Subsystem::Guts {
         SimTK_STAGECHECK_RANGE(Stage::Model, g, Stage::Dynamics,
             "MultibodySystem::getForceCacheEntry()");
 
-        return Value<ForceCacheEntry>::downcast(
+        return Value<ForceCacheEntry>::updDowncast(
             updCacheEntry(s,forceCacheIndices[g-Stage::Model])).upd();
     }
 public:

--- a/Simbody/src/SimbodyMatterSubsystemRep.h
+++ b/Simbody/src/SimbodyMatterSubsystemRep.h
@@ -1007,7 +1007,7 @@ public:
     }
     SBTopologyCache& updTopologyCache(const State& s) const { //mutable
         assert(subsystemTopologyHasBeenRealized() && topologyCacheIndex >= 0);
-        return Value<SBTopologyCache>::downcast
+        return Value<SBTopologyCache>::updDowncast
             (s.updCacheEntry(getMySubsystemIndex(),topologyCacheIndex)).upd();
     }
 
@@ -1016,7 +1016,7 @@ public:
             (s.getCacheEntry(getMySubsystemIndex(),topologyCache.modelingCacheIndex)).get();
     }
     SBModelCache& updModelCache(const State& s) const { //mutable
-        return Value<SBModelCache>::downcast
+        return Value<SBModelCache>::updDowncast
             (s.updCacheEntry(getMySubsystemIndex(),topologyCache.modelingCacheIndex)).upd();
     }
 
@@ -1025,7 +1025,7 @@ public:
             (s.getCacheEntry(getMySubsystemIndex(),topologyCache.instanceCacheIndex)).get();
     }
     SBInstanceCache& updInstanceCache(const State& s) const { //mutable
-        return Value<SBInstanceCache>::downcast
+        return Value<SBInstanceCache>::updDowncast
             (s.updCacheEntry(getMySubsystemIndex(),topologyCache.instanceCacheIndex)).upd();
     }
 
@@ -1034,7 +1034,7 @@ public:
             (s.getCacheEntry(getMySubsystemIndex(),topologyCache.timeCacheIndex)).get();
     }
     SBTimeCache& updTimeCache(const State& s) const { //mutable
-        return Value<SBTimeCache>::downcast
+        return Value<SBTimeCache>::updDowncast
             (s.updCacheEntry(getMySubsystemIndex(),topologyCache.timeCacheIndex)).upd();
     }
 
@@ -1045,7 +1045,7 @@ public:
     }
 
     SBTreePositionCache& updTreePositionCache(const State& s) const { //mutable
-        return Value<SBTreePositionCache>::downcast
+        return Value<SBTreePositionCache>::updDowncast
             (s.updCacheEntry(getMySubsystemIndex(),topologyCache.treePositionCacheIndex)).upd();
     }
 
@@ -1054,7 +1054,7 @@ public:
             (s.getCacheEntry(getMySubsystemIndex(),topologyCache.constrainedPositionCacheIndex)).get();
     }
     SBConstrainedPositionCache& updConstrainedPositionCache(const State& s) const { //mutable
-        return Value<SBConstrainedPositionCache>::downcast
+        return Value<SBConstrainedPositionCache>::updDowncast
             (s.updCacheEntry(getMySubsystemIndex(),topologyCache.constrainedPositionCacheIndex)).upd();
     }
 
@@ -1083,7 +1083,7 @@ public:
     }
 
     SBTreeVelocityCache& updTreeVelocityCache(const State& s) const { //mutable
-        return Value<SBTreeVelocityCache>::downcast
+        return Value<SBTreeVelocityCache>::updDowncast
             (s.updCacheEntry(getMySubsystemIndex(),topologyCache.treeVelocityCacheIndex)).upd();
     }
 
@@ -1092,7 +1092,7 @@ public:
             (s.getCacheEntry(getMySubsystemIndex(),topologyCache.constrainedVelocityCacheIndex)).get();
     }
     SBConstrainedVelocityCache& updConstrainedVelocityCache(const State& s) const { //mutable
-        return Value<SBConstrainedVelocityCache>::downcast
+        return Value<SBConstrainedVelocityCache>::updDowncast
             (s.updCacheEntry(getMySubsystemIndex(),topologyCache.constrainedVelocityCacheIndex)).upd();
     }
 
@@ -1105,7 +1105,7 @@ public:
 
     SBArticulatedBodyVelocityCache& 
     updArticulatedBodyVelocityCache(const State& state) const { //mutable
-        return Value<SBArticulatedBodyVelocityCache>::downcast
+        return Value<SBArticulatedBodyVelocityCache>::updDowncast
             (state.updCacheEntry(getMySubsystemIndex(),
                 topologyCache.articulatedBodyVelocityCacheIndex)).upd();
     }
@@ -1117,7 +1117,7 @@ public:
         return Value<SBDynamicsCache>::downcast(cacheEntry).get();
     }
     SBDynamicsCache& updDynamicsCache(const State& s) const { //mutable
-        return Value<SBDynamicsCache>::downcast
+        return Value<SBDynamicsCache>::updDowncast
             (s.updCacheEntry(getMySubsystemIndex(),topologyCache.dynamicsCacheIndex)).upd();
     }
 
@@ -1126,7 +1126,7 @@ public:
             (s.getCacheEntry(getMySubsystemIndex(),topologyCache.treeAccelerationCacheIndex)).get();
     }
     SBTreeAccelerationCache& updTreeAccelerationCache(const State& s) const { //mutable
-        return Value<SBTreeAccelerationCache>::downcast
+        return Value<SBTreeAccelerationCache>::updDowncast
             (s.updCacheEntry(getMySubsystemIndex(),topologyCache.treeAccelerationCacheIndex)).upd();
     }
 
@@ -1135,7 +1135,7 @@ public:
             (s.getCacheEntry(getMySubsystemIndex(),topologyCache.constrainedAccelerationCacheIndex)).get();
     }
     SBConstrainedAccelerationCache& updConstrainedAccelerationCache(const State& s) const { //mutable
-        return Value<SBConstrainedAccelerationCache>::downcast
+        return Value<SBConstrainedAccelerationCache>::updDowncast
             (s.updCacheEntry(getMySubsystemIndex(),topologyCache.constrainedAccelerationCacheIndex)).upd();
     }
 
@@ -1145,7 +1145,7 @@ public:
             (s.getDiscreteVariable(getMySubsystemIndex(),topologyCache.modelingVarsIndex)).get();
     }
     SBModelVars& updModelVars(State& s) const {
-        return Value<SBModelVars>::downcast
+        return Value<SBModelVars>::updDowncast
             (s.updDiscreteVariable(getMySubsystemIndex(),topologyCache.modelingVarsIndex)).upd();
     }
 
@@ -1154,7 +1154,7 @@ public:
             (s.getDiscreteVariable(getMySubsystemIndex(),topologyCache.topoInstanceVarsIndex)).get();
     }
     SBInstanceVars& updInstanceVars(State& s) const {
-        return Value<SBInstanceVars>::downcast
+        return Value<SBInstanceVars>::updDowncast
             (s.updDiscreteVariable(getMySubsystemIndex(),topologyCache.topoInstanceVarsIndex)).upd();
     }
 
@@ -1163,7 +1163,7 @@ public:
             (s.getDiscreteVariable(getMySubsystemIndex(),getModelCache(s).timeVarsIndex)).get();
     }
     SBTimeVars& updTimeVars(State& s) const {
-        return Value<SBTimeVars>::downcast
+        return Value<SBTimeVars>::updDowncast
             (s.updDiscreteVariable(getMySubsystemIndex(),getModelCache(s).timeVarsIndex)).upd();
     }
 
@@ -1172,7 +1172,7 @@ public:
             (s.getDiscreteVariable(getMySubsystemIndex(),getModelCache(s).qVarsIndex)).get();
     }
     SBPositionVars& updPositionVars(State& s) const {
-        return Value<SBPositionVars>::downcast
+        return Value<SBPositionVars>::updDowncast
             (s.updDiscreteVariable(getMySubsystemIndex(),getModelCache(s).qVarsIndex)).upd();
     }
 
@@ -1181,7 +1181,7 @@ public:
             (s.getDiscreteVariable(getMySubsystemIndex(),getModelCache(s).uVarsIndex)).get();
     }
     SBVelocityVars& updVelocityVars(State& s) const {
-        return Value<SBVelocityVars>::downcast
+        return Value<SBVelocityVars>::updDowncast
             (s.updDiscreteVariable(getMySubsystemIndex(),getModelCache(s).uVarsIndex)).upd();
     }
 
@@ -1190,7 +1190,7 @@ public:
             (s.getDiscreteVariable(getMySubsystemIndex(),getModelCache(s).dynamicsVarsIndex)).get();
     }
     SBDynamicsVars& updDynamicsVars(State& s) const {
-        return Value<SBDynamicsVars>::downcast
+        return Value<SBDynamicsVars>::updDowncast
             (s.updDiscreteVariable(getMySubsystemIndex(),getModelCache(s).dynamicsVarsIndex)).upd();
     }
 
@@ -1199,7 +1199,7 @@ public:
             (s.getDiscreteVariable(getMySubsystemIndex(),getModelCache(s).accelerationVarsIndex)).get();
     }
     SBAccelerationVars& updAccelerationVars(State& s) const {
-        return Value<SBAccelerationVars>::downcast
+        return Value<SBAccelerationVars>::updDowncast
             (s.updDiscreteVariable(getMySubsystemIndex(),getModelCache(s).accelerationVarsIndex)).upd();
     }
 

--- a/Simbody/tests/adhoc/SBPendulum1.cpp
+++ b/Simbody/tests/adhoc/SBPendulum1.cpp
@@ -85,7 +85,7 @@ void stateTest() {
     s.advanceSubsystemToStage(SubsystemIndex(0), Stage::Model);
         //long dv2 = s.allocateDiscreteVariable(SubsystemIndex(0), Stage::Position, new Value<int>(5));
 
-    Value<int>::downcast(s.updDiscreteVariable(SubsystemIndex(0), dv)) = 71;
+    Value<int>::updDowncast(s.updDiscreteVariable(SubsystemIndex(0), dv)) = 71;
     cout << s.getDiscreteVariable(SubsystemIndex(0), dv) << endl;
 
     s.advanceSystemToStage(Stage::Model);


### PR DESCRIPTION
Will deprecate `Value<T>::downcast(non-const&)` soon; this PR will avoid warnings by using the unambiguous `updDowncast()` method instead.