### PR TITLE
Port macOS clock_gettime() fix to 3.5 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@ Simbody Changelog and Release Notes
 
 This is not a comprehensive list of changes but rather a hand-curated collection of the more notable ones. For a comprehensive history, see the [Simbody GitHub repo](https://github.com/simbody/simbody). You can use the release dates below to find all the PRs and issues that were included in a particular release. 
 
-**Heads up**: Simbody 3.5 will be the last release that will build with C++03 (patch builds with version numbers like 3.5.1, if any, will work too). For 3.6 and above we will permit Simbody developers to use C++11, restricted to the subset that is currently supported on all our platforms. Since the C++03 and C++11 ABIs are not compatible, code that uses Simbody 3.6 will also have to be built with C++11. Time to move up, if you haven't already!
+**Heads up**: Simbody 3.5 will be the last release that will build with C++03 (patch builds with version numbers like 3.5.1 will work too). For 3.6 and above we will permit Simbody developers to use C++11, restricted to the subset that is currently supported on all our platforms. Since the C++03 and C++11 ABIs are not compatible, code that uses Simbody 3.6 will also have to be built with C++11. Time to move up, if you haven't already!
+
+3.5.4 (in development)
+----------------------
+* Fixed a bug when compiling on macOS (OSX) with SDK MacOSX10.12.sdk, related
+  to the POSIX function `clock_gettime()` (Issue
+  [#523](https://github.com/simbody/simbody/issues/523)).
 
 3.5.3 (15 June 2015)
 -------------------

--- a/SimTKcommon/include/SimTKcommon/internal/Timing.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Timing.h
@@ -83,11 +83,11 @@ librt realtime library (-lrt). **/
 // The number 101200 identifies macOS version 10.12. The explicit version
 // number must be used instead of a macro like __MAC_10_12 because pre-10.12
 // systems won't have __MAC_10_12 defined.
-#define SimTK_IS_APPLE_AND_MUST_DECLARE_CLOCK_GETTIME defined(__APPLE__) && \
-    __MAC_OS_X_VERSION_MAX_ALLOWED < 101200 // SDK is older than 10.12.
+#define SimTK_IS_APPLE_AND_MUST_DECLARE_CLOCK_GETTIME (defined(__APPLE__) && \
+    __MAC_OS_X_VERSION_MAX_ALLOWED < 101200) // SDK is older than 10.12.
 
-#define SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME defined(__APPLE__) && \
-    __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 // user's OS may be pre-10.12.
+#define SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME (defined(__APPLE__) && \
+    __MAC_OS_X_VERSION_MIN_REQUIRED < 101200) // user's OS may be pre-10.12.
 
 
 

--- a/SimTKcommon/include/SimTKcommon/internal/Timing.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Timing.h
@@ -83,10 +83,10 @@ librt realtime library (-lrt). **/
 // The number 101200 identifies macOS version 10.12. The explicit version
 // number must be used instead of a macro like __MAC_10_12 because pre-10.12
 // systems won't have __MAC_10_12 defined.
-#define SimTK_APPLE_MUST_DECLARE_CLOCK_GETTIME defined(__APPLE__) && \
+#define SimTK_IS_APPLE_AND_MUST_DECLARE_CLOCK_GETTIME defined(__APPLE__) && \
     __MAC_OS_X_VERSION_MAX_ALLOWED < 101200 // SDK is older than 10.12.
 
-#define SimTK_APPLE_MUST_DEFINE_CLOCK_GETTIME defined(__APPLE__) && \
+#define SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME defined(__APPLE__) && \
     __MAC_OS_X_VERSION_MIN_REQUIRED < 101200 // user's OS may be pre-10.12.
 
 
@@ -117,8 +117,8 @@ librt realtime library (-lrt). **/
     }
 #endif
 
