### PR TITLE
Only define clock_gettime() for macOS < 10.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ matrix:
     - os: osx
       compiler: clang
       env: BTYPE=RelWithDebInfo
-    - os: osx
-      osx_image: xcode8
-      compiler: clang
-      env: BTYPE=RelWithDebInfo
 
 before_install:
   ## Ensure that there are no tabs in source code.

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,10 @@ matrix:
     - os: osx
       compiler: clang
       env: BTYPE=RelWithDebInfo
+    - os: osx
+      osx_image: xcode8
+      compiler: clang
+      env: BTYPE=RelWithDebInfo
 
 before_install:
   ## Ensure that there are no tabs in source code.

--- a/SimTKcommon/include/SimTKcommon/internal/Timing.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Timing.h
@@ -59,34 +59,35 @@ librt realtime library (-lrt). **/
 
 
 // macOS (OSX) 10.12 introduced support for clock_gettime().
-// First, figure out if this machine even knows about 10.12.
-#if defined(__APPLE__)
-    #include <Availability.h>
-#endif
-// Assume all versions starting with 10.12 will support clock_gettime().
-// We'll use this macro throughout Timing.(h|cpp).
 // The following logic is based on documentation in /usr/local/Availability.h
 // and from this site:
 // https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html.
 // This website also recommends using Availability.h over the similarly-helpful
 // AvailabilityMacros.h.
-// The number 101200 identifies macOS version 10.12. The explicit version
-// number must be used instead of using a macro like __MAC_10_12 because
-// pre-10.12 systems won't have __MAC_10_12 defined.
-// "MAX_ALLOWED" is the version of the SDK used when building.
+#if defined(__APPLE__)
+    #include <Availability.h>
+#endif
+// We'll use the following macros throughout Timing.(h|cpp).
+// "MAX_ALLOWED" is the version of the OSX SDK used when building.
 // "MIN_REQUIRED" is the "DEPLOYMENT_TARGET": earliest version on which the
 //                binaries should run.
 // One can use the 10.12 SDK to deploy to earlier releases, like 10.11. The SDK
-// version determines if we even need to declare clock_gettime(), and the
-// deployment target determines if we can expect the user's system to
-// contain an implementation of clock_gettime().
+// version determines if we need to declare clock_gettime() (e.g., developer is
+// using an SDK older than 10.12), and the deployment target determines if we
+// cannot expect the user's system to contain an implementation of
+// clock_gettime() (e.g., user may be running an on OS older than 10.12).
 // We need both of these macros because developers may only have the 10.12 SDK,
-// but may want to use it to deploy to machines running 10.11.
+// but may want to use it to deploy to machines running 10.11. In such a case,
+// we cannot declare clock_gettime() ourselves (the SDK does it), but we must
+// still define it.
+// The number 101200 identifies macOS version 10.12. The explicit version
+// number must be used instead of a macro like __MAC_10_12 because pre-10.12
+// systems won't have __MAC_10_12 defined.
 #define SimTK_APPLE_MUST_DECLARE_CLOCK_GETTIME defined(__APPLE__) && \
-    __MAC_OS_X_VERSION_MAX_ALLOWED < 101200
+    __MAC_OS_X_VERSION_MAX_ALLOWED < 101200 // SDK is older than 10.12.
 
 #define SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME defined(__APPLE__) && \
-    __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+    __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 // user's OS may be pre-10.12.
 
 
 

--- a/SimTKcommon/include/SimTKcommon/internal/Timing.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Timing.h
@@ -57,6 +57,39 @@ librt realtime library (-lrt). **/
 // date-handling symbols declared here on all platforms.
 #include <ctime>
 
