### PR TITLE
Remove warnings in installed headers

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/Array.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Array.h
@@ -3320,7 +3320,7 @@ std::istream& readArrayFromStreamHelper
 
     // Now see if the sequence is bare or surrounded by (), [], or {}.
     bool lookForCloser = true;
-    char openBracket, closeBracket;
+    char openBracket, closeBracket{};
     ch = in.peek(); if (in.fail()) return in;
     assert(ch != EOFch); // we already checked above
 

--- a/SimTKcommon/include/SimTKcommon/internal/Array.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Array.h
@@ -3320,11 +3320,10 @@ std::istream& readArrayFromStreamHelper
 
     // Now see if the sequence is bare or surrounded by (), [], or {}.
     bool lookForCloser = true;
-    char openBracket, closeBracket{};
     ch = in.peek(); if (in.fail()) return in;
     assert(ch != EOFch); // we already checked above
 
-    openBracket = (char)ch;
+    char openBracket{static_cast<char>(ch)}, closeBracket{};
     if      (openBracket=='(') {in.get(); closeBracket = ')';}
     else if (openBracket=='[') {in.get(); closeBracket = ']';}
     else if (openBracket=='{') {in.get(); closeBracket = '}';}

--- a/SimTKmath/Geometry/include/simmath/internal/ContactGeometry.h
+++ b/SimTKmath/Geometry/include/simmath/internal/ContactGeometry.h
@@ -1470,11 +1470,7 @@ public:
         Vec3 endpt;
         const Vector& q = state.getQ();
         endpt[0] = q[0]; endpt[1] = q[1]; endpt[2] = q[2];
-        /*Real dist = */plane.getDistance(endpt);
-
-//        ASSERT(std::abs(dist) < 0.01 );
         shouldTerminate = true;
-//        std::cout << "hit plane!" << std::endl;
     }
 
     void setPlane(const Plane& aplane) const {

--- a/SimTKmath/Geometry/include/simmath/internal/ContactGeometry.h
+++ b/SimTKmath/Geometry/include/simmath/internal/ContactGeometry.h
@@ -1470,7 +1470,7 @@ public:
         Vec3 endpt;
         const Vector& q = state.getQ();
         endpt[0] = q[0]; endpt[1] = q[1]; endpt[2] = q[2];
-        Real dist = plane.getDistance(endpt);
+        /*Real dist = */plane.getDistance(endpt);
 
 //        ASSERT(std::abs(dist) < 0.01 );
         shouldTerminate = true;

--- a/SimTKmath/include/simmath/MultibodyGraphMaker.h
+++ b/SimTKmath/include/simmath/MultibodyGraphMaker.h
@@ -444,10 +444,15 @@ public:
     Joint(const std::string& name, int jointTypeNum, 
           int parentBodyNum, int childBodyNum,
           bool mustBeLoopJoint, void* userRef)
-    :   name(name), jointTypeNum(jointTypeNum), 
-        parentBodyNum(parentBodyNum), childBodyNum(childBodyNum),
-        mustBeLoopJoint(mustBeLoopJoint), userRef(userRef),
-        isAddedBaseJoint(false), mobilizer(-1), loopConstraint(-1) {}
+    :   name(name), 
+        mustBeLoopJoint(mustBeLoopJoint), 
+        userRef(userRef),
+        parentBodyNum(parentBodyNum), 
+        childBodyNum(childBodyNum),
+        jointTypeNum(jointTypeNum), 
+        isAddedBaseJoint(false),
+        mobilizer(-1), 
+        loopConstraint(-1) {}
 
     /** Return true if the joint is deleted as a result of restoring it
         to the state prior to generateGraph(). **/


### PR DESCRIPTION
This PR is to remove two warnings we see when compiling OpenSim with Simbody.