### PR TITLE
Qt conflict with definition of qInfo and small

### DIFF
--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/StateImpl.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/StateImpl.h
@@ -687,8 +687,8 @@ public:
     }
 
     QIndex getNextQIndex() const {
-        if (qInfo.empty()) return QIndex(0);
-        const ContinuousVarInfo& last = qInfo.back();
+        if (q_info.empty()) return QIndex(0);
+        const ContinuousVarInfo& last = q_info.back();
         return QIndex(last.getFirstIndex()+last.getNumVars());
     }
     UIndex getNextUIndex() const {
@@ -794,7 +794,7 @@ friend class StateImpl;
     // and popped off the ends as the stage is reduced.
 
     // Topology and Model stage definitions. 
-    Array_<ContinuousVarInfo>      qInfo, uInfo, zInfo;
+    Array_<ContinuousVarInfo>      q_info, uInfo, zInfo;//qInfo -> q_info Qt definition conflict
     Array_<DiscreteVarInfo>        discreteInfo;
 
     // Topology, Model, and Instance stage definitions.
@@ -879,7 +879,7 @@ private:
 
     void popAllStacksBackToStage(const Stage& g);
 
-    // Call once each for qInfo, uInfo, zInfo.
+    // Call once each for q_info, uInfo, zInfo.
     void copyContinuousVarInfoThroughStage
        (const Array_<ContinuousVarInfo>& src, const Stage& g,
         Array_<ContinuousVarInfo>& dest);
@@ -1067,7 +1067,7 @@ public:
         const Stage allocStage = getSubsystemStage(subsys).next();
         PerSubsystemInfo& ss = subsystems[subsys];
         const QIndex nxt(ss.getNextQIndex());
-        ss.qInfo.push_back(ContinuousVarInfo(allocStage,nxt,qInit,Vector())); 
+        ss.q_info.push_back(ContinuousVarInfo(allocStage,nxt,qInit,Vector())); 
         return nxt;
     }
     

--- a/SimTKcommon/Simulation/src/State.cpp
+++ b/SimTKcommon/Simulation/src/State.cpp
@@ -223,7 +223,7 @@ void PerSubsystemInfo::copyAllocationStackThroughStage
 }
 
 void PerSubsystemInfo::clearContinuousVars() {
-    clearAllocationStack(qInfo); 
+    clearAllocationStack(q_info); 
     clearAllocationStack(uInfo);                                
     clearAllocationStack(zInfo); 
 }
@@ -251,7 +251,7 @@ void PerSubsystemInfo::clearAllStacks() {
 }
 
 void PerSubsystemInfo::popContinuousVarsBackToStage(const Stage& g) { 
-    popAllocationStackBackToStage(qInfo,g);
+    popAllocationStackBackToStage(q_info,g);
     popAllocationStackBackToStage(uInfo,g);
     popAllocationStackBackToStage(zInfo,g);
 }
