### PR TITLE
Fixed bug : Compiler version check for gcc incorrecly fails #482 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 3.6 (in development)
 --------------------
+* Forced GCC to be at least 4.9.0, so that new C++11 features like regular
+  expressions can be used (pr #485).
+* Minimum Ubuntu version supported 14.04 LTS (Trusty), with a [manual update of GCC](http://askubuntu.com/questions/466651/how-do-i-use-the-latest-gcc-on-ubuntu-14-04).
+* Recommended minimum Ubuntu version : 15.04 (Vivid), that is shipped with GCC 4.9.2.
 * Added mixin classes `ResetOnCopy<T>` and `ReinitOnCopy<T>` to force default
   construction or reinitialization of data members on copy construction or copy
   assignment, without requiring a user written copy constructor and copy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if(MSVC)
                             " comment this test and configure normally.")
     endif()
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-    set(SIMBODY_REQUIRED_GCC_VERSION 4.8.1)
+    set(SIMBODY_REQUIRED_GCC_VERSION 4.9.0)
     if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${SIMBODY_REQUIRED_GCC_VERSION})
         message(FATAL_ERROR "GNU GCC/G++ version is too old to compile Simbody.\n"
                             "Simbody requires at least version : "

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ if(MSVC)
     # To properly support Visual Studio 2015.
     set(SIMBODY_REQUIRED_CMAKE_VERSION 3.1.3)
 else()
-    set(SIMBODY_REQUIRED_CMAKE_VERSION 2.8.8)
+    set(SIMBODY_REQUIRED_CMAKE_VERSION 2.8.10)
 endif()
 cmake_minimum_required(VERSION ${SIMBODY_REQUIRED_CMAKE_VERSION})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ set(SIMBODY_MAJOR_VERSION 3)
 set(SIMBODY_MINOR_VERSION 6)
 set(SIMBODY_PATCH_VERSION 0)
 
-set(SIMBODY_COPYRIGHT_YEARS "2005-15")
+set(SIMBODY_COPYRIGHT_YEARS "2005-16")
 
 # underbar separated list of dotted authors, no spaces or commas
 set(SIMBODY_AUTHORS "Michael.Sherman_Peter.Eastman")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,20 +53,16 @@ if(MSVC)
     endif()
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
     set(SIMBODY_REQUIRED_GCC_VERSION 4.8.1)
-    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
-                    OUTPUT_VARIABLE GCC_VERSION)
-    if (GCC_VERSION VERSION_LESS ${SIMBODY_REQUIRED_GCC_VERSION})
-        message(FATAL_ERROR "GNU GCC/G++ version is too old to compile Simbody"
-                            "Simbody requires at least version :"
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${SIMBODY_REQUIRED_GCC_VERSION})
+        message(FATAL_ERROR "GNU GCC/G++ version is too old to compile Simbody.\n"
+                            "Simbody requires at least version : "
                             "${SIMBODY_REQUIRED_GCC_VERSION}")
     endif()
 elseif(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
     set(SIMBODY_REQUIRED_CLANG_VERSION 3.4)
-    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
-                    OUTPUT_VARIABLE CLANG_VERSION)
-    if (CLANG_VERSION VERSION_LESS ${SIMBODY_REQUIRED_CLANG_VERSION})
+    if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS ${SIMBODY_REQUIRED_CLANG_VERSION})
         message(FATAL_ERROR "Clang version is too old to compile Simbody.\n"
-                            "Simbody requires at least version :"
+                            "Simbody requires at least version : "
                             "${SIMBODY_REQUIRED_CLANG_VERSION}")
     endif()
 endif()

--- a/README.md
+++ b/README.md
@@ -117,11 +117,11 @@ Using Simbody
 Installing
 ----------
 