+
+// macOS (OSX) 10.12 introduced support for clock_gettime().
+// First, figure out if this machine even knows about 10.12.
+#if defined(__APPLE__)
+    #include <Availability.h>
+#endif
+// Assume all versions starting with 10.12 will support clock_gettime().
+// We'll use this macro throughout Timing.(h|cpp).
+// The following logic is based on documentation in /usr/local/Availability.h
+// and from this site:
+// https://developer.apple.com/library/content/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html.
+// This website also recommends using Availability.h over the similarly-helpful
+// AvailabilityMacros.h.
+// The number 101200 identifies macOS version 10.12. The explicit version
+// number must be used instead of using a macro like __MAC_10_12 because
+// pre-10.12 systems won't have __MAC_10_12 defined.
+// "MAX_ALLOWED" is the version of the SDK used when building.
+// "MIN_REQUIRED" is the "DEPLOYMENT_TARGET": earliest version on which the
+//                binaries should run.
+// One can use the 10.12 SDK to deploy to earlier releases, like 10.11. The SDK
+// version determines if we even need to declare clock_gettime(), and the
+// deployment target determines if we can expect the user's system to
+// contain an implementation of clock_gettime().
+// We need both of these macros because developers may only have the 10.12 SDK,
+// but may want to use it to deploy to machines running 10.11.
+#define SimTK_APPLE_MUST_DECLARE_CLOCK_GETTIME defined(__APPLE__) && \
+    __MAC_OS_X_VERSION_MAX_ALLOWED < 101200
+
+#define SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME defined(__APPLE__) && \
+    __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
+
+
+
 #if defined(_MSC_VER)
     /* Posix nanosleep() sleeps the indicated number of nanoseconds and returns
     0, or if it is interrupted early it returns how much time was left in 
@@ -83,8 +116,8 @@ librt realtime library (-lrt). **/
     }
 #endif
 
-#if defined(_MSC_VER) || defined(__APPLE__)
-    // On Windows and OSX, the Posix clock_gettime function is missing.
+#if defined(_MSC_VER) || SimTK_APPLE_MUST_DECLARE_CLOCK_GETTIME
+    // On Windows and OSX < 10.12, the Posix clock_gettime function is missing.
     typedef long clockid_t;
 
     /* These constants are the clock ids we support. All the varieties of 

--- a/SimTKcommon/include/SimTKcommon/internal/Timing.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Timing.h
@@ -83,11 +83,11 @@ librt realtime library (-lrt). **/
 // The number 101200 identifies macOS version 10.12. The explicit version
 // number must be used instead of a macro like __MAC_10_12 because pre-10.12
 // systems won't have __MAC_10_12 defined.
-#define SimTK_IS_APPLE_AND_MUST_DECLARE_CLOCK_GETTIME defined(__APPLE__) && \
-    __MAC_OS_X_VERSION_MAX_ALLOWED < 101200 // SDK is older than 10.12.
+#define SimTK_IS_APPLE_AND_MUST_DECLARE_CLOCK_GETTIME (defined(__APPLE__) && \
+    __MAC_OS_X_VERSION_MAX_ALLOWED < 101200) // SDK is older than 10.12.
 
-#define SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME defined(__APPLE__) && \
-    __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 // user's OS may be pre-10.12.
+#define SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME (defined(__APPLE__) && \
+    __MAC_OS_X_VERSION_MIN_REQUIRED < 101200) // user's OS may be pre-10.12.
 
 
 

--- a/SimTKcommon/include/SimTKcommon/internal/Timing.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Timing.h
@@ -83,10 +83,10 @@ librt realtime library (-lrt). **/
 // The number 101200 identifies macOS version 10.12. The explicit version
 // number must be used instead of a macro like __MAC_10_12 because pre-10.12
 // systems won't have __MAC_10_12 defined.
-#define SimTK_APPLE_MUST_DECLARE_CLOCK_GETTIME defined(__APPLE__) && \
+#define SimTK_IS_APPLE_AND_MUST_DECLARE_CLOCK_GETTIME defined(__APPLE__) && \
     __MAC_OS_X_VERSION_MAX_ALLOWED < 101200 // SDK is older than 10.12.
 
-#define SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME defined(__APPLE__) && \
+#define SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME defined(__APPLE__) && \
     __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 // user's OS may be pre-10.12.
 
 
@@ -117,7 +117,7 @@ librt realtime library (-lrt). **/
     }
 #endif
 
-#if defined(_MSC_VER) || SimTK_APPLE_MUST_DECLARE_CLOCK_GETTIME
+#if defined(_MSC_VER) || SimTK_IS_APPLE_AND_MUST_DECLARE_CLOCK_GETTIME
     // On Windows and OSX < 10.12, the Posix clock_gettime function is missing.
     typedef long clockid_t;
 

--- a/SimTKcommon/src/Timing.cpp
+++ b/SimTKcommon/src/Timing.cpp
@@ -25,7 +25,7 @@
  * Defines any routines that have to be supplied to implement the features
  * promised in Timing.h. Currently this consists of faking up the
  * Posix timing routines when using the Microsoft Visual Studio C/C++
