### PR TITLE
SimbodyMatterSubsystem::calcConstraintAccelerationErrors().

### DIFF
--- a/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
+++ b/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
@@ -1594,10 +1594,51 @@ accelerations for the constrained bodies; even with udot==0 body accelerations
 may have a non-zero velocity-dependent component (the coriolis accelerations). 
 Those are already available in the state, but only as accelerations in Ground. 
 For constraints that have a non-Ground Ancestor, we have to convert the 
-accelerations to A at a cost of 105 flops/constrained body. **/
+accelerations to A at a cost of 105 flops/constrained body.
+
+@see calcConstraintAccelerationErrors() **/
 void calcBiasForAccelerationConstraints(const State& state,
                                         Vector&      bias) const;
 
+/** Given a complete set of nu generalized accelerations udot, this operator
+computes the constraint acceleration errors that result due to the constraints
+currently active in the given state:
+<pre>
+       pvaerr = G udot - b(t,q,u)
+
+             where
+
+              [P]    [bp]
+            G=[V]  b=[bv]
+              [A]    [ba]
+</pre>
+The quantity Subsystem::getUDotErr() is computed by the same operation as this
+method performs.
+
+@param[in] state
+    A State compatible with this System that has already been realized to
+    Stage::Velocity.
+@param[in] knownUDot
+    A complete set of generalized accelerations. Must have the same length
+    as the number of mobilities nu, or if length zero the udots will be taken
+    as all zero in which case only the bias vector -b will be returned.
+@param[out] pvaerr
+    The error in the acceleration-level constraint equations.
+    All acceleration-level constraints are included: holonomic second
+    derivatives, nonholonomic first derivatives, and acceleration-only
+    constraints. The vector will be resized if necessary to length m=mp+mv+ma,
+    the total number of active acceleration-level constraint equations.
+
+@par Implementation
+This operator takes O(m+n) time.
+
+@par Required stage
+  \c Stage::Velocity
+
+@see calcG(), calcBiasForAccelerationConstraints() **/
+void calcConstraintAccelerationErrors(const State&  state,
+                                      const Vector& knownUDot,
+                                      Vector&       pvaerr) const;
 
 /** Returns f = ~G*lambda, the product of the n X m transpose of the 
 acceleration constraint Jacobian G (=[P;V;A]) and a multiplier-like vector 
@@ -2184,7 +2225,6 @@ implementation uses 12*nu + 18*nb flops to produce nb body accelerations.
 void calcBodyAccelerationFromUDot(const State&         state,
                                   const Vector&        knownUDot,
                                   Vector_<SpatialVec>& A_GB) const;
-
 
 /** Treating all Constraints together, given a comprehensive set of m 
 Lagrange multipliers \e lambda, generate the complete set of body spatial forces

--- a/Simbody/src/SimbodyMatterSubsystemRep.h
+++ b/Simbody/src/SimbodyMatterSubsystemRep.h
@@ -960,7 +960,7 @@ public:
     // acceleration errors that result due to the constraints currently active
     // in the given state. All acceleration-level constraints are included:
     // holonomic second derivatives, nonholonomic first derivatives, and 
-    // acceleratin-only constraints. This is a pure operator and does not 
+    // acceleration-only constraints. This is a pure operator and does not
     // affect the state or state cache. Vectors must use contiguous data.
     // State must have been realized through Velocity stage.
     void calcConstraintAccelerationErrors

--- a/Simbody/tests/TestConstraints.cpp
+++ b/Simbody/tests/TestConstraints.cpp
@@ -582,6 +582,152 @@ void testConstraintMatrices() {
     delete &system;
 }
 
+// Test the operator SimbodyMatterSubsystem::calcConstraintAccelerationErrors(),
+// which computes pvaerr = G udot - b. For the most part, we just ensure that
+// this operator gives results consistent with other methods.
+void testConstraintAccelerationErrors() {
+    // Create a chain of bodies. Copied from testConstraintMatrices().
+    MultibodySystem& system = createSystem();
+    SimbodyMatterSubsystem& matter = system.updMatterSubsystem();
+    MobilizedBody& first = matter.updMobilizedBody(MobilizedBodyIndex(1));
+    MobilizedBody& second = matter.updMobilizedBody(MobilizedBodyIndex(2));
+    MobilizedBody& fifth = matter.updMobilizedBody(MobilizedBodyIndex(5));
+    MobilizedBody& last = matter.updMobilizedBody(MobilizedBodyIndex(NUM_BODIES));
+
+    // Add a body on a free joint to body 5 then weld it.
+    MobilizedBody::Free extra(fifth, Transform(),
+        MassProperties(1, Vec3(.01,.02,.03), Inertia(1,1.1,1.2)), Transform());
+    Constraint::Weld weld(extra, fifth);
+
+    Constraint::Ball ball(first, last);
+    Constraint::ConstantAcceleration accel2(second, MobilizerUIndex(1), .01);
+    Constraint::ConstantSpeed speed5(fifth, MobilizerUIndex(1), .1);
+
+    // Obtain constraint errors from realizing to Acceleration.
+    Vector udotFromForward, pvaerrFromForward;
+    State state;
+    {
+        State stateForward;
+        createState(system, stateForward); // Realizes to Acceleration.
+        udotFromForward = stateForward.getUDot();
+        pvaerrFromForward = stateForward.getUDotErr();
+        state = stateForward; // This copy assignment invalidates the cache.
+    }
+
+    const int nu = matter.getNU(state);
+    const int m  = matter.getNUDotErr(state);
+
+    // Ensure that we get an exception if not realized to Velocity yet.
+    {
+        system.realize(state, SimTK::Stage::Position);
+        SimTK_TEST(state.getSystemStage() == SimTK::Stage::Position);
+        Vector output; Vector udot(nu);
+        SimTK_TEST_MUST_THROW_EXC(
+                matter.calcConstraintAccelerationErrors(state, udot, output),
+                SimTK::Exception::ErrorCheck);
+    }
+
+    // Obtain constraint errors using the operator.
+    Vector biasFromOperator; // used in a subsequent test.
+    {
+        State stateOperator = state;
+        // Realizing to Velocity should be sufficient.
+        system.realize(stateOperator, SimTK::Stage::Velocity);
+
+        // With udot=0, errors should be nonzero.
+        Vector outputWithZeroUDot;
+        matter.calcConstraintAccelerationErrors
+                (stateOperator, Vector(nu, 0.0), outputWithZeroUDot);
+        SimTK_TEST(outputWithZeroUDot.norm() > 1e-6);
+        biasFromOperator = outputWithZeroUDot; // used in a subsequent test.
+
+        // Ensure the operator did not internally realize to a later stage.
+        SimTK_TEST(stateOperator.getSystemStage() == SimTK::Stage::Velocity);
+
+        // With udot from forward dynamics, errors should be close to zero.
+        Vector pvaerrFromOperator;
+        matter.calcConstraintAccelerationErrors
+                (stateOperator, udotFromForward, pvaerrFromOperator);
+
+        SimTK_TEST(pvaerrFromOperator.norm() < 1e-10);
+
+        // The same code should have been executed when using forward
+        // dynamics or the operator, so the errors should be exactly the same.
+        SimTK_TEST(pvaerrFromOperator.size() == m);
+        for (int i = 0; i < pvaerrFromOperator.size(); ++i) {
+            SimTK_TEST(pvaerrFromOperator[i] == pvaerrFromForward[i]);
+        }
+    }
+
+    // Check that the bias term is consistent with that from other methods.
+    {
+        State stateCompareBias = state;
+        system.realize(stateCompareBias, SimTK::Stage::Velocity);
+        Vector biasFromSepOperator;
+        matter.calcBiasForAccelerationConstraints(stateCompareBias,
+                                                  biasFromSepOperator);
+        SimTK_TEST_EQ(biasFromOperator, biasFromSepOperator);
+    }
+
+    // Compute G using calcConstraintAccelerationErrors; compare to calcG().
+    // pvaerr     = G * udot   + -bias(t,q,u)
+    // pvaerr_j   = G * udot_j + (-bias)
+    // G * udot_j = pvaerr_j   - (-bias)
+    // G_j = G * e_j (where e_j is the unit vector in direction j)
+    {
+        State stateCompareG = state;
+        system.realize(stateCompareG, SimTK::Stage::Velocity);
+        Matrix GFromCalcG;
+        matter.calcG(stateCompareG, GFromCalcG);
+        Matrix GFromOperator(m, nu);
+        Vector udot(nu, 0.0);
+        for (int icol = 0; icol < GFromCalcG.ncol(); ++icol) {
+            udot[icol] = 1.0;
+            // pvaerr_j = G * e_j + -bias
+            matter.calcConstraintAccelerationErrors
+                    (stateCompareG, udot, GFromOperator.updCol(icol));
+            // G_j = G * e_j + (-bias) - (-bias)
+            GFromOperator.updCol(icol) -= biasFromOperator;
+            udot[icol] = 0.0;
+        }
+        SimTK_TEST_EQ(GFromCalcG, GFromOperator);
+    }
+
+    // Test noncontiguous input and output vectors (similar to TestMassMatrix).
+    {
+        system.realize(state, SimTK::Stage::Velocity);
+        Matrix MatUdot(3, nu);  // use middle row
+        MatUdot.setToNaN();
+        MatUdot[1] = ~udotFromForward;
+        Matrix Matpvaerr(3, m); // use middle row
+        Matpvaerr.setToNaN();
+        auto TODO = ~MatUdot[1];
+        matter.calcConstraintAccelerationErrors(state, ~MatUdot[1],
+                                                ~Matpvaerr[1]);
+        SimTK_TEST_EQ(Matpvaerr[1], ~pvaerrFromForward);
+    }
+
+    // Check that we object to wrong-length arguments.
+    {
+        Vector output;
+        SimTK_TEST_MUST_THROW_EXC(matter.calcConstraintAccelerationErrors
+                                          (state, Vector(1), output),
+                                  SimTK::Exception::ErrorCheck);
+    }
+
+    system.realize(state, SimTK::Stage::Velocity);
+
+    // Verify that leaving out arguments makes them act like zeros.
+    {
+        Vector outputZeros, outputEmpty;
+        matter.calcConstraintAccelerationErrors(state, Vector(nu, 0.0),
+                                                outputZeros);
+        matter.calcConstraintAccelerationErrors(state, Vector(),
+                                                outputEmpty);
+        SimTK_TEST_EQ_TOL(outputZeros, outputEmpty, SignificantReal);
+    }
+}
+
 int main() {
     SimTK_START_TEST("TestConstraints");
         SimTK_SUBTEST(testBallConstraint);
@@ -596,6 +742,7 @@ int main() {
         SimTK_SUBTEST(testWeldConstraintWithPreAssembly);
         SimTK_SUBTEST(testConstraintForces);
         SimTK_SUBTEST(testConstraintMatrices);
+        SimTK_SUBTEST(testConstraintAccelerationErrors);
         SimTK_SUBTEST(testDisablingConstraints);
     SimTK_END_TEST();
 }

--- a/Simbody/tests/TestConstraints.cpp
+++ b/Simbody/tests/TestConstraints.cpp
@@ -651,12 +651,8 @@ void testConstraintAccelerationErrors() {
 
         SimTK_TEST(pvaerrFromOperator.norm() < 1e-10);
 
-        // The same code should have been executed when using forward
-        // dynamics or the operator, so the errors should be exactly the same.
-        SimTK_TEST(pvaerrFromOperator.size() == m);
-        for (int i = 0; i < pvaerrFromOperator.size(); ++i) {
-            SimTK_TEST(pvaerrFromOperator[i] == pvaerrFromForward[i]);
-        }
+        // Forward dynamics and the operator should give the same result.
+        SimTK_TEST_EQ(pvaerrFromOperator, pvaerrFromForward);
     }
 
     // Check that the bias term is consistent with that from other methods.
@@ -701,7 +697,6 @@ void testConstraintAccelerationErrors() {
         MatUdot[1] = ~udotFromForward;
         Matrix Matpvaerr(3, m); // use middle row
         Matpvaerr.setToNaN();
-        auto TODO = ~MatUdot[1];
         matter.calcConstraintAccelerationErrors(state, ~MatUdot[1],
                                                 ~Matpvaerr[1]);
         SimTK_TEST_EQ(Matpvaerr[1], ~pvaerrFromForward);


### PR DESCRIPTION
Previously, `SimbodyMatterSubsystemRep` had an operator
`calcConstraintAccelerationErrors()`, but there was no related operator for use
by users. This PR introduces such an operator. The operator is tested
in TestConstraints to ensure it gives results that are consistent with
other methods/operators.

In the doxygen, I stated that the complexity of the operator is O(m+n) This was determined by inspecting the internal documentation for:
 * `SimbodyMatterSubsystemRep::calcConstraintAccelerationErrors()` (O(m+n)), 
 * `SimbodyMatterSubsystemRep::calcBodyAccelerationsFromUDot()` (O(nu+nb)), and 
 * `SimbodyMatterSubsystem::calcQDotDot()` (O(n)).

Fixes #514.