@@ -305,7 +305,7 @@ void PerSubsystemInfo::copyEventsThroughStage
 void PerSubsystemInfo::copyAllStacksThroughStage
    (const PerSubsystemInfo& src, const Stage& g)
 {
-    copyContinuousVarInfoThroughStage(src.qInfo, g, qInfo);
+    copyContinuousVarInfoThroughStage(src.q_info, g, q_info);
     copyContinuousVarInfoThroughStage(src.uInfo, g, uInfo);
     copyContinuousVarInfoThroughStage(src.zInfo, g, zInfo);
 
@@ -552,8 +552,8 @@ void StateImpl::advanceSystemToStage(Stage stg) const {
         // Count up all 
         for (SubsystemIndex i(0); i<subsystems.size(); ++i) {
             const PerSubsystemInfo& ss = subsystems[i];
-            for (unsigned j=0; j<ss.qInfo.size(); ++j)
-                ssnq[i] += ss.qInfo[j].getNumVars();
+            for (unsigned j=0; j<ss.q_info.size(); ++j)
+                ssnq[i] += ss.q_info[j].getNumVars();
             nq += ssnq[i];
             for (unsigned j=0; j<ss.uInfo.size(); ++j)
                 ssnu[i] += ss.uInfo[j].getNumVars();
@@ -605,9 +605,9 @@ void StateImpl::advanceSystemToStage(Stage stg) const {
             // Build the views.
             ss.q.viewAssign(wThis->q(nxtq, nq));
             int nxt=0;
-            for (unsigned j=0; j<ss.qInfo.size(); ++j) {
-                const int nv = ss.qInfo[j].getNumVars();
-                ss.q(nxt, nv) = ss.qInfo[j].getInitialValues();
+            for (unsigned j=0; j<ss.q_info.size(); ++j) {
+                const int nv = ss.q_info[j].getNumVars();
+                ss.q(nxt, nv) = ss.q_info[j].getInitialValues();
                 nxt += nv;
             }
 

--- a/SimTKcommon/include/SimTKlapack.h
+++ b/SimTKcommon/include/SimTKlapack.h
@@ -1279,7 +1279,7 @@ extern int disnan( SimTK_D_INPUT_(din) );
 
 extern int dlaisnan( SimTK_D_INPUT_(din1), SimTK_D_INPUT_(din2) );
 
-extern void dlabad_(SimTK_D_INOUT_(small1), SimTK_D_INOUT_(large));
+extern void dlabad_(SimTK_D_INOUT_(small1), SimTK_D_INOUT_(large));//small -> small1 conflict with definition when Qt is used
 
 extern void dlabrd_(SimTK_FDIM_(m), SimTK_FDIM_(n),  SimTK_FDIM_(nb), double *a, SimTK_FDIM_(lda), double *d__, double *e, double *tauq, double *taup, double *x, SimTK_FDIM_(ldx), double *y, SimTK_FDIM_(ldy));
 
@@ -1982,7 +1982,7 @@ extern int sisnan( SimTK_S_INPUT_(sin) );
 
 extern int slaisnan( SimTK_S_INPUT_(sin1), SimTK_S_INPUT_(sin2) );
 
-extern void slabad_(SimTK_S_INOUT_(small1), SimTK_S_INOUT_(large));
+extern void slabad_(SimTK_S_INOUT_(small1), SimTK_S_INOUT_(large));//small -> small1 conflict with definition when Qt is used
 
 extern void slabrd_(SimTK_FDIM_(m), SimTK_FDIM_(n), SimTK_FDIM_(nb), float *a, SimTK_FDIM_(lda), float *d__, float *e, float *tauq, float *taup, float *x, SimTK_FDIM_(ldx), float *y, SimTK_FDIM_(ldy));
 

--- a/SimTKcommon/include/SimTKlapack.h
+++ b/SimTKcommon/include/SimTKlapack.h
@@ -1279,7 +1279,7 @@ extern int disnan( SimTK_D_INPUT_(din) );
 
 extern int dlaisnan( SimTK_D_INPUT_(din1), SimTK_D_INPUT_(din2) );
 
-extern void dlabad_(SimTK_D_INOUT_(small), SimTK_D_INOUT_(large));
+extern void dlabad_(SimTK_D_INOUT_(small1), SimTK_D_INOUT_(large));
 
 extern void dlabrd_(SimTK_FDIM_(m), SimTK_FDIM_(n),  SimTK_FDIM_(nb), double *a, SimTK_FDIM_(lda), double *d__, double *e, double *tauq, double *taup, double *x, SimTK_FDIM_(ldx), double *y, SimTK_FDIM_(ldy));
 
@@ -1982,7 +1982,7 @@ extern int sisnan( SimTK_S_INPUT_(sin) );
 
 extern int slaisnan( SimTK_S_INPUT_(sin1), SimTK_S_INPUT_(sin2) );
 
-extern void slabad_(SimTK_S_INOUT_(small), SimTK_S_INOUT_(large));
+extern void slabad_(SimTK_S_INOUT_(small1), SimTK_S_INOUT_(large));
 
 extern void slabrd_(SimTK_FDIM_(m), SimTK_FDIM_(n), SimTK_FDIM_(nb), float *a, SimTK_FDIM_(lda), float *d__, float *e, float *tauq, float *taup, float *x, SimTK_FDIM_(ldx), float *y, SimTK_FDIM_(ldy));
 


### PR DESCRIPTION
Without auto formatting.

Regarding issue [#477](https://github.com/simbody/simbody/issues/477) I have renamed **qInfo  -> q_info** in StateImpl.h and State.cpp. Also, for some reason on windows when I use Qt and Simbody there is the header rpcndr.h, which defines small as:

`#define small char`

which is in conflict with SimTKlapack.h. I have renamed **small  -> small1**. 

The tests pass, and I have also tested with Qt. The Qt team said that will work on a definition that will undo some of their macros.