- * compiler cl on Windows, or when running on Mac OSX.
+ * compiler cl on Windows, or when running on Mac OSX 10.11 or older.
  */
 
 
@@ -48,7 +48,7 @@
     #define WIN32_LEAN_AND_MEAN
     #define NOMINMAX
     #include <Windows.h>
-#elif defined(__APPLE__)
+#elif SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME 
     #include <unistd.h>
     #include <sys/time.h>
     #include <mach/mach.h>
@@ -57,7 +57,7 @@
 
 // These local symbols are not needed on all platforms. Define them just
 // when needed to avoid "unused variable" warnings.
-#if defined(_MSC_VER) || defined(__APPLE__)
+#if defined(_MSC_VER) || SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME
     // There are a billion (1e9) nanoseconds in a second.
     static const long long NsPerSec = 1000000000LL;
 #endif
@@ -128,7 +128,7 @@
         filetimeToTimespec(ft, *tp);     // now in ns since 1-1-1970
         return 0;
     }
-#elif defined(__APPLE__)
+#elif SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME 
     static int getnstimeofday(struct timespec *tp) {
         if (!tp) return 0;
         struct timeval tod;
@@ -169,7 +169,7 @@
 
         return 0;
     }
-#elif defined(__APPLE__)
+#elif SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME 
     static int getperformancecounter(struct timespec *tp) {
         if (!tp) return 0;
 
@@ -208,7 +208,7 @@
         hectoNsToTimespec(ktime+utime, *tp);
         return 0;
     }
-#elif defined(__APPLE__)
+#elif SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME 
     static int getprocesscputime(struct timespec* tp) {
         if (!tp) return 0;
 
@@ -261,7 +261,7 @@
         hectoNsToTimespec(ktime+utime, *tp);
         return 0;
     }
