### PR TITLE
Add a helper for fromXmlElement implementations; Add serialization for Rotation

### DIFF
--- a/SimTKcommon/Mechanics/include/SimTKcommon/internal/Rotation.h
+++ b/SimTKcommon/Mechanics/include/SimTKcommon/internal/Rotation.h
@@ -1116,7 +1116,7 @@ void fromXmlElement(Xml::Element e, const std::string& requiredName) {
     // TODO template argument P?
     Mat33P mat;
     fromXmlElementHelperHelper("Rotation", 1, e, requiredName,
-            mat, "value");
+            std::make_pair(&mat, "value"));
     setRotationFromMat33TrustMe(mat);
 }
 //@}

--- a/SimTKcommon/Mechanics/include/SimTKcommon/internal/Rotation.h
+++ b/SimTKcommon/Mechanics/include/SimTKcommon/internal/Rotation.h
@@ -30,6 +30,7 @@
 #include "SimTKcommon/internal/CoordinateAxis.h"
 #include "SimTKcommon/internal/UnitVec.h"
 #include "SimTKcommon/internal/Quaternion.h"
+#include "SimTKcommon/internal/Xml.h"
 
 //------------------------------------------------------------------------------
 #include <iosfwd>  // Forward declaration of iostream
@@ -1094,6 +1095,30 @@ bool areAllRotationElementsSameToEpsilon(const Rotation_& R, RealP epsilon) cons
 of the corresponding element of "R". **/
 bool areAllRotationElementsSameToMachinePrecision( const Rotation_& R ) const       
 { return areAllRotationElementsSameToEpsilon(R, NTraits<P>::getSignificant()); } 
+//@}
+
+//------------------------------------------------------------------------------
+/** @name Xml serialization **/
+//@{
+Xml::Element toXmlElement(const std::string& name) const {
+    static const int version = 1;
+    // TODO template argument P?
+    Xml::Element e("Rotation");
+    if (!name.empty()) e.setAttributeValue("name", name);
+    e.setAttributeValue("version", String(version));
+    e.appendNode(toXmlElementHelper(asMat33(), "value", true));
+    return e;
+}
+
+/** This does not check or ensure that the %Xml element contains a 
+valid rotation matrix. **/
+void fromXmlElement(Xml::Element e, const std::string& requiredName) {
+    // TODO template argument P?
+    Mat33P mat;
+    fromXmlElementHelperHelper("Rotation", 1, e, requiredName,
+            mat, "value");
+    setRotationFromMat33TrustMe(mat);
+}
 //@}
 
 

--- a/SimTKcommon/include/SimTKcommon/internal/Value.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Value.h
@@ -158,6 +158,19 @@ of the underlying concrete type.
 inline std::ostream& operator<<(std::ostream& o, const AbstractValue& v) 
 {   o << v.toXmlElement(""); return o; }
 
+// TODO document this method.
+template <template <typename> class OwningSmartPtrType, typename ... TArgs>
+inline void fromXmlElementHelperHelperRecurse(Xml::element_iterator eit,
+        Xml::element_iterator end,
+        OwningSmartPtrType<AbstractValue>& fieldValue, const std::string& fieldName, 
+        TArgs& ... fields) {
+    assert(eit != end);
+    std::unique_ptr<AbstractValue> vp =
+        AbstractValue::createFromXmlElement(*eit++, fieldName);
+    fieldValue.reset(vp.release());
+    fromXmlElementHelperHelperRecurse(eit, end, fields...);
+}
+
 
 //==============================================================================
 //                               VALUE <T>

--- a/SimTKcommon/include/SimTKcommon/internal/Value.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Value.h
@@ -165,16 +165,17 @@ inline std::ostream& operator<<(std::ostream& o, const AbstractValue& v)
 // (through fromXmlElementHelperHelper()) a smart pointer to the AbstractValue
 // they want deserialized. We heap-allocate a new AbstractValue of the right
 // type, and transfer ownership to the passed-in smart pointer.
-template <template <typename...> class OwningSmartPtrType, typename ... FieldTypes>
+template <template <typename... PtrArgs> class OwningSmartPtrType,
+        typename... PtrArgs, typename... FieldTypes>
 inline void fromXmlElementHelperHelperRecurse(Xml::element_iterator eit,
         Xml::element_iterator end,
-        std::pair<OwningSmartPtrType<AbstractValue>*, const char*> firstField,
-        std::pair<FieldTypes*, const char*> ... remainingFields) {
+        std::pair<OwningSmartPtrType<AbstractValue, PtrArgs...>*, const char*> firstField,
+        std::pair<FieldTypes*, const char*>... remainingFields) {
     assert(eit != end);
     OwningSmartPtrType<AbstractValue>* value = firstField.first;
     const std::string& name = firstField.second;
     std::unique_ptr<AbstractValue> vp =
-        AbstractValue::createFromXmlElement(*eit++, name);
+            AbstractValue::createFromXmlElement(*eit++, name);
     value->reset(vp.release());
     fromXmlElementHelperHelperRecurse(eit, end, remainingFields...);
 }

