### PR TITLE
Add some compiler checks to avoid having compilation crash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,14 +506,6 @@ include(Dart)
 set(DART_TESTING_TIMEOUT 7200)
 
 if(BUILD_TESTING)
-
-    #if(UNIX AND NOT CYGWIN AND NOT APPLE)
-    #  if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE MATCHES Debug)
-    #    add_definitions(-fprofile-arcs -ftest-coverage)
-    #    link_libraries(gcov)
-    #  endif()
-    #endif()
-
     #
     # Testing
     #
@@ -530,10 +522,7 @@ if(BUILD_TESTING)
     else()
         set(cmd ${cmd} -C ${CMAKE_BUILD_TYPE})
     endif()
-    add_custom_target(RUN_TESTS_PARALLEL
-        COMMAND ${cmd}
-    )
-
+    add_custom_target(RUN_TESTS_PARALLEL COMMAND ${cmd})
 endif()
 
 include(ApiDoxygen.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,17 +29,6 @@ endif()
 
 project(Simbody)
 
-if(MSVC)
-    if(MSVC_VERSION LESS 1800 OR MSVC_VERSION EQUAL 1800)
-        message(FATAL_ERROR "\nMSVC does not support C++ 2011 features, for "
-                            "example 'constexpr'. Update to at least MSVC 2015 "
-                            "or use a MinGW version on Windows.\nLook at the "
-                            "README.md for more information.\nIf you have the"
-                            " 'Visual C++ Compiler Nov 2013 CTP (CTP_Nov2013)'"
-                            " comment this test and configure normally.")
-    endif()
-endif()
-
 # At this point CMake will have set CMAKE_INSTALL_PREFIX to /usr/local on Linux
 # or appropriate ProgramFiles directory on Windows, for example
 # C:/Program Files/Simbody, C:/Program Files (x86)/Simbody, or the local
@@ -55,6 +44,30 @@ endif()
 
 # Include GNUInstallDirs to get canonical paths
 include(GNUInstallDirs)
+
+# Check compiler version
+if(MSVC)
+    if(MSVC_VERSION LESS 1800 OR MSVC_VERSION EQUAL 1800)
+        message(FATAL_ERROR "\nMSVC does not support C++ 2011 features, for "
+                            "example 'constexpr'. Update to at least MSVC 2015 "
+                            "or use a MinGW version on Windows.\nLook at the "
+                            "README.md for more information.\nIf you have the"
+                            " 'Visual C++ Compiler Nov 2013 CTP (CTP_Nov2013)'"
+                            " comment this test and configure normally.")
+    endif()
+elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
+                    OUTPUT_VARIABLE GCC_VERSION)
+    if (GCC_VERSION LESS 4.8.1)
+        message(FATAL_ERROR "GNU GCC/G++ version is too old to compile Simbody")
+    endif()
+elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
+                    OUTPUT_VARIABLE CLANG_VERSION)
+    if (CLANG_VERSION LESS 3.4)
+        message(FATAL_ERROR "Clang version is too old to compile Simbody")
+    endif()
+endif()
 
 set(SIMBODY_MAJOR_VERSION 3)
 set(SIMBODY_MINOR_VERSION 6)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ if(COMMAND cmake_policy)
         # MACOSX_RPATH enabled by default; policy introduced with cmake 3.0.
         cmake_policy(SET CMP0042 NEW)
     endif()
-endif(COMMAND cmake_policy)
+endif()
 
 project(Simbody)
 
