### PR TITLE
In StateImpl::fromXmlElement(), clear subsystems.

### DIFF
--- a/SimTKcommon/Simulation/src/State.cpp
+++ b/SimTKcommon/Simulation/src/State.cpp
@@ -877,6 +877,8 @@ fromXmlElement(Xml::Element e, const std::string& requiredName) {
     fromXmlElementHelper(qerrWeights, *nxt++, "qerrWeights", true);
     fromXmlElementHelper(uerrWeights, *nxt++, "uerrWeights", true);
 
+    subsystems.clear();
+    subsystems.reserve(nsubsys);
     for (unsigned i=0; i < nsubsys; ++i) {
         subsystems.emplace_back(*this);
         fromXmlElementHelper(subsystems.back(), *nxt++, String(i), true);


### PR DESCRIPTION
Previously, calling `fromXmlElement()` multiple times on the same State caused
subsystems to erroneously pile up.

This PR also reserves the appropriate memory for the `subsystem` variable.