### PR TITLE
Add operator>> for Motion::Level enum

### DIFF
--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
@@ -325,11 +325,7 @@ inline std::istream& operator>>(std::istream& input, Stage& g)
     else if (levelName == "Acceleration") g = Stage(Stage::Acceleration);
     else if (levelName == "Report")       g = Stage(Stage::Report);
     else if (levelName == "Infinity")     g = Stage(Stage::Infinity);
-    else {
-        SimTK_THROW4(SimTK::Exception::ErrorCheck, "valid level name",
-                "operator>>(std::istream&, Stage&)",
-                "Level name '%s' is not valid.", levelName.c_str());
-    }
+    else     input.setstate(std::ios::failbit);
     return input;
 }
 

--- a/Simbody/include/simbody/internal/Motion.h
+++ b/Simbody/include/simbody/internal/Motion.h
@@ -231,6 +231,20 @@ particular implementation object. **/
 explicit Motion(MotionImpl* r) : HandleBase(r) { }
 };
 
+/** This operator is used when deserializing a SimTK::Motion::Level enum
+from an Xml element. **/
+inline std::istream& operator>>(std::istream& input, Motion::Level& level)
+{
+    int i;
+    input >> i;
+    switch (i) {
+    case -1: level = Motion::NoLevel;           return input;
+    case  0: level = Motion::Acceleration;      return input;
+    case  1: level = Motion::Velocity;          return input;
+    case  2: level = Motion::Position;          return input;
+    default: input.setstate(std::ios::failbit); return input;
+    }
+}
 
 //==============================================================================
 //                            MOTION :: SINUSOID

--- a/Simbody/include/simbody/internal/Motion.h
+++ b/Simbody/include/simbody/internal/Motion.h
@@ -231,22 +231,22 @@ particular implementation object. **/
 explicit Motion(MotionImpl* r) : HandleBase(r) { }
 };
 
+
+inline std::ostream& operator<<(std::ostream& o, const Motion::Level& level)
+{ o << Motion::nameOfLevel(level); return o; }
+
 /** This operator is used when deserializing a SimTK::Motion::Level enum
 from an Xml element. **/
 inline std::istream& operator>>(std::istream& input, Motion::Level& level)
 {
-    int i;
-    input >> i;
-    switch (i) {
-    // Fallthrough all the valid cases to just check the int is valid.
-    case Motion::NoLevel:
-    case Motion::Acceleration:
-    case Motion::Velocity:
-    case Motion::Position:
-        level = Motion::Level(i);
-        return input;
-    default: input.setstate(std::ios::failbit); return input;
-    }
+    std::string levelName;
+    input >> levelName;
+    if      (levelName == "NoLevel")      level = Motion::NoLevel;
+    else if (levelName == "Acceleration") level = Motion::Acceleration;
+    else if (levelName == "Velocity")     level = Motion::Velocity;
+    else if (levelName == "Position")     level = Motion::Position;
+    else     input.setstate(std::ios::failbit);
+    return input;
 }
 
 //==============================================================================

--- a/Simbody/include/simbody/internal/Motion.h
+++ b/Simbody/include/simbody/internal/Motion.h
@@ -238,10 +238,13 @@ inline std::istream& operator>>(std::istream& input, Motion::Level& level)
     int i;
     input >> i;
     switch (i) {
-    case -1: level = Motion::NoLevel;           return input;
-    case  0: level = Motion::Acceleration;      return input;
-    case  1: level = Motion::Velocity;          return input;
-    case  2: level = Motion::Position;          return input;
+    // Fallthrough all the valid cases to just check the int is valid.
+    case Motion::NoLevel:
+    case Motion::Acceleration:
+    case Motion::Velocity:
+    case Motion::Position:
+        level = Motion::Level(i);
+        return input;
     default: input.setstate(std::ios::failbit); return input;
     }
 }

--- a/Simbody/tests/TestSimbodyStateXml.cpp
+++ b/Simbody/tests/TestSimbodyStateXml.cpp
@@ -1,5 +1,5 @@
 /* -------------------------------------------------------------------------- *
- *                       Simbody(tm): SimTKcommon                             *
+ *                       Simbody(tm): SimTKsimbody                            *
  * -------------------------------------------------------------------------- *
  * This is part of the SimTK biosimulation toolkit originating from           *
  * Simbios, the NIH National Center for Physics-Based Simulation of           *
@@ -21,52 +21,44 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include "SimTKcommon.h"
+#include "SimTKsimbody.h"
 
 using namespace SimTK;
 
-void testStageXml() {
-    auto testStageLevel = [](Stage::Level level) {
-        Stage stage0(level);
-        Xml::Element stageXml = toXmlElementHelper(stage0, "", true);
-        Stage stage1;
-        fromXmlElementHelper(stage1, stageXml, "", true);
-        SimTK_TEST(stage1 == level);
+void testMotionLevelXml() {
+    auto testMotionLevel = [](Motion::Level level) {
+        Motion::Level ml0(level);
+        Xml::Element mlXml = toXmlElementHelper(ml0, "", true);
+        Motion::Level ml1;
+        fromXmlElementHelper(ml1, mlXml, "", true);
+        SimTK_TEST(ml1 == level);
     };
     
-    testStageLevel(Stage::Empty);
-    testStageLevel(Stage::Topology);
-    testStageLevel(Stage::Model);
-    testStageLevel(Stage::Instance);
-    testStageLevel(Stage::Time);
-    testStageLevel(Stage::Position);
-    testStageLevel(Stage::Velocity);
-    testStageLevel(Stage::Dynamics);
-    testStageLevel(Stage::Acceleration);
-    testStageLevel(Stage::Report);
-    testStageLevel(Stage::Infinity);
+    testMotionLevel(Motion::Level::NoLevel);
+    testMotionLevel(Motion::Level::Acceleration);
+    testMotionLevel(Motion::Level::Velocity);
+    testMotionLevel(Motion::Level::Position);
     
-    // Test invalid stage name.
+
+    // Test invalid level.
     {
         std::stringstream ss;
         ss.exceptions(std::stringstream::failbit);
-        ss << "NotAStageLevelName";
-        Stage stage;
-        SimTK_TEST_MUST_THROW_EXC(ss >> stage, std::stringstream::failure);
+        ss << "3";
+        Motion::Level level;
+        SimTK_TEST_MUST_THROW_EXC(ss >> level, std::stringstream::failure);
     }
     {
-        Stage stage0(Stage::Acceleration);
-        Xml::Element stageXml = toXmlElementHelper(stage0, "", true);
-        stageXml.setValue("NotAStageLevelName");
-        Stage stage1;
-        SimTK_TEST_MUST_THROW_EXC(
-                fromXmlElementHelper(stage1, stageXml, "", true),
+        Motion::Level ml0 = Motion::Level(3);
+        Xml::Element mlXml = toXmlElementHelper(ml0, "", true);
+        Motion::Level ml1;
+        SimTK_TEST_MUST_THROW_EXC(fromXmlElementHelper(ml1, mlXml, "", true),
                 Exception::ErrorCheck);
     }
 }
 
 int main() {
-    SimTK_START_TEST("TestStateXml");
-        SimTK_SUBTEST(testStageXml);
+    SimTK_START_TEST("TestSimbodyStateXml");
+        SimTK_SUBTEST(testMotionLevelXml);
     SimTK_END_TEST();
 }


### PR DESCRIPTION
This PR adds an `operator>>` for enum `Motion::Level`.

This PR also changes the error-handling mechanism used for `Stage`s `operator>>` to use `failbit` instead of an exception. This is more consistent with the rest of the Simbody code base.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/503)
<!-- Reviewable:end -->