@@ -116,7 +116,7 @@ set(BUILD_VERSIONED_LIBRARIES FALSE CACHE BOOL
 set(NS)
 if(BUILD_USING_NAMESPACE)
     set(NS "${BUILD_USING_NAMESPACE}_")
-endif(BUILD_USING_NAMESPACE)
+endif()
 
 # Ensure that debug libraries have "_d" appended to their names.
 set(CMAKE_DEBUG_POSTFIX "_d")
@@ -435,9 +435,9 @@ endif()
 
 if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
    set(NEED_QUOTES FALSE)
-else(${CMAKE_GENERATOR} MATCHES "Visual Studio")
+else()
    set(NEED_QUOTES TRUE)
-endif(${CMAKE_GENERATOR} MATCHES "Visual Studio")
+endif()
 
 ##TODO: doesn't work without quotes in nightly build
 set(NEED_QUOTES TRUE)
@@ -445,10 +445,10 @@ set(NEED_QUOTES TRUE)
 if(NEED_QUOTES)
    add_definitions(-DSimTK_SIMBODY_COPYRIGHT_YEARS="${SIMBODY_COPYRIGHT_YEARS}"
                    -DSimTK_SIMBODY_AUTHORS="${SIMBODY_AUTHORS}")
-else(NEED_QUOTES)
+else()
    add_definitions(-DSimTK_SIMBODY_COPYRIGHT_YEARS=${SIMBODY_COPYRIGHT_YEARS}
                    -DSimTK_SIMBODY_AUTHORS=${SIMBODY_AUTHORS})
-endif(NEED_QUOTES)
+endif()
 
 # Determine which math libraries to use for this platform.
 # Intel MKL: mkl_intel_c_dll;mkl_sequential_dll;mkl_core_dll
@@ -499,8 +499,8 @@ if(BUILD_TESTING)
     #  if(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE MATCHES Debug)
     #    add_definitions(-fprofile-arcs -ftest-coverage)
     #    link_libraries(gcov)
-    #  endif(NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE MATCHES Debug)
-    #endif(UNIX AND NOT CYGWIN AND NOT APPLE)
+    #  endif()
+    #endif()
 
     #
     # Testing
@@ -522,7 +522,7 @@ if(BUILD_TESTING)
         COMMAND ${cmd}
     )
 
-endif(BUILD_TESTING)
+endif()
 
 include(ApiDoxygen.cmake)
 
@@ -560,7 +560,7 @@ add_subdirectory( Simbody )
 
 if( BUILD_EXAMPLES )
   add_subdirectory( examples )