--- a/SimTKcommon/include/SimTKcommon/internal/Value.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Value.h
@@ -159,16 +159,18 @@ inline std::ostream& operator<<(std::ostream& o, const AbstractValue& v)
 {   o << v.toXmlElement(""); return o; }
 
 // TODO document this method.
-template <template <typename> class OwningSmartPtrType, typename ... TArgs>
+template <template <typename> class OwningSmartPtrType, typename ... FieldTypes>
 inline void fromXmlElementHelperHelperRecurse(Xml::element_iterator eit,
         Xml::element_iterator end,
-        OwningSmartPtrType<AbstractValue>& fieldValue, const std::string& fieldName, 
-        TArgs& ... fields) {
+        std::pair<OwningSmartPtrType<AbstractValue>*, const char*> firstField,
+        std::pair<FieldTypes*, const char*> ... remainingFields) {
     assert(eit != end);
+    OwningSmartPtrType<AbstractValue>* value = firstField.first;
+    const std::string& name = firstField.second;
     std::unique_ptr<AbstractValue> vp =
-        AbstractValue::createFromXmlElement(*eit++, fieldName);
-    fieldValue.reset(vp.release());
-    fromXmlElementHelperHelperRecurse(eit, end, fields...);
+        AbstractValue::createFromXmlElement(*eit++, name);
+    value->reset(vp.release());
+    fromXmlElementHelperHelperRecurse(eit, end, remainingFields...);
 }
 
 

--- a/SimTKcommon/include/SimTKcommon/internal/Value.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Value.h
@@ -158,8 +158,14 @@ of the underlying concrete type.
 inline std::ostream& operator<<(std::ostream& o, const AbstractValue& v) 
 {   o << v.toXmlElement(""); return o; }
 
