### PR TITLE
Add operator>> to index types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ to ParallelExecutor, mutex state lock.
 * Started using RPATH on OSX so that users need not set `DYLD_LIBRARY_PATH` to
   run `simbody-visualizer` or the example executables, regardless of where you
   install Simbody.
+* Index types created with the `SimTK_DEFINE_UNIQUE_INDEX_TYPE` macro and its
+  variants now have an `operator>>`.
 * (There are more that haven't been added yet)
 
 

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -547,6 +547,8 @@ public:                                     \
     typedef int size_type;                                                  \
     typedef int difference_type;                                            \
     static size_type max_size() {return std::numeric_limits<int>::max();}   \
+    friend std::istream& operator>>(std::istream& in, NAME& obj)            \
+    { return in >> obj.ix; }                                                \
 };
 
 /** Use this macro to generate a cast that is dynamic_cast in Debug builds

--- a/SimTKcommon/tests/TestXml.cpp
+++ b/SimTKcommon/tests/TestXml.cpp
@@ -8,7 +8,7 @@
  *                                                                            *
  * Portions copyright (c) 2010-16 Stanford University and the Authors.        *
  * Authors: Michael Sherman                                                   *
- * Contributors:                                                              *
+ * Contributors: Chris Dembia                                                 *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -638,6 +638,28 @@ void testValueSerialization() {
 }
 
 
+SimTK_DEFINE_UNIQUE_INDEX_TYPE(FooIndex);
+
+class Outer {
+public:
+    SimTK_DEFINE_UNIQUE_LOCAL_INDEX_TYPE(Outer, LocalIndex);
+};
+
+void testXmlUniqueIndexType() {
+    FooIndex fi0(73);
+    Xml::Element fiXml = toXmlElementHelper(fi0, "FooIndexName", true);
+    FooIndex fi1;
+    fromXmlElementHelper(fi1, fiXml, "FooIndexName", true);
+    SimTK_TEST(fi1 == 73);
+    
+    Outer::LocalIndex oli0(41);
+    Xml::Element oliXml = toXmlElementHelper(oli0, "OuterInnerIndexName", true);
+    Outer::LocalIndex oli1;
+    fromXmlElementHelper(oli1, oliXml, "OuterInnerIndexName", true);
+    SimTK_TEST(oli1 == 41);
+}
+
+
 int main() {
     cout << "Path of this executable: '" << Pathname::getThisExecutablePath() << "'\n";
     cout << "Executable directory: '" << Pathname::getThisExecutableDirectory() << "'\n";
@@ -649,7 +671,8 @@ int main() {
         SimTK_SUBTEST(testXmlFromString);
         SimTK_SUBTEST(testXmlFromScratch);
         SimTK_SUBTEST(testValueSerialization);
-
+        SimTK_SUBTEST(testXmlUniqueIndexType);
+    
     SimTK_END_TEST();
 }
 


### PR DESCRIPTION
This PR adds `operator>>` to Index types generated with the macros in common.h. This stream operator allows one to deserialize an Xml element holding an index.

Note: This PR is into the `feature_state_serialization` branch.