### PR TITLE
Avoid exception in Visualizer::Impl::~Impl().

### DIFF
--- a/Simbody/Visualizer/src/Visualizer.cpp
+++ b/Simbody/Visualizer/src/Visualizer.cpp
@@ -144,8 +144,13 @@ public:
         pthread_cond_destroy(&m_queueNotFull);
         pthread_mutex_destroy(&m_queueLock);
 
-        if (m_shutdownWhenDestructed)
-            m_protocol.shutdownGUI();
+        if (m_shutdownWhenDestructed) {
+            try {
+                // This throws an exception if the pipe is broken (e.g., if the
+                // simbody-visualizer has already been shut down).
+                m_protocol.shutdownGUI();
+            } catch (...) {}
+        }
     }
 
     void setShutdownWhenDestructed(bool shouldShutdown)


### PR DESCRIPTION
This exception, which occurred when destructing a model whose
simbody-visualizer was already shutdown, was causing OpenSim's MATLAB and
Python bindings to crash.

I imagine that if we are destructing the Visualizer, it is fine if there is difficulty sending the shutdown signal to the simbody-visualizer GUI.