### PR TITLE
Removed unused variable in ContactTest.cpp

### DIFF
--- a/Simbody/tests/adhoc/ContactTest.cpp
+++ b/Simbody/tests/adhoc/ContactTest.cpp
@@ -303,7 +303,6 @@ try
                           pend2, Vec3(0,-linkLength/2,0), rbProto);
 
     mbs.realizeModel(s);
-    bool suppressProjection = false;
 
     //RungeKuttaMersonIntegrator ee(mbs); const Real Accuracy = .02;
 


### PR DESCRIPTION
Unused variable detected with GCC4.9.2

    ContactTest.cpp:306:10: warning: unused variable 'suppressProjection' [-Wunused-variable]
     bool suppressProjection = false;
          ^