### PR TITLE
Mention macOS clock_gettime() fix in CHANGELOG (master branch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Simbody Changelog and Release Notes
 
 This is not a comprehensive list of changes but rather a hand-curated collection of the more notable ones. For a comprehensive history, see the [Simbody GitHub repo](https://github.com/simbody/simbody). You can use the release dates below to find all the PRs and issues that were included in a particular release. 
 
-**Heads up**: Simbody 3.5 was the last release that will build with C++03 (patch builds with version numbers like 3.5.1, if any, will work too). For 3.6 and above we will permit Simbody developers to use C++11, restricted to the subset that is currently supported on all our platforms. Since the C++03 and C++11 ABIs are not compatible, code that uses Simbody 3.6 will also have to be built with C++11. Time to move up, if you haven't already!
+**Heads up**: Simbody 3.5 was the last release that will build with C++03 (patch builds with version numbers like 3.5.1, will work too). For 3.6 and above we will permit Simbody developers to use C++11, restricted to the subset that is currently supported on all our platforms. Since the C++03 and C++11 ABIs are not compatible, code that uses Simbody 3.6 will also have to be built with C++11. Time to move up, if you haven't already!
 
 
 3.6 (in development)
@@ -72,6 +72,10 @@ to ParallelExecutor, mutex state lock.
 * Started using RPATH on OSX so that users need not set `DYLD_LIBRARY_PATH` to
   run `simbody-visualizer` or the example executables, regardless of where you
   install Simbody.
+* Fixed a bug when compiling on macOS (OSX) with SDK MacOSX10.12.sdk, related
+  to the POSIX function `clock_gettime()`.
+  [Issue #523](https://github.com/simbody/simbody/issues/523),
+  [PR 524](#https://github.com/simbody/simbody/pull/524)
 * (There are more that haven't been added yet)
 
 


### PR DESCRIPTION
This PR mentions the fix from #524 in the CHANGELOG, for the master branch (3.6 development).