-Simbody works on Windows, Mac, and Linux. For Windows, you must build from source. For Mac and Linux, you can use a package manager or build from source. In this file, we provide instructions for 4 different ways of installing Simbody:
+Simbody works on Windows, Mac, and Linux. For Windows, you must build from source. For Mac and Linux, you can use a package manager or build from source. In this file, we provide instructions for 5 different ways of installing Simbody:
 
 1. [**Windows**](#windows-using-visual-studio): build from source using Microsoft Visual Studio.
-3. [**Linux or Mac (make)**](#linux-or-mac-using-make): build from source using gcc or Clang with make.
-2. [**Mac (Homebrew)**](#mac-and-homebrew): automated build/install with Homebrew.
+2. [**Linux or Mac (make)**](#linux-or-mac-using-make): build from source using gcc or Clang with make.
+3. [**Mac (Homebrew)**](#mac-and-homebrew): automated build/install with Homebrew.
 4. [**Ubuntu/Debian**](#ubuntu-and-apt-get): install pre-built binaries with apt-get.
 5. [**Windows using MinGW**](#windows-using-mingw): build from source using MinGW.
 

--- a/README.md
+++ b/README.md
@@ -248,10 +248,10 @@ framework. Mac's come with the visualization dependencies.
 
 On Ubuntu, we need to get the dependencies ourselves. Open a terminal and run the following commands.
 
-1. Get the necessary dependencies: `$ sudo apt-get install cmake liblapack-dev`. The cmake on Ubuntu 12.04 is not new enough; you could instead download it from [cmake.org](http://www.cmake.org/download/) or use [this third party PPA](https://launchpad.net/~robotology/+archive/ubuntu/ppa).
+1. Get the necessary dependencies: `$ sudo apt-get install cmake liblapack-dev`.
 2. If you want to use the CMake GUI, install `cmake-qt-gui`.
-3. For visualization (optional): `$ sudo apt-get install freeglut3-dev libxi-dev libxmu-dev`
-4. For API documentation (optional): `$ sudo apt-get install doxygen`
+3. For visualization (optional): `$ sudo apt-get install freeglut3-dev libxi-dev libxmu-dev`.
+4. For API documentation (optional): `$ sudo apt-get install doxygen`.
 
 #### Get the Simbody source code
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Dependencies
 
 Simbody depends on the following:
 
-* cross-platform building: [CMake](http://www.cmake.org/cmake/resources/software.html) 2.8.8 or later (3.1.3 or later for Visual Studio).
-* compiler: [Visual Studio](http://www.visualstudio.com) 2015 (Windows only), [gcc](http://gcc.gnu.org/) 4.8.1 or later (typically on Linux), or [Clang](http://clang.llvm.org/) 3.4 or later (typically on Mac, possibly through Xcode)
+* cross-platform building: [CMake](http://www.cmake.org/cmake/resources/software.html) 2.8.10 or later (3.1.3 or later for Visual Studio).
+* compiler: [Visual Studio](http://www.visualstudio.com) 2015 (Windows only), [gcc](http://gcc.gnu.org/) 4.9.0 or later (typically on Linux), or [Clang](http://clang.llvm.org/) 3.4 or later (typically on Mac, possibly through Xcode)
 * linear algebra: [LAPACK](http://www.netlib.org/lapack/) and [BLAS](http://www.netlib.org/blas/)
 * visualization (optional): [FreeGLUT](http://freeglut.sourceforge.net/), [Xi and Xmu](http://www.x.org/wiki/)
 * API documentation (optional): [Doxygen](http://www.stack.nl/~dimitri/doxygen/) 1.8.6 or later; we recommend at least 1.8.8.


### PR DESCRIPTION
This bug was reported here:
#482

We use CMAKE_CXX_COMPILER_VERSION, to fetch compiler version

I dont think it is required to update the version of CMake required to configure the project: from Cmake documentation, it says it is already defined

Below are the documentation found

From https://cmake.org/Wiki/CMake_2.8.8_Docs, it says it is defined but internal
  CMAKE_<LANG>_COMPILER_VERSION
       An internal variable subject to change.

       Compiler version in major[.minor[.patch[.tweak]]] format.  This
       variable is reserved for internal use by CMake and is not guaranteed
       to be set.

From https://cmake.org/Wiki/CMake_2.8.10_Docs, it says it is defined
  CMAKE_<LANG>_COMPILER_VERSION
       Compiler version string.

       Compiler version in major[.minor[.patch[.tweak]]] format.  This
       variable is not guaranteed to be defined for all compilers or
       languages.