-// TODO document this method.
-template <template <typename> class OwningSmartPtrType, typename ... FieldTypes>
+// This function is invoked by fromXmlElementHelperHelper().
+// Users should not call this method.
+// Since one cannot use fromXmlElementHelper() to deserialize AbstractValues,
+// we must handle them specially. Here, the user passes us
+// (through fromXmlElementHelperHelper()) a smart pointer to the AbstractValue
+// they want deserialized. We heap-allocate a new AbstractValue of the right
+// type, and transfer ownership to the passed-in smart pointer.
+template <template <typename...> class OwningSmartPtrType, typename ... FieldTypes>
 inline void fromXmlElementHelperHelperRecurse(Xml::element_iterator eit,
         Xml::element_iterator end,
         std::pair<OwningSmartPtrType<AbstractValue>*, const char*> firstField,

--- a/SimTKcommon/include/SimTKcommon/internal/Xml.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Xml.h
@@ -1728,11 +1728,11 @@ inline void fromXmlElementHelperHelperRecurse(Xml::element_iterator eit,
 // Meat of the recursion for deserializing through
 // fromXmlElementHelperHelper(). This function invokes fromXmlElementHelper()
 // on each of the fields provided.
-template <typename FieldType, typename ... FieldTypes> inline
+template <typename FieldType, typename... FieldTypes> inline
 void fromXmlElementHelperHelperRecurse(Xml::element_iterator eit,
         Xml::element_iterator end,
         std::pair<FieldType*, const char*> firstField,
-        std::pair<FieldTypes*, const char*> ... remainingFields) {
+        std::pair<FieldTypes*, const char*>... remainingFields) {
     // Make sure we didn't run out of Xml elements.
     assert(eit != end);
     // Perform the actual deserialization.
@@ -1794,11 +1794,11 @@ private:
 
 @see fromXmlElementHelper()
 @relates SimTK::Xml::Element **/
-template <typename ... FieldTypes> inline
+template <typename... FieldTypes> inline
 void fromXmlElementHelperHelper(const std::string& typeName,
         int requiredVersion,
         Xml::Element& e, const std::string& requiredName,
-        std::pair<FieldTypes*, const char*> ... fields) {
+        std::pair<FieldTypes*, const char*>... fields) {
     SimTK_ERRCHK2_ALWAYS(e.getElementTag()==typeName,
             (typeName+"::fromXmlElement()").c_str(),
             "Expected element tag '%s' but got '%s'.",

--- a/SimTKcommon/include/SimTKcommon/internal/Xml.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Xml.h
@@ -1698,7 +1698,6 @@ template <class T> inline
 auto fromXmlElementHelper(T& thing, Xml::Element& elt, 
                           const std::string& requiredTag, bool)
     -> decltype(std::declval<T>().fromXmlElement(elt,requiredTag)) {
-    // TODO std::cout << "DEBUGfromXmlmember" << elt << std::endl;
     return thing.fromXmlElement(elt,requiredTag); // call member function
 }
 
@@ -1709,7 +1708,6 @@ template <class T> inline
 auto fromXmlElementHelper(T& thing, Xml::Element& elt, 
                           const std::string& requiredTag, int) 
     -> void {
-    // TODO std::cout << "DEBUGfromXmlfree" << elt << std::endl;
     fromXmlElement(thing, elt, requiredTag); // call free function
 }
 
@@ -1718,25 +1716,6 @@ inline void fromXmlElementHelperHelperRecurse(Xml::element_iterator eit,
         Xml::element_iterator end) {
     assert(eit == end);
 }
-
-/*
-// TODO decide between this and the other interface. 
-// With this interface, the call
-// is more verbose but also more clear:
-//
-// fromXmlElementHelperHelper("Foo", 1, e, "reqName",
-//     std::make_pair{bar, "bar"},
-//     std::make_pair{baz, "baz"}
-//     );
-template <typename T, typename ... TArgs> inline
-void fromXmlElementHelperHelperRecurse(Xml::element_iterator eit,
-        std::pair<T&, std::string> firstField,
-        std::pair<TArgs&, std::string> ... fields) {
-    fromXmlElementHelper(firstField.first, *eit++, firstField.second, true);
-    fromXmlElementHelperHelperRecurse(eit, fields...);
-    // TODO 
-}
-*/
 
 template <typename FieldType, typename ... FieldTypes> inline
 void fromXmlElementHelperHelperRecurse(Xml::element_iterator eit,

--- a/SimTKcommon/include/SimTKcommon/internal/Xml.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Xml.h
@@ -1738,22 +1738,23 @@ void fromXmlElementHelperHelperRecurse(Xml::element_iterator eit,
 }
 */
 
-template <typename T, typename ... TArgs> inline
+template <typename FieldType, typename ... FieldTypes> inline
 void fromXmlElementHelperHelperRecurse(Xml::element_iterator eit,
         Xml::element_iterator end,
-        T& fieldValue, const std::string& fieldName, 
-        TArgs& ... fields) {
+        std::pair<FieldType*, const char*> firstField,
+        std::pair<FieldTypes*, const char*> ... remainingFields) {
     assert(eit != end);
-    fromXmlElementHelper(fieldValue, *eit++, fieldName, true);
-    fromXmlElementHelperHelperRecurse(eit, end, fields...);
+    FieldType* value = firstField.first;
+    const std::string& name = firstField.second;
+    fromXmlElementHelper(*value, *eit++, name, true);
+    fromXmlElementHelperHelperRecurse(eit, end, remainingFields...);
     // TODO 
 }
 
-template <typename ... TArgs> inline
+template <typename ... FieldTypes> inline
 void fromXmlElementHelperHelper(const std::string& typeName, int requiredVersion,
         Xml::Element& e, const std::string& requiredName,
-        TArgs& ... args) {
-        // TODO std::pair<TArgs&, std::string> ... fields) {
+        std::pair<FieldTypes*, const char*> ... fields) {
     SimTK_ERRCHK2_ALWAYS(e.getElementTag()==typeName,
             (typeName+"::fromXmlElement()").c_str(),
             "Expected element tag '%s' but got '%s'.",
@@ -1776,7 +1777,7 @@ void fromXmlElementHelperHelper(const std::string& typeName, int requiredVersion
 
     // We've seen <typeName name="requiredName" version="requiredVersion">
     fromXmlElementHelperHelperRecurse(e.element_begin(), e.element_end(),
-            args...);
+            fields...);
 }
 
 // Definition of these functions (which should really be methods of 

--- a/SimTKcommon/tests/TestStateXml.cpp
+++ b/SimTKcommon/tests/TestStateXml.cpp
@@ -25,6 +25,46 @@
 
 using namespace SimTK;
 
+/* This function converts the provided instance of `T` to Xml, deserializes
+it from Xml, ensures the deserialized instance is equal to the original
+instance, reserializes the deserialized instance back to Xml and ensures
+the original desrialization and the reserialization are equal.
+
+One might set `checkInMemoryEquality` to false if `value` contains NaNs. */
+template <typename T>
+void testXmlRoundtrip(const T& value, bool checkInMemoryEquality = true,
+                      std::string name = "") {
+    Xml::Element xml = toXmlElementHelper(value, name, true);
+    T deserialized;
+    fromXmlElementHelper(deserialized, xml, name, true);
+    if (checkInMemoryEquality) {
+        try {
+            SimTK_TEST(value == deserialized);
+        }
+        catch (Exception::Assert& e) {
+            std::cout << "value: " << value << std::endl;
+            std::cout << "serialized:\n" << xml << std::endl;
+            std::cout << "deserialized: " << deserialized << std::endl;
+            throw e;
+        }
+    }
+    
+    Xml::Element xmlReserialized = toXmlElementHelper(deserialized, name, true);
+    String xmlStr, xmlReserializedStr;
+    xml.writeToString(xmlStr);
+    xmlReserialized.writeToString(xmlReserializedStr);
+    try {
+        SimTK_TEST(xmlStr == xmlReserializedStr);
+    } catch (Exception::Assert& e) {
+        std::cout << "value: " << value << std::endl;
+        std::cout << "serialized:\n" << xml << std::endl;
+        std::cout << "deserialized:" << deserialized << std::endl;
+        std::cout << "reserialized:\n" << xmlReserialized << std::endl;
+        throw e;
+    }
+        
+}
+
 void testStageXml() {
     auto testStageLevel = [](Stage::Level level) {
         Stage stage0(level);
@@ -55,9 +95,16 @@ void testStageXml() {
     }
 }
 
+void testRotationXml() {
+    testXmlRoundtrip(Rotation());
+    testXmlRoundtrip(Rotation(BodyRotationSequence,
+                              0.1, XAxis, 0.3, YAxis, 0.4, ZAxis));
+    testXmlRoundtrip(Rotation(NaN, XAxis), false);
+}
 
 int main() {
     SimTK_START_TEST("TestStateXml");
         SimTK_SUBTEST(testStageXml);
+        SimTK_SUBTEST(testRotationXml);
     SimTK_END_TEST();
 }

--- a/SimTKcommon/tests/TestStateXml.cpp
+++ b/SimTKcommon/tests/TestStateXml.cpp
@@ -28,7 +28,7 @@ using namespace SimTK;
 /* This function converts the provided instance of `T` to Xml, deserializes
 it from Xml, ensures the deserialized instance is equal to the original
 instance, reserializes the deserialized instance back to Xml and ensures
-the original desrialization and the reserialization are equal.
+the original deserialization and the reserialization are equal.
 
 One might set `checkInMemoryEquality` to false if `value` contains NaNs. */
 template <typename T>

--- a/SimTKcommon/tests/TestXml.cpp
+++ b/SimTKcommon/tests/TestXml.cpp
@@ -719,7 +719,7 @@ int main() {
         SimTK_SUBTEST(testXmlFromString);
         SimTK_SUBTEST(testXmlFromScratch);
         SimTK_SUBTEST(testValueSerialization);
-        SimTK_SUBTEST(testValueSerializationHelperHelper);
+        SimTK_SUBTEST(testFromXmlElementHelperHelper);
         SimTK_SUBTEST(testToXmlElementException);
         SimTK_SUBTEST(testXmlUniqueIndexType);
     

--- a/SimTKcommon/tests/TestXml.cpp
+++ b/SimTKcommon/tests/TestXml.cpp
@@ -656,7 +656,8 @@ public:
         // This helper knows that `m_value` is a smart pointer and will reset
         // it for us.
         fromXmlElementHelperHelper("ClassWithAbstractValue", 1, e, requiredName,
-                m_number, "number", m_value, "value");
+                std::make_pair(&m_number, "number"),
+                std::make_pair(&m_value, "value"));
     }
 };
 


### PR DESCRIPTION
This PR contains a new helper function that can be used when implementing `fromXmlElement()`. Right now, it's named `fromXmlElementHelperHelper()`; a better name would be `fromXmlElementHelper()` but that's taken for now. This is a variadic template function that takes references to the variables you want to set. It also handles `AbstractValue`s in a uniform way (if the `AbstractValue` is contained in a smart pointer). I don't expect _all_ implementations of `fromXmlElement()` to use `fromXmlElementHelperHelper()`, but I think it can be useful in many cases and reduces the chance of making an error. In particular, this helper does not really help with managing backwards compatibility for multiple versions; I expect the implementor would have to detect the version and then make appropriate calls to the helperhelper.

This PR also adds xml (de)serialization methods for Rotation. 

@sherm1, even if you like these changes, I expect some cleanup will be necessary. I would like to do such cleanup in follow-up PRs to the feature branch. If you like the helperhelper, I will also create one for `toXmlElement()`.

Some questions:
1. What's the best way to handle the template type to `Rotation_`? Right now, I ignore it. Is that okay? Should we use another Xml attribute (`P="Real"`)?
2. Right now, `Rotation_::fromXmlElement()` does _not_ try to make the provided Mat33 a valid rotation matrix. I think this is the right thing to do, but your opinion would be helpful. I think it's important to get the _exact_ same results with the deserialized State, and this requires using all values exactly as they were, without doing any corrections. I tried using `Rotation(mat)` originally to deserialize, and this led to the last 2 or 3 digits being different from the original values.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/504)
<!-- Reviewable:end -->
