### PR TITLE
Use RPATH on OSX to find simbody-visualizer, etc.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,9 @@ to ParallelExecutor, mutex state lock.
   iterators. [PR#467](https://github.com/simbody/simbody/pull/467)
 * Added the method `State::isConsistent()` to compare two states
   [PR #469](https://github.com/simbody/simbody/pull/469).
+* Started using RPATH on OSX so that users need not set `DYLD_LIBRARY_PATH` to
+  run `simbody-visualizer` or the example executables, regardless of where you
+  install Simbody.
 * (There are more that haven't been added yet)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,7 @@ if(APPLE AND NOT (${CMAKE_VERSION} VERSION_LESS 2.8.12))
     # into directories that are not already searched by the linker.
     list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
         "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
+    # CMake sets isSystemDir to -1 if the lib dir is NOT a system lib dir.
     if("${isSystemDir}" STREQUAL "-1")
         # This variable is used later on to toggle if RPATH should be set for
         # specific targets.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,6 @@ cmake_minimum_required(VERSION ${SIMBODY_REQUIRED_CMAKE_VERSION})
 if(COMMAND cmake_policy)
     cmake_policy(SET CMP0003 NEW)
     cmake_policy(SET CMP0005 NEW)
-    if(NOT (${CMAKE_VERSION} VERSION_LESS 3.0))
-        # MACOSX_RPATH enabled by default; policy introduced with cmake 3.0.
-        cmake_policy(SET CMP0042 NEW)
-    endif()
 endif(COMMAND cmake_policy)
 
 project(Simbody)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -271,6 +271,46 @@ else()
     set(inst_set_to_use ${default_build_inst_set})
 endif()
 
+
+# RPATH
+# -----
+set(SIMBODY_USE_INSTALL_RPATH FALSE)
+if(APPLE AND NOT (${CMAKE_VERSION} VERSION_LESS 2.8.12))
+    # CMake 2.8.12 introduced the ability to set RPATH for shared libraries on
+    # OSX. This helps executables find the libraries they depend on without
+    # having to set the DYLD_LIBRARY_PATH environment variable.
+
+    # Consider a library libfoo.dyld and an executable bar.
+    # On OSX, libraries have an "install name" that, when linking, is copied
+    # into the target (e.g., bar). The "install name" can be the full path to
+    # libfoo.dylib, in which case bar will have no trouble finding libfoo.dylib
+    # at runtime (since it has the full path to it). This doesn't work if you
+    # want to be able to relocate your project. Therefore, it's possible to use
+    # special tokens in the "install name" that are evaluated separately. The
+    # token "@exectuable_path" is evaluated (at run time) to the full path of
+    # the exectuable (e.g., bar) that is trying to load libfoo.dylib. An even
+    # more flexible token is "@rpath", which is evaluated to a path (called
+    # RPATH) that can be baked into the executable just after compiling or any
+    # time before running the executable (using the executable
+    # "install_name_tool"). The RPATH stored in executables can also contain
+    # "@executable_path", etc.
+
+    # Set the install name of libraries to contain "@rpath".
+    # This allows clients of our libraries to point to them however they wish.
+    set(CMAKE_MACOSX_RPATH ON)
+
+    # We only need to set RPATH in executables if the libraries are installed
+    # into directories that are not already searched by the linker.
+    list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
+        "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" isSystemDir)
+    if("${isSystemDir}" STREQUAL "-1")
+        # This variable is used later on to toggle if RPATH should be set for
+        # specific targets.
+        set(SIMBODY_USE_INSTALL_RPATH TRUE)
+    endif()
+endif()
+
+
 ## When building in any of the Release modes, tell gcc/clang to use
 ## not-quite most agressive optimization.  Here we
 ## are specifying *all* of the Release flags, overriding CMake's defaults.

--- a/README.md
+++ b/README.md
@@ -348,7 +348,9 @@ From your build directory, you can run Simbody's example programs. For instance,
 
 If you are only building Simbody to use it with OpenSim, you can skip this section.
 
-1. Allow executables to find Simbody libraries (.dylib's or so's) by adding the Simbody lib directory to your linker path.
+1. Allow executables to find Simbody libraries (.dylib's or so's) by adding the
+   Simbody lib directory to your linker path. On Mac, most users can skip
+   this step.
     * If your `CMAKE_INSTALL_PREFIX` is `/usr/local/`, run:
 
             $ sudo ldconfig
@@ -360,7 +362,9 @@ If you are only building Simbody to use it with OpenSim, you can skip this secti
         * Ubuntu:
 
                 $ echo 'export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:~/simbody/lib/x86_64-linux-gnu' >> ~/.bashrc
-        These commands add a line to a configuration file that is loaded every time you open a new terminal. If using Ubuntu, you may need to replace `x86_64-linux-gnu` with the appropriate directory on your computer.
+        These commands add a line to a configuration file that is loaded every
+        time you open a new terminal. If using Ubuntu, you may need to replace
+        `x86_64-linux-gnu` with the appropriate directory on your computer.
 2. Allow Simbody and other projects (e.g., OpenSim) to find Simbody. Make sure to replace `~/simbody` with your `CMAKE_INSTALL_PREFIX`.
     * Mac:
 

--- a/Simbody/Visualizer/simbody-visualizer/CMakeLists.txt
+++ b/Simbody/Visualizer/simbody-visualizer/CMakeLists.txt
@@ -49,6 +49,23 @@ set_target_properties(${GUI_NAME} PROPERTIES
         PROJECT_LABEL "Code - ${GUI_NAME}"
         DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
 
+# On OSX, bake the relative path to the Simbody libraries into the visualizer
+# executable. Then there's no need to set `DYLD_LIBRARY_PATH` to find the
+# libraries when using the visualizer.
+if(${SIMBODY_USE_INSTALL_RPATH})
+    # @executable_path only makes sense on OSX, so if we use RPATH on
+    # Linux we'll have to revisit.
+
+    # vis_dir_to_install_dir is most likely "../"
+    file(RELATIVE_PATH vis_dir_to_install_dir
+        "${SIMBODY_VISUALIZER_INSTALL_DIR}"
+        "${CMAKE_INSTALL_PREFIX}")
+    set(vis_dir_to_lib_dir "${vis_dir_to_install_dir}${CMAKE_INSTALL_LIBDIR}")
+    set_target_properties(${GUI_NAME} PROPERTIES
+        INSTALL_RPATH "\@executable_path/${vis_dir_to_lib_dir}"
+        )
+endif()
+
 target_link_libraries(${GUI_NAME} 
     ${TEST_SHARED_TARGET} ${GLUT_LIBRARIES} ${OPENGL_LIBRARIES})
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -78,6 +78,17 @@ else()
       ${CMAKE_INSTALL_FULL_LIBDIR}/simbody/examples/)
 endif()
 
+# Set RPATH for all example targets in this directory and in subdirectories.
+if(${SIMBODY_USE_INSTALL_RPATH})
+    file(RELATIVE_PATH exbin_dir_to_install_dir "${EXAMPLES_INSTALL_BIN}"
+        "${CMAKE_INSTALL_PREFIX}")
+    set(exbin_dir_to_lib_dir
+        "${exbin_dir_to_install_dir}${CMAKE_INSTALL_LIBDIR}")
+    if(${SIMBODY_USE_INSTALL_RPATH})
+        set(CMAKE_INSTALL_RPATH "\@executable_path/${exbin_dir_to_lib_dir}")
+    endif()
+endif()
+
 # CMAKE_INSTALL_PREFIX may be a relative path name; we want to bake in
 # the absolute path for the examples.
 get_filename_component(ABS_CMAKE_INSTALL_PREFIX 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -80,7 +80,8 @@ endif()
 
 # Set RPATH for all example targets in this directory and in subdirectories.
 if(${SIMBODY_USE_INSTALL_RPATH})
-    file(RELATIVE_PATH exbin_dir_to_install_dir "${EXAMPLES_INSTALL_BIN}"
+    file(RELATIVE_PATH exbin_dir_to_install_dir
+        "${CMAKE_INSTALL_PREFIX}/${EXAMPLES_INSTALL_BIN}"
         "${CMAKE_INSTALL_PREFIX}")
     set(exbin_dir_to_lib_dir
         "${exbin_dir_to_install_dir}${CMAKE_INSTALL_LIBDIR}")


### PR DESCRIPTION
On OSX, we can avoid requiring users to set DYLD_LIBRARY_PATH by baking, into executables, the relative path from the executables to the Simbody libraries.

This is helpful in OpenSim also when using the Simbody visualizer; OpenSim users won't need to modify their DYLD_LIBRARY_PATH to point to Simbody's libraries.

Even if you relocate the Simbody installation (intact), the Simbody visualizer and examples will properly find the libraries.