### PR TITLE
Add State::isConsistent() method.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ to ParallelExecutor, mutex state lock.
   make an XML-friendly modification of `namestr()` that replaces angle brackets
   with curly braces. Added a new regression test to verify that the names come
   out right. [PR #461](https://github.com/simbody/simbody/pull/461)
+* Added the method `State::isConsistent()` to compare two states
+  [PR #469](https://github.com/simbody/simbody/pull/469).
 * (There are more that haven't been added yet)
 
 

--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/State.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/State.h
@@ -311,6 +311,28 @@ State& operator=(State&& source);
 /// Restore State to default-constructed condition.
 void clear();
 
+/// Checks if a given state has the same number of state variables,
+/// constraints, etc as this state. Returns true if the following quantities
+/// are the same for both this state and `otherState`.
+/// 
+/// - number of subsystems
+/// - number of generalized coordinates (Q's)
+/// - number of generalized speeds (U's)
+/// - number of auxiliary state variables (Z's)
+/// - number of position constraints (QErr's)
+/// - number of velocity constraints (UErr's)
+/// - number of acceleration constraints (UDotErr's)
+/// - number of constraint Lagrange multipliers
+/// - number of event triggers
+/// 
+/// Returns false otherwise.
+/// 
+/// This method does NOT guarantee that both states are for the same system or
+/// that both states will work with the same system. Also, this method does
+/// NOT check for any relationship between the times in the
+/// two states.
+bool isConsistent(const SimTK::State& otherState) const;
+
 /// Set the number of subsystems in this state. This is done during
 /// initialization of the State by a System; it completely wipes out
 /// anything that used to be in the State so use cautiously!

--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/State.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/State.h
@@ -326,6 +326,9 @@ void clear();
 /// - number of event triggers
 /// 
 /// Returns false otherwise.
+///
+/// You can call this after Instance stage has been realized on both this state
+/// and `otherState`.
 /// 
 /// This method does NOT guarantee that both states are for the same system or
 /// that both states will work with the same system. Also, this method does

--- a/SimTKcommon/Simulation/src/State.cpp
+++ b/SimTKcommon/Simulation/src/State.cpp
@@ -96,6 +96,67 @@ SimTK::operator<<(std::ostream& o, const State& s) {
     return o << s.cacheToString() << std::endl;
 }
 
+bool State::isConsistent(const SimTK::State& otherState) const {
+
+    if (getNumSubsystems() != otherState.getNumSubsystems())
+        return false;
+
+    // State variables.
+    if (getNQ() != otherState.getNQ())
+        return false;
+    if (getNU() != otherState.getNU())
+        return false;
+    if (getNZ() != otherState.getNZ())
+        return false;
+
+    // Constraints.
+    if (getNQErr() != otherState.getNQErr())
+        return false;
+    if (getNUErr() != otherState.getNUErr())
+        return false;
+    if (getNUDotErr() != otherState.getNUDotErr())
+        return false;
+    // NMultipliers should be the same as NUDotErr, but we leave this check
+    // here in case they diverge in the future.
+    if (getNMultipliers() != otherState.getNMultipliers())
+        return false;
+
+    // Events.
+    if (getNEventTriggers() != otherState.getNEventTriggers())
+        return false;
+
+    // Per-subsystem quantities.
+    // TODO we could get rid of the total-over-subsystems checks above, but
+    // those checks would let us exit earlier.
+    for (SimTK::SubsystemIndex isub(0); isub < getNumSubsystems();
+            ++isub) {
+        if (getNQ(isub) != otherState.getNQ(isub))
+            return false;
+        if (getNU(isub) != otherState.getNU(isub))
+            return false;
+        if (getNZ(isub) != otherState.getNZ(isub))
+            return false;
+        if (getNQErr(isub) != otherState.getNQErr(isub))
+            return false;
+        if (getNUErr(isub) != otherState.getNUErr(isub))
+            return false;
+        if (getNUDotErr(isub) != otherState.getNUDotErr(isub))
+            return false;
+        // NMultipliers should be the same as NUDotErr, but we leave this check
+        // here in case they diverge in the future.
+        if (getNMultipliers(isub) != otherState.getNMultipliers(isub))
+            return false;
+
+        for(SimTK::Stage stage = SimTK::Stage::LowestValid;
+                stage <= SimTK::Stage::HighestRuntime; ++stage) {
+            if (getNEventTriggersByStage(isub, stage) !=
+                    otherState.getNEventTriggersByStage(isub, stage))
+                return false;
+        }
+    }
+    return true;
+}
+
 
 //==============================================================================
 //                          PER SUBSYSTEM INFO

--- a/SimTKcommon/tests/StateTest.cpp
+++ b/SimTKcommon/tests/StateTest.cpp
@@ -532,10 +532,10 @@ int main() {
     }
 
 
-    // TODO SimTK_START_TEST("StateTest");
+    SimTK_START_TEST("StateTest");
         //SimTK_SUBTEST(testLowestModified);
         SimTK_SUBTEST(testCacheValidity);
         SimTK_SUBTEST(testMisc);
         SimTK_SUBTEST(testConsistent);
-    // TODO SimTK_END_TEST();
+    SimTK_END_TEST();
 }

--- a/SimTKcommon/tests/StateTest.cpp
+++ b/SimTKcommon/tests/StateTest.cpp
@@ -411,6 +411,97 @@ void testMisc() {
     //cout << "after clear(), State s=" << s;
 }
 
+void testConsistent() {
+    State sA;
+    State sB;
+
+    SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+    sA.updQ().resize(5);
+    SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+    sB.updQ().resize(5);
+    SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+    sA.updU().resize(3);
+    SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+    sB.updU().resize(3);
+    SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+    sA.updZ().resize(8);
+    SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+    sB.updZ().resize(8);
+    SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+    sA.updQErr().resize(2);
+    SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+    sB.updQErr().resize(2);
+    SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+    sA.updUErr().resize(7);
+    SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+    sB.updUErr().resize(7);
+    SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+    sA.updUDotErr().resize(1);
+    SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+    sB.updUDotErr().resize(1);
+    SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+    sA.updEventTriggers().resize(12);
+    SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+    sB.updEventTriggers().resize(12);
+    SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+    // Subsystems.
+    int numSubsys = 3;
+    sA.setNumSubsystems(numSubsys);
+    SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+    sB.setNumSubsystems(numSubsys);
+    SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+    for (int i = 0; i < numSubsys; ++i) {
+        sA.updQ(SubsystemIndex(i)).resize(2);
+        SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+        sB.updQ(SubsystemIndex(i)).resize(2);
+        SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+        sA.updU(SubsystemIndex(i)).resize(6);
+        SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+        sB.updU(SubsystemIndex(i)).resize(6);
+        SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+        sA.updZ(SubsystemIndex(i)).resize(9);
+        SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+        sB.updZ(SubsystemIndex(i)).resize(9);
+        SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+        sA.updQErr(SubsystemIndex(i)).resize(4);
+        SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+        sB.updQErr(SubsystemIndex(i)).resize(4);
+        SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+        sA.updUErr(SubsystemIndex(i)).resize(3);
+        SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+        sB.updUErr(SubsystemIndex(i)).resize(3);
+        SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+        sA.updUDotErr(SubsystemIndex(i)).resize(8);
+        SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+        sB.updUDotErr(SubsystemIndex(i)).resize(8);
+        SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+
+        for(SimTK::Stage stage = SimTK::Stage::LowestValid;
+                stage <= SimTK::Stage::HighestRuntime; ++stage) {
+            // I'm using `i` as a way to arbitrarily choose different sizes.
+            sA.updEventTriggersByStage(SubsystemIndex(i), stage).resize(4 + i);
+            SimTK_TEST(!sA.isConsistent(sB)); SimTK_TEST(!sB.isConsistent(sA));
+            sB.updEventTriggersByStage(SubsystemIndex(i), stage).resize(4 + i);
+            SimTK_TEST(sA.isConsistent(sB)); SimTK_TEST(sB.isConsistent(sA));
+        }
+    }
+
+}
+
 int main() {
     int major,minor,build;
     char out[100];
@@ -429,5 +520,10 @@ int main() {
         //SimTK_SUBTEST(testLowestModified);
         SimTK_SUBTEST(testCacheValidity);
         SimTK_SUBTEST(testMisc);
+        #ifdef NDEBUG
+            // This test relies on avoiding the stage checks that happen in
+            // debug mode, so we can only run it in release.
+            SimTK_SUBTEST(testConsistent);
+        #endif
     SimTK_END_TEST();
 }


### PR DESCRIPTION
This method compares if two states have the same number of subsystems, state variables, constraints, etc. I use such a method in OpenSim's StatesTrajectory class ([see PR](https://github.com/opensim-org/opensim-core/pull/730)).

Notes:

1. The function checks that the number of multipliers matches in both states, even though NUDotErr should be the same as NMultipliers. I did this in case the two numbers diverge in the future for some reason.
2. The test is only executed in release mode, since the test relies on the fact that the stage checks do not occur in release.


Questions:

1. Where should the implementation of this method go? It felt wrong to put its implementation in State; should I move the implementation to StateImpl? OR should this method be a static method in State that takes two states, or a free function?

2. Where should I put the function in State.h? I chose to place it between `clear()` and `setNumSubsystems)`; this is how it looks in doxygen:

 ![image](https://cloud.githubusercontent.com/assets/846001/12772964/aac750c8-c9eb-11e5-84f5-3f4a44aaaf81.png)