-#if defined(_MSC_VER) || defined(__APPLE__)
-    // On Windows and OSX, the Posix clock_gettime function is missing.
+#if defined(_MSC_VER) || SimTK_IS_APPLE_AND_MUST_DECLARE_CLOCK_GETTIME
+    // On Windows and OSX < 10.12, the Posix clock_gettime function is missing.
     typedef long clockid_t;
 
     /* These constants are the clock ids we support. All the varieties of 

--- a/SimTKcommon/src/Timing.cpp
+++ b/SimTKcommon/src/Timing.cpp
@@ -48,7 +48,7 @@
     #define WIN32_LEAN_AND_MEAN
     #define NOMINMAX
     #include <Windows.h>
-#elif defined(__APPLE__)
+#elif SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME 
     #include <unistd.h>
     #include <sys/time.h>
     #include <mach/mach.h>
@@ -57,7 +57,7 @@
 
 // These local symbols are not needed on all platforms. Define them just
 // when needed to avoid "unused variable" warnings.
-#if defined(_MSC_VER) || defined(__APPLE__)
+#if defined(_MSC_VER) || SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME
     // There are a billion (1e9) nanoseconds in a second.
     static const long long NsPerSec = 1000000000LL;
 #endif
@@ -128,7 +128,7 @@
         filetimeToTimespec(ft, *tp);     // now in ns since 1-1-1970
         return 0;
     }
-#elif defined(__APPLE__)
+#elif SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME 
     static int getnstimeofday(struct timespec *tp) {
         if (!tp) return 0;
         struct timeval tod;
@@ -169,7 +169,7 @@
 
         return 0;
     }
-#elif defined(__APPLE__)
+#elif SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME 
     static int getperformancecounter(struct timespec *tp) {
         if (!tp) return 0;
 
@@ -208,7 +208,7 @@
         hectoNsToTimespec(ktime+utime, *tp);
         return 0;
     }
-#elif defined(__APPLE__)
+#elif SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME 
     static int getprocesscputime(struct timespec* tp) {
         if (!tp) return 0;
 
@@ -261,7 +261,7 @@
         hectoNsToTimespec(ktime+utime, *tp);
         return 0;
     }
-#elif defined(__APPLE__)
+#elif SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME 
     static int getthreadcputime(struct timespec* tp) {
         if (!tp) return 0;
 
@@ -291,7 +291,7 @@
 // int clock_gettime()
 // -------------------
 // Now define the Posix clock_gettime() function in terms of the above helpers.
-#if defined(_MSC_VER) || defined(__APPLE__)
+#if defined(_MSC_VER) || SimTK_IS_APPLE_AND_MUST_DEFINE_CLOCK_GETTIME 
     int clock_gettime (clockid_t clock_id, struct timespec *tp) {
         int retval = EINVAL;
 

--- a/SimTKcommon/src/Timing.cpp
+++ b/SimTKcommon/src/Timing.cpp
@@ -25,7 +25,7 @@
  * Defines any routines that have to be supplied to implement the features
  * promised in Timing.h. Currently this consists of faking up the
  * Posix timing routines when using the Microsoft Visual Studio C/C++
- * compiler cl on Windows, or when running on Mac OSX.
+ * compiler cl on Windows, or when running on Mac OSX 10.11 or older.
  */
 
 
@@ -301,7 +301,11 @@
             retval = getnstimeofday(tp);
             break;
         case CLOCK_MONOTONIC:
-        case CLOCK_MONOTONIC_HR:  // "high resolution"
+        #ifdef CLOCK_MONOTONIC_HR
+        case CLOCK_MONOTONIC_HR:  // "high resolution"; not defined on macOS if
+                                  // using SDK MacOSX10.12.sdk or greater with
+                                  // deployment target 10.11 or lower.
+        #endif
         case CLOCK_MONOTONIC_RAW: // "not subject to NTP adjustments"
             retval = getperformancecounter(tp);
             break;


### PR DESCRIPTION
This PR ports the fix from #524 to the 3.5 branch. 

OpenSim 3.3 depends on Simbody 3.5.3, and is not compatible with Simbody 3.6. Since we expect OpenSim users to use Xcode 8 before OpenSim 4.0 will be released, it would be helpful to create a 3.5.4 bug fix release for OpenSim users who want to use OpenSim 3.3 with Xcode 8 (and thus the MacOSX10.12.sdk).