### PR TITLE
Iterator range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ to ParallelExecutor, mutex state lock.
   make an XML-friendly modification of `namestr()` that replaces angle brackets
   with curly braces. Added a new regression test to verify that the names come
   out right. [PR #461](https://github.com/simbody/simbody/pull/461)
+* Added helper class IteratorRange to use range-based for loops with a pair of
+  iterators. [PR#467](https://github.com/simbody/simbody/pull/467)
 * (There are more that haven't been added yet)
 
 

--- a/Doxyfile.in
+++ b/Doxyfile.in
@@ -1000,7 +1000,7 @@ VERBATIM_HEADERS       = YES
 # compiled with the --with-libclang option.
 # The default value is: NO.
 
-CLANG_ASSISTED_PARSING = NO
+# CLANG_ASSISTED_PARSING = NO
 
 # If clang assisted parsing is enabled you can provide the compiler with command
 # line options that you would normally use when invoking the compiler. Note that
@@ -1008,7 +1008,7 @@ CLANG_ASSISTED_PARSING = NO
 # specified with INPUT and INCLUDE_PATH.
 # This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
 
-CLANG_OPTIONS          =
+# CLANG_OPTIONS          =
 
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index

--- a/SimTKcommon/include/SimTKcommon/internal/IteratorRange.h
+++ b/SimTKcommon/include/SimTKcommon/internal/IteratorRange.h
@@ -9,7 +9,7 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2008-16 Stanford University and the Authors.        *
+ * Portions copyright (c) 2016 Stanford University and the Authors.           *
  * Authors: Chris Dembia                                                      *
  * Contributors:                                                              *
  *                                                                            *
@@ -27,21 +27,38 @@
 namespace SimTK {
 
 /** Helper class to use range-based for loops with a pair of iterators. This
- * class should only be used when you're sure the iterators are valid. Don't
- * use this class directly; instead, use makeIteratorRange().
- *
- * @code
- * for (auto& x : makeIteratorRange(v.begin(), v.end())) {
- *     ...
- * }
- * @endcode
- * */
+class should only be used when you're sure the iterators are valid. Don't
+use this class directly; instead, use makeIteratorRange().
+
+@code
+std::vector<int> v {5, 10, 15, 20};
+auto first = std::lower_bound(v.begin(), v.end(), 10);
+auto last = std::lower_bound(v.begin(), v.end(), 15);
+for (auto& x : makeIteratorRange(first, last)) {
+    ...
+}
+@endcode
+
+You can also use this class with an std::pair of iterators, such as that
+returned by std::multimap::equal_range(). We assume the first iterator in the
+pair is the first iterator in the range, and the second iterator in the pair is
+the last iterator in the range.
+@code
+std::multimap<std::string, int> map;
+...
+for (auto& x : makeIteratorRange(map.equal_range("some_key"))) {
+    ...
+}
+@endcode
+*/
 // http://stackoverflow.com/questions/6167598/why-was-pair-range-access-removed-from-c11
 template <class Iterator>
 class IteratorRange {
 public:
     IteratorRange(Iterator first, Iterator last)
         : m_first(first), m_last(last) {}
+    explicit IteratorRange(const std::pair<Iterator, Iterator>& range)
+        : m_first(range.first), m_last(range.second) {}
     Iterator begin() const { return m_first; }
     Iterator end() const { return m_last; }
 private:
@@ -49,12 +66,22 @@ private:
     const Iterator m_last;
 };
 
-/** Make an IteratorRange object to be used in a range-based for loop.
- * @relates IteratorRange
- */
+/** Make an IteratorRange object to be used in a range-based for loop, using
+ * two iterators.
+@relates IteratorRange
+*/
 template <class Iterator>
 IteratorRange<Iterator> makeIteratorRange(Iterator first, Iterator last) {
     return IteratorRange<Iterator>(first, last);
+}
+/** Make an IteratorRange object to be used in a range-based for loop, using
+ * an std::pair of iterators.
+@relates IteratorRange
+*/
+template <class Iterator>
+IteratorRange<Iterator> makeIteratorRange(
+        const std::pair<Iterator, Iterator>& range) {
+    return IteratorRange<Iterator>(range);
 }
 
 } // namespace SimTK

--- a/SimTKcommon/include/SimTKcommon/internal/IteratorRange.h
+++ b/SimTKcommon/include/SimTKcommon/internal/IteratorRange.h
@@ -30,10 +30,12 @@ namespace SimTK {
 class should only be used when you're sure the iterators are valid. Don't
 use this class directly; instead, use makeIteratorRange().
 
+Here's an example of using iterators `first` and `last` to iterate over the
+range `[first, last)` (that is, `last` won't be reached):
 @code
-std::vector<int> v {5, 10, 15, 20};
+std::vector<int> v {5, 10, 15, 20, 22};
 auto first = std::lower_bound(v.begin(), v.end(), 10);
-auto last = std::lower_bound(v.begin(), v.end(), 15);
+auto last = std::lower_bound(v.begin(), v.end(), 15); // actually points to 20.
 for (auto& x : makeIteratorRange(first, last)) {
     ...
 }
@@ -55,6 +57,8 @@ for (auto& x : makeIteratorRange(map.equal_range("some_key"))) {
 template <class Iterator>
 class IteratorRange {
 public:
+    /** This constructor allows you to iterate over the range `[first, last)`;
+    this means `last` won't be reached. */
     IteratorRange(Iterator first, Iterator last)
         : m_first(first), m_last(last) {}
     explicit IteratorRange(const std::pair<Iterator, Iterator>& range)
@@ -67,15 +71,16 @@ private:
 };
 
 /** Make an IteratorRange object to be used in a range-based for loop, using
- * two iterators.
+two iterators.
 @relates IteratorRange
+@see IteratorRange::IteratorRange()
 */
 template <class Iterator>
 IteratorRange<Iterator> makeIteratorRange(Iterator first, Iterator last) {
     return IteratorRange<Iterator>(first, last);
 }
 /** Make an IteratorRange object to be used in a range-based for loop, using
- * an std::pair of iterators.
+an std::pair of iterators.
 @relates IteratorRange
 */
 template <class Iterator>

--- a/SimTKcommon/include/SimTKcommon/internal/IteratorRange.h
+++ b/SimTKcommon/include/SimTKcommon/internal/IteratorRange.h
@@ -1,5 +1,5 @@
-#ifndef SimTK_SimTKCOMMON_BASICS_H_
-#define SimTK_SimTKCOMMON_BASICS_H_
+#ifndef SimTK_SimTKCOMMON_ITERATOR_RANGE_H_
+#define SimTK_SimTKCOMMON_ITERATOR_RANGE_H_
 
 /* -------------------------------------------------------------------------- *
  *                       Simbody(tm): SimTKcommon                             *
@@ -9,8 +9,8 @@
  * Biological Structures at Stanford, funded under the NIH Roadmap for        *
  * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
  *                                                                            *
- * Portions copyright (c) 2005-15 Stanford University and the Authors.        *
- * Authors: Michael Sherman                                                   *
+ * Portions copyright (c) 2008-16 Stanford University and the Authors.        *
+ * Authors: Chris Dembia                                                      *
  * Contributors:                                                              *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
@@ -24,38 +24,39 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-/**@file
- * Includes internal headers providing declarations for the basic SimTK
- * Core classes. This file can be included from ANSI C code as well as
- * C++, although only a small subset of the definitions will be done
- * in a C program. These include default precision and simple macros
- * such as those used for physical constants.
+namespace SimTK {
+
+/** Helper class to use range-based for loops with a pair of iterators. This
+ * class should only be used when you're sure the iterators are valid. Don't
+ * use this class directly; instead, use makeIteratorRange().
+ *
+ * @code
+ * for (auto& x : makeIteratorRange(v.begin(), v.end())) {
+ *     ...
+ * }
+ * @endcode
+ * */
+// http://stackoverflow.com/questions/6167598/why-was-pair-range-access-removed-from-c11
+template <class Iterator>
+class IteratorRange {
+public:
+    IteratorRange(Iterator first, Iterator last)
+        : m_first(first), m_last(last) {}
+    Iterator begin() const { return m_first; }
+    Iterator end() const { return m_last; }
+private:
+    const Iterator m_first;
+    const Iterator m_last;
+};
+
+/** Make an IteratorRange object to be used in a range-based for loop.
+ * @relates IteratorRange
  */
+template <class Iterator>
+IteratorRange<Iterator> makeIteratorRange(Iterator first, Iterator last) {
+    return IteratorRange<Iterator>(first, last);
+}
 
-/* NOTE: don't use "//" comments in this file! */
+} // namespace SimTK
 
-/* These two are safe for C programs. */
-#include "SimTKcommon/internal/common.h"
-#include "SimTKcommon/Constants.h"
-
-#if defined(__cplusplus)
-#include "SimTKcommon/internal/Exception.h"
-#include "SimTKcommon/internal/ExceptionMacros.h"
-#include "SimTKcommon/internal/ClonePtr.h"
-#include "SimTKcommon/internal/CloneOnWritePtr.h"
-#include "SimTKcommon/internal/ReferencePtr.h"
-#include "SimTKcommon/internal/ResetOnCopy.h"
-#include "SimTKcommon/internal/ReinitOnCopy.h"
-#include "SimTKcommon/internal/String.h"
-#include "SimTKcommon/internal/Serialize.h"
-#include "SimTKcommon/internal/IteratorRange.h"
-#include "SimTKcommon/internal/Fortran.h"
-#include "SimTKcommon/internal/Array.h"
-#include "SimTKcommon/internal/StableArray.h"
-#include "SimTKcommon/internal/Value.h"
-#include "SimTKcommon/internal/Stage.h"
-#include "SimTKcommon/internal/CoordinateAxis.h"
-#endif
-
-
-#endif /* SimTK_SimTKCOMMON_BASICS_H_ */
+#endif // SimTK_SimTKCOMMON_ITERATOR_RANGE_H_

--- a/SimTKcommon/tests/TestIteratorRange.cpp
+++ b/SimTKcommon/tests/TestIteratorRange.cpp
@@ -1,0 +1,82 @@
+/* -------------------------------------------------------------------------- *
+ *                       Simbody(tm): SimTKcommon                             *
+ * -------------------------------------------------------------------------- *
+ * This is part of the SimTK biosimulation toolkit originating from           *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
+ *                                                                            *
+ * Portions copyright (c) 2016 Stanford University and the Authors.           *
+ * Authors: Chris Dembia                                                      *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "SimTKcommon.h"
+#include <map>
+
+using namespace SimTK;
+
+void testFirstLast() {
+    std::vector<int> v {1, 5, 6, 7, 9, 10, 15};
+    
+    {
+        std::vector<int> indices {6, 7, 9};
+        int index = 0;
+        for (auto& x : makeIteratorRange(
+                    std::lower_bound(v.begin(), v.end(), 6),
+                    std::upper_bound(v.begin(), v.end(), 9))) {
+            SimTK_TEST(indices[index] == x);
+            index++;
+        }
+    }
+}
+
+void testPair() {
+    std::multimap<std::string, int> map;
+    map.insert({"avocado", 5});
+    map.insert({"broccoli", 5});
+    map.insert({"broccoli", 16});
+    map.insert({"eggplant", 1});
+    map.insert({"guineafowl", 11});
+    map.insert({"broccoli", 17});
+    map.insert({"broccoli", 5});
+    map.insert({"avocado", 71});
+    map.insert({"jackfruit", 8});
+
+    {
+        std::vector<int> avocado {5, 71};
+        int index = 0;
+        for (auto& x : makeIteratorRange(map.equal_range("avocado"))) {
+            SimTK_TEST(avocado[index] == x.second);
+            index++;
+        }
+    }
+
+    {
+        std::vector<int> broccoli {5, 16, 17, 5};
+        int index = 0;
+        for (auto& x : makeIteratorRange(map.equal_range("broccoli"))) {
+            SimTK_TEST(broccoli[index] == x.second);
+            index++;
+        }
+    }
+}
+
+int main() {
+    SimTK_START_TEST("TestIteratorRange");
+
+        SimTK_SUBTEST(testFirstLast);
+        SimTK_SUBTEST(testPair);
+
+    SimTK_END_TEST();
+}


### PR DESCRIPTION
This PR adds a helper class that allows using range-based for loops with a pair of iterators:

```cpp
std::vector<int> v {5, 10, 15, 20};
auto first = std::lower_bound(v.begin(), v.end(), 10);
auto last = std::upper_bound(v.begin(), v.end(), 15);
for (auto& x : makeIteratorRange(first, last)) {
    ...
}
```