### PR TITLE
Set Ground's Inertia to Infinity using UnitInertia instead of Inertia

### DIFF
--- a/Simbody/src/BodyRep.h
+++ b/Simbody/src/BodyRep.h
@@ -132,7 +132,8 @@ private:
 class Body::Ground::GroundRep : public Body::BodyRep {
 public:
     GroundRep() 
-    :   BodyRep(), infiniteMassProperties(Infinity, Vec3(0), Inertia(Infinity))
+    :   BodyRep(), infiniteMassProperties(Infinity, Vec3(0),
+                                          UnitInertia(Infinity))
     {
     }
     GroundRep* clone() const override {


### PR DESCRIPTION
Previously, Ground's inertia ended up being NaN as a result of
an Inf/Inf in Inertia's constructor (thanks @sherm1 for explaining). This PR changes Ground's inertia to be Inf by using the UnitInertia constructor instead.

Fixes #507.