### PR TITLE
simbody.pc.in: include dir to match cmake config

### DIFF
--- a/cmake/pkgconfig/simbody.pc.in
+++ b/cmake/pkgconfig/simbody.pc.in
@@ -1,6 +1,6 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+includedir=${prefix}/@SIMBODY_INCLUDE_INSTALL_DIR@
 
 Name: simbody
 Description: Simbody Libraries


### PR DESCRIPTION
The cmake config file defines `Simbody_INCLUDE_DIR` as [PACKAGE_SIMBODY_INCLUDE_INSTALL_DIR](https://github.com/simbody/simbody/blob/master/cmake/SimbodyConfig.cmake.in#L38-L39), which is set to [${CMAKE_INSTALL_INCLUDEDIR}/simbody](https://github.com/simbody/simbody/blob/master/CMakeLists.txt#L578), but the pkg-config file sets it to just the include folder.