-#elif defined(__APPLE__)
+#elif SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME 
     static int getthreadcputime(struct timespec* tp) {
         if (!tp) return 0;
 
@@ -291,7 +291,7 @@
 // int clock_gettime()
 // -------------------
 // Now define the Posix clock_gettime() function in terms of the above helpers.
-#if defined(_MSC_VER) || defined(__APPLE__)
+#if defined(_MSC_VER) || SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME 
     int clock_gettime (clockid_t clock_id, struct timespec *tp) {
         int retval = EINVAL;
 
@@ -301,7 +301,11 @@
             retval = getnstimeofday(tp);
             break;
         case CLOCK_MONOTONIC:
-        case CLOCK_MONOTONIC_HR:  // "high resolution"
+        #ifdef CLOCK_MONOTONIC_HR
+        case CLOCK_MONOTONIC_HR:  // "high resolution"; not defined on macOS if
+                                  // using SDK MacOSX10.12.sdk or greater with
+                                  // deployment target 10.11 or lower.
+        #endif
         case CLOCK_MONOTONIC_RAW: // "not subject to NTP adjustments"
             retval = getperformancecounter(tp);
             break;

--- a/SimTKcommon/src/Timing.cpp
+++ b/SimTKcommon/src/Timing.cpp
@@ -48,7 +48,7 @@
     #define WIN32_LEAN_AND_MEAN
     #define NOMINMAX
     #include <Windows.h>
-#elif SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME 
+#elif SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME 
     #include <unistd.h>
     #include <sys/time.h>
     #include <mach/mach.h>
@@ -57,7 +57,7 @@
 
 // These local symbols are not needed on all platforms. Define them just
 // when needed to avoid "unused variable" warnings.
-#if defined(_MSC_VER) || SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME
+#if defined(_MSC_VER) || SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME
     // There are a billion (1e9) nanoseconds in a second.
     static const long long NsPerSec = 1000000000LL;
 #endif
@@ -128,7 +128,7 @@
         filetimeToTimespec(ft, *tp);     // now in ns since 1-1-1970
         return 0;
     }
-#elif SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME 
+#elif SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME 
     static int getnstimeofday(struct timespec *tp) {
         if (!tp) return 0;
         struct timeval tod;
@@ -169,7 +169,7 @@
 
         return 0;
     }
-#elif SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME 
+#elif SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME 
     static int getperformancecounter(struct timespec *tp) {
         if (!tp) return 0;
 
@@ -208,7 +208,7 @@
         hectoNsToTimespec(ktime+utime, *tp);
         return 0;
     }
-#elif SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME 
+#elif SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME 
     static int getprocesscputime(struct timespec* tp) {
         if (!tp) return 0;
 
@@ -261,7 +261,7 @@
         hectoNsToTimespec(ktime+utime, *tp);
         return 0;
     }
-#elif SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME 
+#elif SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME 
     static int getthreadcputime(struct timespec* tp) {
         if (!tp) return 0;
 
@@ -291,7 +291,7 @@
 // int clock_gettime()
 // -------------------
 // Now define the Posix clock_gettime() function in terms of the above helpers.
-#if defined(_MSC_VER) || SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME 
+#if defined(_MSC_VER) || SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME 
     int clock_gettime (clockid_t clock_id, struct timespec *tp) {
         int retval = EINVAL;
 


### PR DESCRIPTION
This PR fixes #523: OSX previously did not provide `clock_gettime()`, but macOS 10.12 now does provide this function. This PR causes Simbody's version of `clock_gettime()` to only appear if using an older version of OSX.

### Background on OSX SDKs, etc.

There are two versions to consider here: the MacOSX SDK version used when compiling the source code, and the version of the OS on a user's computer (called the DEPLOYMENT_TARGET). Both the SDK and the OS version use the same numbering scheme (e.g., 10.10, 10.11, 10.12). A single SDK can be used to deploy to multiple different versions. For example, one can build Simbody with the 10.12 SDK and deploy those binaries to OSX 10.10, 10.11 (as well as 10.12). 

When a developer builds Simbody with CMake, they can specify:

1. **CMAKE_OSX_SYSROOT**: the SDK to use.
2. **CMAKE_OSX_DEPLOYMENT_TARGET**: the minimum version of OSX that users must have to use the resulting Simbody binaries.

The 10.12 SDK declares and defines `clock_gettime()`, and (as one would expect) 10.12 operating system provides `clock_gettime()` in a dynamic library (libSystemB.dylib maybe?).

With respect to this PR, this results in 3 scenarios:

1. **SDK version < 10.12 and DEPLOYMENT_TARGET < 10.12**: This is the old scenario. Simbody must provide `clock_gettime()`.
2. **SDK version >= 10.12 and DEPLOYMENT_TARGET >= 10.12**: This is the scenario that will be common for most users/developers pretty soon (in say a year?). And it is simple: Simbody should not declare or define `clock_gettime()`.
3. **SDK version >= 10.12 and DEPLOYMENT_TARGET < 10.12**: This is the nasty scenario, and it's the one I was in yesterday. Basically, the SDK declares `clock_gettime()`, but it may not be on the user's system. This occurs when developers update their Xcode to Xcode 8. Updating to Xcode 8 removes the previous SDKs (e.g., MacOSX10.11.sdk) and only leaves MacOSX10.12.sdk on the developer's machine. However, a developer with Xcode 8 on their machine is likely still interested in providing Simbody to users with OSX 10.11, etc. It is true that developers like me can go find MacOSX10.11.sdk online and download it again, but this is undesirable and we shouldn't force developers with Xcode 8 to fetch older SDKs.

(The scenario SDK version < 10.12 and DEPLOYMENT_TARGET >= 10.12 doesn't make sense. SDKs cannot target future versions of OSX)

### Changes in this PR

This PR introduces two macros that control how Simbody builds:

1. (DECLARE) **SimTK_IS_APPLE_AND_MUST_DECLARE_CLOCK_GETTIME**: This is true if the SDK version is older than 10.12, as such SDKs do not declare clock_gettime(). The 10.12 SDK declares `clock_gettime()`, so we don't need to declare it again. In fact, we can't declare it again because  `clockid_t` is different in Simbody's implementation as compared to Apple's implementation: Simbody uses `typedef long clockid_t`, while Apple uses an enum.
2. (DEFINE) **SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME**: This is true if the DEPLOYMENT_TARGET is older than 10.12: if we want to allow users with OSX 10.10 or 10.11 to use Simbody, we must define `clock_gettime()`.

I use `*_DECLARE_*` to decide if we should declare `clock_gettime()` in Timing.h and I use `*_DEFINE_*` to decide if we should define clock_gettime (and related functions) in Timing.cpp.

### Testing

I tested scenarios (2) and (3) above locally. On a computer with OSX 10.11, I upgraded to Xcode 8 and used the MacOSX10.12.sdk, and was able to run the tests successfully. Then I upgraded my computer to macOS 10.12 and was again able to run the tests successfully. Travis tests scenario (1), since travis is using an older OSX with an older Xcode.