-endif( BUILD_EXAMPLES )
+endif()
 
 file(GLOB TOPLEVEL_DOCS LICENSE.txt *.md doc/*.pdf doc/*.txt doc/*.md)
 install(FILES ${TOPLEVEL_DOCS} DESTINATION ${CMAKE_INSTALL_DOCDIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,16 +56,22 @@ if(MSVC)
                             " comment this test and configure normally.")
     endif()
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+    set(SIMBODY_REQUIRED_GCC_VERSION 4.8.1)
     execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
                     OUTPUT_VARIABLE GCC_VERSION)
-    if (GCC_VERSION LESS 4.8.1)
-        message(FATAL_ERROR "GNU GCC/G++ version is too old to compile Simbody")
+    if (GCC_VERSION VERSION_LESS ${SIMBODY_REQUIRED_GCC_VERSION})
+        message(FATAL_ERROR "GNU GCC/G++ version is too old to compile Simbody"
+                            "Simbody requires at least version :"
+                            "${SIMBODY_REQUIRED_GCC_VERSION}")
     endif()
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+    set(SIMBODY_REQUIRED_CLANG_VERSION 3.4)
     execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
                     OUTPUT_VARIABLE CLANG_VERSION)
-    if (CLANG_VERSION LESS 3.4)
-        message(FATAL_ERROR "Clang version is too old to compile Simbody")
+    if (CLANG_VERSION VERSION_LESS ${SIMBODY_REQUIRED_CLANG_VERSION})
+        message(FATAL_ERROR "Clang version is too old to compile Simbody.\n"
+                            "Simbody requires at least version :"
+                            "${SIMBODY_REQUIRED_CLANG_VERSION}")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,11 +46,11 @@ endif()
 # language equivalent.
 
 if(WIN32)
-  set(CMAKE_INSTALL_DOCDIR doc CACHE PATH "documentation root (DATAROOTDIR/doc/PROJECT_NAME)")
+    set(CMAKE_INSTALL_DOCDIR doc CACHE PATH "documentation root (DATAROOTDIR/doc/PROJECT_NAME)")
 else()
-  # Redefine DOCDIR to use the project name in lowercase to avoid
-  # problems with some platforms: NTFS on Win, XFS or JFS variants
-  set(CMAKE_INSTALL_DOCDIR share/doc/simbody CACHE PATH "documentation root (DATAROOTDIR/doc/PROJECT_NAME)")
+    # Redefine DOCDIR to use the project name in lowercase to avoid
+    # problems with some platforms: NTFS on Win, XFS or JFS variants
+    set(CMAKE_INSTALL_DOCDIR share/doc/simbody CACHE PATH "documentation root (DATAROOTDIR/doc/PROJECT_NAME)")
 endif()
 
 # Include GNUInstallDirs to get canonical paths
@@ -320,10 +320,10 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
     set(GCC_OPT_DISABLE)
     # We know Gcc 4.4.3 on Ubuntu 10 is buggy.
     if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-      if(GCC_VERSION VERSION_EQUAL 4.4)
-        set(GCC_OPT_DISABLE
-        "-fno-strict-aliasing -fno-tree-vrp -fno-guess-branch-probability")
-      endif()
+        if(GCC_VERSION VERSION_EQUAL 4.4)
+            set(GCC_OPT_DISABLE
+                "-fno-strict-aliasing -fno-tree-vrp -fno-guess-branch-probability")
+        endif()
     endif()
 
     # C++
@@ -434,20 +434,20 @@ endif()
 # in Visual Studio which end up in the binary.
 
 if(${CMAKE_GENERATOR} MATCHES "Visual Studio")
-   set(NEED_QUOTES FALSE)
+    set(NEED_QUOTES FALSE)
 else()
-   set(NEED_QUOTES TRUE)
+    set(NEED_QUOTES TRUE)
 endif()
 
 ##TODO: doesn't work without quotes in nightly build
 set(NEED_QUOTES TRUE)
 
 if(NEED_QUOTES)
-   add_definitions(-DSimTK_SIMBODY_COPYRIGHT_YEARS="${SIMBODY_COPYRIGHT_YEARS}"
-                   -DSimTK_SIMBODY_AUTHORS="${SIMBODY_AUTHORS}")
+    add_definitions(-DSimTK_SIMBODY_COPYRIGHT_YEARS="${SIMBODY_COPYRIGHT_YEARS}"
+                    -DSimTK_SIMBODY_AUTHORS="${SIMBODY_AUTHORS}")
 else()
-   add_definitions(-DSimTK_SIMBODY_COPYRIGHT_YEARS=${SIMBODY_COPYRIGHT_YEARS}
-                   -DSimTK_SIMBODY_AUTHORS=${SIMBODY_AUTHORS})
+    add_definitions(-DSimTK_SIMBODY_COPYRIGHT_YEARS=${SIMBODY_COPYRIGHT_YEARS}
+                    -DSimTK_SIMBODY_AUTHORS=${SIMBODY_AUTHORS})
 endif()
 
 # Determine which math libraries to use for this platform.
@@ -531,17 +531,17 @@ include(ApiDoxygen.cmake)
 #
 # Also specify where include files are installed.
 if(WIN32)
-  # Install visualizer to bin, since it needs to be co-located with dll's
-  set(SIMBODY_VISUALIZER_REL_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})
-  # Install include files into base include folder since it's a sandbox
-  set(SIMBODY_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+    # Install visualizer to bin, since it needs to be co-located with dll's
+    set(SIMBODY_VISUALIZER_REL_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})
+    # Install include files into base include folder since it's a sandbox
+    set(SIMBODY_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
 else()
-  # Visualizer is not intended to be a user executable. Proper place is
-  # inside the lib directory
-  set(SIMBODY_VISUALIZER_REL_INSTALL_DIR ${CMAKE_INSTALL_LIBEXECDIR}/simbody)
-  # Install include files in simbody subfolder to avoid polluting the
-  # global build folder
-  set(SIMBODY_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/simbody)
+    # Visualizer is not intended to be a user executable. Proper place is
+    # inside the lib directory
+    set(SIMBODY_VISUALIZER_REL_INSTALL_DIR ${CMAKE_INSTALL_LIBEXECDIR}/simbody)
+    # Install include files in simbody subfolder to avoid polluting the
+    # global build folder
+    set(SIMBODY_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/simbody)
 endif()
 set(SIMBODY_VISUALIZER_INSTALL_DIR
     ${CMAKE_INSTALL_PREFIX}/${SIMBODY_VISUALIZER_REL_INSTALL_DIR})
@@ -559,7 +559,7 @@ add_subdirectory( Simbody )
 # SimTKSIMBODY_INCLUDE_DIRECTORIES now set(but not used)
 
 if( BUILD_EXAMPLES )
-  add_subdirectory( examples )
+    add_subdirectory( examples )
 endif()
 
 file(GLOB TOPLEVEL_DOCS LICENSE.txt *.md doc/*.pdf doc/*.txt doc/*.md)
@@ -567,11 +567,11 @@ install(FILES ${TOPLEVEL_DOCS} DESTINATION ${CMAKE_INSTALL_DOCDIR})
 
 # Add uninstall target
 configure_file(
-  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
-  "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake"
-  IMMEDIATE @ONLY)
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
 add_custom_target(uninstall
-  "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake")
+    "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake/cmake_uninstall.cmake")
 
 # Make the cmake config files
 set(PKG_NAME ${PROJECT_NAME})
@@ -582,9 +582,9 @@ set(PKG_LIBRARIES
     )
 
 if(WIN32)
-  set(SIMBODY_CMAKE_DIR cmake)
+    set(SIMBODY_CMAKE_DIR cmake)
 elseif(UNIX)
-  set(SIMBODY_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/simbody/)
+    set(SIMBODY_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/simbody/)
 endif()
 
 # Configure SimbodyConfig.cmake in a way that allows the installation to be
@@ -603,8 +603,8 @@ configure_package_config_file(
         SIMBODY_INSTALL_DOXYGENDIR
     )
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/SimbodyConfigForInstall.cmake
-    DESTINATION ${SIMBODY_CMAKE_DIR}
-    RENAME SimbodyConfig.cmake)
+        DESTINATION ${SIMBODY_CMAKE_DIR}
+        RENAME SimbodyConfig.cmake)
 
 # Create a file that allows clients to Simbody to ensure they have the version
 # of Simbody they want.
@@ -619,11 +619,11 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cmake/SimbodyConfigVersion.cmake
         DESTINATION ${SIMBODY_CMAKE_DIR})
 
 install(EXPORT SimbodyTargets DESTINATION
-  "${SIMBODY_CMAKE_DIR}") #optionally: COMPONENT dev
+        "${SIMBODY_CMAKE_DIR}") #optionally: COMPONENT dev
 
 # Install a sample CMakeLists.txt that uses SimbodyConfig.cmake.
 install(FILES ${CMAKE_SOURCE_DIR}/cmake/SampleCMakeLists.txt
-    DESTINATION ${SIMBODY_CMAKE_DIR})
+        DESTINATION ${SIMBODY_CMAKE_DIR})
 
 # Make the pkgconfig file: select the proper flags depending on the platform
 if(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,13 +331,13 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
     # If you know of optimization bugs that affect Simbody in particular
     # gcc versions, this is the place to turn off those optimizations.
     set(GCC_OPT_DISABLE)
-    # We know Gcc 4.4.3 on Ubuntu 10 is buggy.
-    if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-        if(GCC_VERSION VERSION_EQUAL 4.4)
-            set(GCC_OPT_DISABLE
-                "-fno-strict-aliasing -fno-tree-vrp -fno-guess-branch-probability")
-        endif()
-    endif()
+    # # We know Gcc 4.4.3 on Ubuntu 10 is buggy.
+    # if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+    #     if(GCC_VERSION VERSION_EQUAL 4.4)
+    #         set(GCC_OPT_DISABLE
+    #             "-fno-strict-aliasing -fno-tree-vrp -fno-guess-branch-probability")
+    #     endif()
+    # endif()
 
     # C++
     set(BUILD_CXX_FLAGS_DEBUG          "-g ${GCC_INST_SET}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,13 +337,6 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU" OR
     # If you know of optimization bugs that affect Simbody in particular
     # gcc versions, this is the place to turn off those optimizations.
     set(GCC_OPT_DISABLE)
-    # # We know Gcc 4.4.3 on Ubuntu 10 is buggy.
-    # if(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-    #     if(GCC_VERSION VERSION_EQUAL 4.4)
-    #         set(GCC_OPT_DISABLE
-    #             "-fno-strict-aliasing -fno-tree-vrp -fno-guess-branch-probability")
-    #     endif()
-    # endif()
 
     # C++
     set(BUILD_CXX_FLAGS_DEBUG          "-g ${GCC_INST_SET}")


### PR DESCRIPTION
This PR adds some compiler checks to avoid having compilation crash.
These checks stops cmake configuration if compilers are too old.
The minimum version number are taken from the Readme.md

This PR comes from a compilation crash that occured with GCC 4.7.2 on Debian