### PR TITLE
Update version to 3.5.4. Prepare CHANGELOG.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 **Heads up**: Simbody 3.5 will be the last release that will build with C++03 (patch builds with version numbers like 3.5.1 will work too). For 3.6 and above we will permit Simbody developers to use C++11, restricted to the subset that is currently supported on all our platforms. Since the C++03 and C++11 ABIs are not compatible, code that uses Simbody 3.6 will also have to be built with C++11. Time to move up, if you haven't already!
 
-3.5.4 (in development)
-----------------------
+3.5.4 (30 Sep 2016)
+-------------------
 * Fixed a bug when compiling on macOS (OSX) with SDK MacOSX10.12.sdk, related
   to the POSIX function `clock_gettime()` (Issue
   [#523](https://github.com/simbody/simbody/issues/523)).

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ All needed library dependencies are provided with the Simbody installation on Wi
     2. Clone the github repository into `C:/Simbody-source`. Run the following in a Git Bash / Git Shell, or find a way to run the equivalent commands in a GUI client:
 
             $ git clone https://github.com/simbody/simbody.git C:/Simbody-source
-            $ git checkout Simbody-3.5.3
+            $ git checkout Simbody-3.5.4
 
     3. In the last line above, we assumed you want to build a released version. Feel free to change the version you want to build. If you want to build the latest development version ("bleeding edge") of Simbody off the master branch, you can omit the `checkout` line.
 
@@ -247,7 +247,7 @@ There are two ways to get the source code.
     2. Clone the github repository into `~/simbody-source`.
 
             $ git clone https://github.com/simbody/simbody.git ~/simbody-source
-            $ git checkout Simbody-3.5.3
+            $ git checkout Simbody-3.5.4
 
     3. In the last line above, we assumed you want to build a released version. Feel free to change the version you want to build. If you want to build the latest development version ("bleeding edge") of Simbody off the master branch, you can omit the `checkout` line.
 
@@ -400,7 +400,7 @@ With this method, Simbody is built with C++11 (the `-std=c++11` compiler flag). 
 
 #### Where is Simbody installed?
 
-Simbody is now installed to `/usr/local/Cellar/simbody/<version>/`, where `<version>` is either the version number (e.g., `3.5.3`), or `HEAD` if you specified `--HEAD` above.
+Simbody is now installed to `/usr/local/Cellar/simbody/<version>/`, where `<version>` is either the version number (e.g., `3.5.4`), or `HEAD` if you specified `--HEAD` above.
 
 Some directories are symlinked (symbolically linked) to `/usr/local/`, which is where your system typically expects to find executables, shared libraries (.dylib's), headers (.h's), etc. The following directories from the Simbody installation are symlinked:
 


### PR DESCRIPTION
This PR changes the version number that is mentioned in a few files to 3.5.4. The root CMakeLists.txt already lists the version as 3.5.4. I also updated to changelog to no longer say "in development" for 3.5.4. I also put today's date as the release date for 3.5.4.

As soon as this PR is merged:
- Locally, I will tag the resulting merge commit as `Simbody-3.5.4`. I will use an [annotated tag](https://git-scm.com/book/en/v2/Git-Basics-Tagging#Annotated-Tags), using the release notes as the annotation.
- I will push that tag up to this repo. No PR necesasry.
- I will check the GitHub "Releases" page to make sure the release notes show up properly from the annotation. If the notes do not show up properly, I will clean them up.
- I will make a new PR to change the version number in CMakeLists.txt to 3.5.5.

I will also:
- Update OpenSim's build-from-source instructions [here](http://simtk-confluence.stanford.edu:8080/display/OpenSim/Building+OpenSim+from+Source).