### PR TITLE
Fix bug in ContinuousVarInfo::toXmlElement.

### DIFF
--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/StateImpl.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/StateImpl.h
@@ -553,7 +553,7 @@ public:
         e.appendNode(toXmlElementHelper(allocationStage, "allocationStage", true));
         e.appendNode(toXmlElementHelper(firstIndex, "firstIndex", true));
         e.appendNode(toXmlElementHelper(initialValues, "initialValues", true));
-        e.appendNode(toXmlElementHelper(initialValues, "weights", true));
+        e.appendNode(toXmlElementHelper(weights, "weights", true));
         return e;
     }
 private:


### PR DESCRIPTION
I think were was a copy-paste bug in ContinuousVarInfo. This PR fixes it.