### PR TITLE
Implement VisualizerGeometry::implementMeshFileGeometry on Simbody side

### DIFF
--- a/SimTKcommon/Geometry/include/SimTKcommon/internal/DecorativeGeometry.h
+++ b/SimTKcommon/Geometry/include/SimTKcommon/internal/DecorativeGeometry.h
@@ -544,7 +544,8 @@ private:
 };
 
 /** This defines a displayable mesh by referencing an already-existing
-PolygonalMesh object. **/
+PolygonalMesh object. If you have a full path to a file containing a mesh,
+consider using DecorativeMeshFile instead. @see DecorativeMeshFile **/
 class SimTK_SimTKCOMMON_EXPORT DecorativeMesh : public DecorativeGeometry {
 public:
     explicit DecorativeMesh(const PolygonalMesh& mesh);
@@ -573,7 +574,8 @@ private:
 /** This defines a displayable mesh by referencing a file name containing the 
 mesh. If format is not supported by visualizer it will be ignored. The mesh
 is lazy-loaded and cached to avoid reloading on each frame. If the file fails 
-to load, the call to getMesh will fail. **/
+to load, the call to getMesh will fail. If you already have a PolygonalMesh you
+can use DecorativeMesh directly @see DecorativeMesh above. **/
 class SimTK_SimTKCOMMON_EXPORT DecorativeMeshFile : public DecorativeGeometry {
 public:
     explicit DecorativeMeshFile(const std::string& meshFileName);

--- a/SimTKcommon/Geometry/include/SimTKcommon/internal/DecorativeGeometry.h
+++ b/SimTKcommon/Geometry/include/SimTKcommon/internal/DecorativeGeometry.h
@@ -576,6 +576,7 @@ class SimTK_SimTKCOMMON_EXPORT DecorativeMeshFile : public DecorativeGeometry {
 public:
     explicit DecorativeMeshFile(const std::string& meshFileName);
     const std::string& getMeshFile() const;
+    const PolygonalMesh& getMesh() const;
 
     // Retain the derived type when setting generic geometry options.
     DecorativeMeshFile& setBodyId(int b)          {DecorativeGeometry::setBodyId(b);        return *this;}

--- a/SimTKcommon/Geometry/include/SimTKcommon/internal/DecorativeGeometry.h
+++ b/SimTKcommon/Geometry/include/SimTKcommon/internal/DecorativeGeometry.h
@@ -571,11 +571,15 @@ private:
 
 
 /** This defines a displayable mesh by referencing a file name containing the 
-mesh. If format is not supported by visualizer it will be ignored. . **/
+mesh. If format is not supported by visualizer it will be ignored. The mesh
+is lazy-loaded and cached to avoid reloading on each frame. If the file fails 
+to load, the call to getMesh will fail. **/
 class SimTK_SimTKCOMMON_EXPORT DecorativeMeshFile : public DecorativeGeometry {
 public:
     explicit DecorativeMeshFile(const std::string& meshFileName);
     const std::string& getMeshFile() const;
+    /** Load the mesh from file and return a reference. Mesh is cached for future calls.
+    This method can throw an exception if the file fails to open or load. */
     const PolygonalMesh& getMesh() const;
 
     // Retain the derived type when setting generic geometry options.

--- a/SimTKcommon/Geometry/src/DecorativeGeometry.cpp
+++ b/SimTKcommon/Geometry/src/DecorativeGeometry.cpp
@@ -370,6 +370,9 @@ const std::string& DecorativeMeshFile::getMeshFile() const {
     return DecorativeMeshFileRep::downcast(*rep).getMeshFile();
 }
 
+const PolygonalMesh& DecorativeMeshFile::getMesh() const {
+    return DecorativeMeshFileRep::downcast(*rep).getMesh();
+}
 
 /////////////////////
 // DECORATIVE TORUS //

--- a/SimTKcommon/Geometry/src/DecorativeGeometryRep.h
+++ b/SimTKcommon/Geometry/src/DecorativeGeometryRep.h
@@ -567,20 +567,21 @@ class DecorativeMeshFileRep : public DecorativeGeometryRep {
 public:
 // no default constructor
 explicit DecorativeMeshFileRep(const std::string& meshFileName) 
-:   meshFile(meshFileName) {
-    pmesh = nullptr;
+:   meshFile(meshFileName),
+    isInitialized(false) {
 }
 
 const std::string& getMeshFile() const {
     return  meshFile;
 }
-
+// This is logically const but is non-const here to facilitate caching of the mesh 
+// once file is opened.
 const PolygonalMesh& getMesh() {
-    if (pmesh==nullptr) {
-        pmesh.reset(new PolygonalMesh());
-        pmesh->loadFile(meshFile);
+    if (!isInitialized) {
+        isInitialized = true; // We tried to load.
+        pmesh.loadFile(meshFile);
     }
-    return *pmesh;
+    return pmesh;
 }
 // virtuals
 DecorativeGeometryRep* cloneDecorativeGeometryRep() const override {
@@ -595,7 +596,9 @@ void implementGeometry(DecorativeGeometryImplementation& geometry) const overrid
 SimTK_DOWNCAST(DecorativeMeshFileRep, DecorativeGeometryRep);
 private:
 std::string meshFile;
-std::shared_ptr<PolygonalMesh> pmesh;
+PolygonalMesh pmesh;
+bool isInitialized; // Whether we attempted to load the file into pmesh;
+
 // This is just a static downcast since the DecorativeGeometry handle class 
 // is not virtual.
 

--- a/SimTKcommon/Geometry/src/DecorativeGeometryRep.h
+++ b/SimTKcommon/Geometry/src/DecorativeGeometryRep.h
@@ -568,12 +568,20 @@ public:
 // no default constructor
 explicit DecorativeMeshFileRep(const std::string& meshFileName) 
 :   meshFile(meshFileName) {
+    pmesh = nullptr;
 }
 
 const std::string& getMeshFile() const {
     return  meshFile;
 }
 
+const PolygonalMesh& getMesh() {
+    if (pmesh==nullptr) {
+        pmesh.reset(new PolygonalMesh());
+        pmesh->loadFile(meshFile);
+    }
+    return *pmesh;
+}
 // virtuals
 DecorativeGeometryRep* cloneDecorativeGeometryRep() const override {
     DecorativeMeshFileRep* DGRep = new DecorativeMeshFileRep(*this);
@@ -587,7 +595,7 @@ void implementGeometry(DecorativeGeometryImplementation& geometry) const overrid
 SimTK_DOWNCAST(DecorativeMeshFileRep, DecorativeGeometryRep);
 private:
 std::string meshFile;
-
+std::shared_ptr<PolygonalMesh> pmesh;
 // This is just a static downcast since the DecorativeGeometry handle class 
 // is not virtual.
 

--- a/Simbody/Visualizer/src/VisualizerGeometry.cpp
+++ b/Simbody/Visualizer/src/VisualizerGeometry.cpp
@@ -134,6 +134,14 @@ void VisualizerGeometry::implementMeshGeometry(const SimTK::DecorativeMesh& geom
                                getColor(geom), getRepresentation(geom));
 }
 
+
+void VisualizerGeometry::implementMeshFileGeometry(const SimTK::DecorativeMeshFile& geom) {
+    const PolygonalMesh& pMesh = geom.getMesh();
+    const Transform X_GD = calcX_GD(geom);
+    protocol.drawPolygonalMesh(pMesh, X_GD, getScaleFactors(geom),
+        getColor(geom), getRepresentation(geom));
+}
+
 Vec4 VisualizerGeometry::getColor(const DecorativeGeometry& geom,
                                   const Vec3& defaultColor) {
     Vec4 result;

--- a/Simbody/Visualizer/src/VisualizerGeometry.h
+++ b/Simbody/Visualizer/src/VisualizerGeometry.h
@@ -50,7 +50,7 @@ public:
     void implementFrameGeometry(const DecorativeFrame& geom) override;
     void implementTextGeometry(const DecorativeText& geom) override;
     void implementMeshGeometry(const DecorativeMesh& geom) override;
-    void implementMeshFileGeometry(const DecorativeMeshFile& geom) override {}; // Not handled yet by this Visualizer
+    void implementMeshFileGeometry(const DecorativeMeshFile& geom) override; 
     void implementArrowGeometry(const DecorativeArrow& geom) override {}; // Not handled yet by this Visualizer
     void implementTorusGeometry(const DecorativeTorus& geom) override {}; // Not handled yet by this Visualizer
     void implementConeGeometry(const DecorativeCone& geom) override {}; // Not handled yet by this Visualizer


### PR DESCRIPTION
Some background. The cleanest fix in my opinion to this issue is to beef up the protocol to  support passing MeshFile by name and have the Visualizer process load the file,  cache it and never load it again, unfortunately that shifts a significant responsibility to the visualizer and makes it hard to report/handle errors gracefully (since it's a different process). 
Implemented fix is a compromise where the caller to construct DecorativeMeshFile does the search to make sure the file exists and can be opened, then DecorativeMeshFile is instantiated with the full path. DecorativeMeshFileRep lazily loads the file into a PolygonalMesh object, caches it and sends it across the protocol to the visualizer. 
A straightforward approach to do the loading inside implementDecorativeMeshFile call proved expensive since it causes the file to be loaded anew with every frame (even if it's 'Fixed' geometry). 

Please let me know what you think or if you have suggestions for improvement, before spending much time on the code/implementation. Thanks much.
