### PR TITLE
Added second AppVeyor job for CI testing of OpenSim on 32-bit

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,9 @@ platform: x64
 environment:
   matrix:
     - CMAKE_GENERATOR: "Visual Studio 14 2015"
-      NUGET_PACKAGE_ID: "simbody-x86"
+      NUGET_PACKAGE_ID_SUFFIX: "-x86"
     - CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
-      NUGET_PACKAGE_ID: "simbody-x64"
+      NUGET_PACKAGE_ID_SUFFIX: "-x64"
 
 build_script:
   # Must create separate build dir, otherwise can't read test files
@@ -47,7 +47,7 @@ after_test:
   # Create NuGet package.
   - IF DEFINED DISTR cd %APPVEYOR_BUILD_FOLDER%
   # Create a nupkg. The install directory is to be packaged.
-  - IF DEFINED DISTR nuget pack doc/.simbody.nuspec -Properties "packageId=%NUGET_PACKAGE_ID%" -BasePath C:\simbody
-  # The line above creates the file %NUGET_PACKAGE_ID%.0.0.0.nupkg.
+  - IF DEFINED DISTR nuget pack doc/.simbody.nuspec -Properties "packageIdSuffix=%NUGET_PACKAGE_ID_SUFFIX%" -BasePath C:\simbody
+  # The line above creates the file simbody%NUGET_PACKAGE_ID_SUFFIX%.0.0.0.nupkg.
   # Push this file to Appveyor's NuGet account feed, to be used by OpenSim.
-  - IF DEFINED DISTR appveyor PushArtifact %NUGET_PACKAGE_ID%.0.0.0.nupkg
+  - IF DEFINED DISTR appveyor PushArtifact simbody%NUGET_PACKAGE_ID_SUFFIX%.0.0.0.nupkg

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,9 +39,7 @@ test_script:
 after_test:
   ## On master branch, create NuGet package for Simbody, for use by OpenSim.
   # Detect if we are on the master branch.
-  # TODO: Temporarily create NuGet package regardless of branch (to test before merging).
-  #- IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
-  - SET DISTR=TRUE
+  - IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
   # Install Simbody.
   - IF DEFINED DISTR cmake --build . --target install --config Release -- /maxcpucount /verbosity:quiet
   # Create NuGet package.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,9 @@ test_script:
 after_test:
   ## On master branch, create NuGet package for Simbody, for use by OpenSim.
   # Detect if we are on the master branch.
-  - IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
+  # TODO: Temporarily create NuGet package regardless of branch (to test before merging).
+  #- IF %APPVEYOR_REPO_BRANCH% EQU master IF NOT DEFINED APPVEYOR_PULL_REQUEST_NUMBER SET DISTR=TRUE
+  - SET DISTR=TRUE
   # Install Simbody.
   - IF DEFINED DISTR cmake --build . --target install --config Release -- /maxcpucount /verbosity:quiet
   # Create NuGet package.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,20 +15,27 @@ os: Visual Studio 2015
 
 platform: x64
 
+environment:
+  matrix:
+    - CMAKE_GENERATOR: "Visual Studio 14 2015"
+      NUGET_PACKAGE_ID: "simbody-x86"
+    - CMAKE_GENERATOR: "Visual Studio 14 2015 Win64"
+      NUGET_PACKAGE_ID: "simbody-x64"
+
 build_script:
   # Must create separate build dir, otherwise can't read test files
   # for some reason.
   - mkdir build
   - cd build
   # Treat all warnings as errors.
-  - cmake .. -G"Visual Studio 14 2015 Win64" -DBUILD_VISUALIZER=OFF -DCMAKE_INSTALL_PREFIX=C:\simbody
+  - cmake .. -G"%CMAKE_GENERATOR%" -DBUILD_VISUALIZER=OFF -DCMAKE_INSTALL_PREFIX=C:\simbody
   # See http://msdn.microsoft.com/en-us/library/ms164311.aspx for
   # command-line options to MSBuild.
   - cmake --build . --target ALL_BUILD --config Release -- /maxcpucount:4 /verbosity:quiet /p:TreatWarningsAsErrors="true"
 
 test_script:
   - ctest --parallel 4 --build-config Release --output-on-failure
-    
+
 after_test:
   ## On master branch, create NuGet package for Simbody, for use by OpenSim.
   # Detect if we are on the master branch.
@@ -38,7 +45,7 @@ after_test:
   # Create NuGet package.
   - IF DEFINED DISTR cd %APPVEYOR_BUILD_FOLDER%
   # Create a nupkg. The install directory is to be packaged.
-  - IF DEFINED DISTR nuget pack doc/.simbody.nuspec -BasePath C:\simbody
-  # The line above creates the file simbody.0.0.0.nupkg.
+  - IF DEFINED DISTR nuget pack doc/.simbody.nuspec -Properties "packageId=%NUGET_PACKAGE_ID%" -BasePath C:\simbody
+  # The line above creates the file %NUGET_PACKAGE_ID%.0.0.0.nupkg.
   # Push this file to Appveyor's NuGet account feed, to be used by OpenSim.
-  - IF DEFINED DISTR appveyor PushArtifact simbody.0.0.0.nupkg
+  - IF DEFINED DISTR appveyor PushArtifact %NUGET_PACKAGE_ID%.0.0.0.nupkg

--- a/doc/.simbody.nuspec
+++ b/doc/.simbody.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package>
   <metadata>
-    <id>$packageId$</id>
+    <id>simbody$packageIdSuffix$</id>
     <version>0.0.0</version>
     <authors>Michael Sherman</authors>
     <owners>Michael Sherman</owners>

--- a/doc/.simbody.nuspec
+++ b/doc/.simbody.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
-<package >
+<package>
   <metadata>
-    <id>simbody</id>
+    <id>$packageId$</id>
     <version>0.0.0</version>
     <authors>Michael Sherman</authors>
     <owners>Michael Sherman</owners>
@@ -11,10 +11,10 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>High-performance C++ multibody dynamics/physics library for simulating articulated biomechanical and mechanical systems like vehicles, robots, and the human skeleton. This package is for use in Appveyor testing. It is not a proper distribution of Simbody.</description>
     <releaseNotes>https://github.com/simbody/simbody/releases</releaseNotes>
-    <copyright>Copyright 2014</copyright>
+    <copyright>Copyright 2016</copyright>
     <tags>multibody dynamics biomechanics robotics</tags>
   </metadata>
   <files>
-        <file src="**" target="" />
-    </files>
+    <file src="**" target="" />
+  </files>
 </package>


### PR DESCRIPTION
AppVeyor now runs 32- and 64-bit jobs. The NuGet packages ("simbody-x86.0.0.0.nupkg" and "simbody-x64.0.0.0.nupkg") are used by [this OpenSim PR](https://github.com/opensim-org/opensim-core/pull/921).