### PR TITLE
Throw meaningful exception if T cannot be converted to Xml element

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/Xml.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Xml.h
@@ -1621,7 +1621,17 @@ function over the free function if both exist, using SFINAE.
 template <class T> inline Xml::Element
 toXmlElement(const T& thing, const std::string& name) {
     std::ostringstream os;
-    writeUnformatted(os, thing);
+    try {
+        writeUnformatted(os, thing);
+    } catch (const SimTK::Exception::ErrorCheck& e) {
+        const std::string& strT = SimTK::NiceTypeName<T>::namestr();
+        SimTK_THROW1(SimTK::Exception::Cant,
+                "Unable to convert " + strT + " to an Xml element. "
+                "Either add a member function `" +
+                strT + "::toXmlElement(const std::string&) const`" 
+                " or create a free function `" 
+                "toXmlElement(const " + strT + "&, const std::string&)`.");
+    }
     return Xml::Element(name.empty()?"value":name, os.str());
 }
 

--- a/SimTKcommon/include/SimTKcommon/internal/Xml.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Xml.h
@@ -1623,7 +1623,7 @@ toXmlElement(const T& thing, const std::string& name) {
     std::ostringstream os;
     try {
         writeUnformatted(os, thing);
-    } catch (const SimTK::Exception::ErrorCheck& e) {
+    } catch (const SimTK::Exception::ErrorCheck&) {
         const std::string& strT = SimTK::NiceTypeName<T>::namestr();
         SimTK_THROW1(SimTK::Exception::Cant,
                 "Unable to convert " + strT + " to an Xml element. "

--- a/SimTKcommon/tests/TestXml.cpp
+++ b/SimTKcommon/tests/TestXml.cpp
@@ -638,6 +638,18 @@ void testValueSerialization() {
 }
 
 
+class HasNoSerialization {
+};
+
+// Ensure that the error one gets when a type cannot be serialized is helpful.
+void testToXmlElementException() {
+    HasNoSerialization obj;
+    SimTK_TEST_MUST_THROW_EXC(toXmlElementHelper(obj, "Alfred", true),
+                              Exception::Cant);
+    SimTK_TEST_MUST_THROW_SHOW(toXmlElementHelper(obj, "Alfred", true));
+}
+
+
 int main() {
     cout << "Path of this executable: '" << Pathname::getThisExecutablePath() << "'\n";
     cout << "Executable directory: '" << Pathname::getThisExecutableDirectory() << "'\n";
@@ -649,7 +661,8 @@ int main() {
         SimTK_SUBTEST(testXmlFromString);
         SimTK_SUBTEST(testXmlFromScratch);
         SimTK_SUBTEST(testValueSerialization);
-
+        SimTK_SUBTEST(testToXmlElementException);
+    
     SimTK_END_TEST();
 }
 


### PR DESCRIPTION
This PR now correctly goes into the the `feature_state_serialization` branch, and hopefully does not produce a warning with MSVC.

Could you also review the exception message? It's tailored for developers, not end-users. Perhaps that's not what we want?