### PR TITLE
Remove need for users to `include_directories(${Simbody_INCLUDE_DIR})`

### DIFF
--- a/SimTKcommon/sharedTarget/CMakeLists.txt
+++ b/SimTKcommon/sharedTarget/CMakeLists.txt
@@ -27,7 +27,7 @@ if(BUILD_UNVERSIONED_LIBRARIES)
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
     if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
-        # This removes the need for downstream projects to use
+        # This removes the need for client projects to use
         # `include_directories(${Simbody_INCLUDE_DIR})`. However, this ability
         # was only introduced in CMake 3.0.
         target_include_directories(${SHARED_TARGET} INTERFACE

--- a/SimTKcommon/sharedTarget/CMakeLists.txt
+++ b/SimTKcommon/sharedTarget/CMakeLists.txt
@@ -25,6 +25,16 @@ if(BUILD_UNVERSIONED_LIBRARIES)
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+
+    if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
+        # This removes the need for downstream projects to use
+        # `include_directories(${Simbody_INCLUDE_DIR})`. However, this ability
+        # was only introduced in CMake 3.0.
+        target_include_directories(${SHARED_TARGET} INTERFACE
+            $<INSTALL_INTERFACE:${SIMBODY_INCLUDE_INSTALL_DIR}>
+            )
+    endif()
+
 endif(BUILD_UNVERSIONED_LIBRARIES)
 
 if(BUILD_VERSIONED_LIBRARIES)
@@ -49,6 +59,13 @@ if(BUILD_VERSIONED_LIBRARIES)
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+
+    if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
+        target_include_directories(${SHARED_TARGET_VN} INTERFACE
+            $<INSTALL_INTERFACE:${SIMBODY_INCLUDE_INSTALL_DIR}>
+            )
+    endif()
+
 endif(BUILD_VERSIONED_LIBRARIES)
 
 

--- a/SimTKcommon/staticTarget/CMakeLists.txt
+++ b/SimTKcommon/staticTarget/CMakeLists.txt
@@ -21,6 +21,15 @@ if(BUILD_UNVERSIONED_LIBRARIES)
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+
+    if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
+        # This removes the need for downstream projects to use
+        # `include_directories(${Simbody_INCLUDE_DIR})`. However, this ability
+        # was only introduced in CMake 3.0.
+        target_include_directories(${STATIC_TARGET} INTERFACE
+            $<INSTALL_INTERFACE:${SIMBODY_INCLUDE_INSTALL_DIR}>
+            )
+    endif()
 endif(BUILD_UNVERSIONED_LIBRARIES)
 
 if(BUILD_VERSIONED_LIBRARIES)
@@ -40,4 +49,10 @@ if(BUILD_VERSIONED_LIBRARIES)
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
+
+    if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
+        target_include_directories(${STATIC_TARGET_VN} INTERFACE
+            $<INSTALL_INTERFACE:${SIMBODY_INCLUDE_INSTALL_DIR}>
+            )
+    endif()
 endif(BUILD_VERSIONED_LIBRARIES)

--- a/SimTKcommon/staticTarget/CMakeLists.txt
+++ b/SimTKcommon/staticTarget/CMakeLists.txt
@@ -23,7 +23,7 @@ if(BUILD_UNVERSIONED_LIBRARIES)
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} )
 
     if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
-        # This removes the need for downstream projects to use
+        # This removes the need for client projects to use
         # `include_directories(${Simbody_INCLUDE_DIR})`. However, this ability
         # was only introduced in CMake 3.0.
         target_include_directories(${STATIC_TARGET} INTERFACE

--- a/SimTKmath/sharedTarget/CMakeLists.txt
+++ b/SimTKmath/sharedTarget/CMakeLists.txt
@@ -48,7 +48,7 @@ if(BUILD_UNVERSIONED_LIBRARIES)
                      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
     if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
-        # This removes the need for downstream projects to use
+        # This removes the need for client projects to use
         # `include_directories(${Simbody_INCLUDE_DIR})`. However, this ability
         # was only introduced in CMake 3.0.
         target_include_directories(${SHARED_TARGET} INTERFACE

--- a/SimTKmath/sharedTarget/CMakeLists.txt
+++ b/SimTKmath/sharedTarget/CMakeLists.txt
@@ -47,6 +47,15 @@ if(BUILD_UNVERSIONED_LIBRARIES)
                      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+    if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
+        # This removes the need for downstream projects to use
+        # `include_directories(${Simbody_INCLUDE_DIR})`. However, this ability
+        # was only introduced in CMake 3.0.
+        target_include_directories(${SHARED_TARGET} INTERFACE
+            $<INSTALL_INTERFACE:${SIMBODY_INCLUDE_INSTALL_DIR}>
+            )
+    endif()
+
 endif(BUILD_UNVERSIONED_LIBRARIES)
 
 
@@ -72,5 +81,11 @@ if(BUILD_VERSIONED_LIBRARIES)
                      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+    if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
+        target_include_directories(${SHARED_TARGET_VN} INTERFACE
+            $<INSTALL_INTERFACE:${SIMBODY_INCLUDE_INSTALL_DIR}>
+            )
+    endif()
 
 endif(BUILD_VERSIONED_LIBRARIES)

--- a/SimTKmath/staticTarget/CMakeLists.txt
+++ b/SimTKmath/staticTarget/CMakeLists.txt
@@ -49,7 +49,7 @@ if(BUILD_UNVERSIONED_LIBRARIES)
                      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
     if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
-        # This removes the need for downstream projects to use
+        # This removes the need for client projects to use
         # `include_directories(${Simbody_INCLUDE_DIR})`. However, this ability
         # was only introduced in CMake 3.0.
         target_include_directories(${STATIC_TARGET} INTERFACE

--- a/SimTKmath/staticTarget/CMakeLists.txt
+++ b/SimTKmath/staticTarget/CMakeLists.txt
@@ -48,6 +48,15 @@ if(BUILD_UNVERSIONED_LIBRARIES)
                      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+    if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
+        # This removes the need for downstream projects to use
+        # `include_directories(${Simbody_INCLUDE_DIR})`. However, this ability
+        # was only introduced in CMake 3.0.
+        target_include_directories(${STATIC_TARGET} INTERFACE
+            $<INSTALL_INTERFACE:${SIMBODY_INCLUDE_INSTALL_DIR}>
+            )
+    endif()
+
 endif(BUILD_UNVERSIONED_LIBRARIES)
 
 
@@ -72,5 +81,11 @@ if(BUILD_VERSIONED_LIBRARIES)
                      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+    if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
+        target_include_directories(${STATIC_TARGET_VN} INTERFACE
+            $<INSTALL_INTERFACE:${SIMBODY_INCLUDE_INSTALL_DIR}>
+            )
+    endif()
 
 endif(BUILD_VERSIONED_LIBRARIES)

--- a/Simbody/sharedTarget/CMakeLists.txt
+++ b/Simbody/sharedTarget/CMakeLists.txt
@@ -29,7 +29,7 @@ if(BUILD_UNVERSIONED_LIBRARIES)
                      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     
     if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
-        # This removes the need for downstream projects to use
+        # This removes the need for client projects to use
         # `include_directories(${Simbody_INCLUDE_DIR})`. However, this ability
         # was only introduced in CMake 3.0.
         target_include_directories(${SHARED_TARGET} INTERFACE

--- a/Simbody/sharedTarget/CMakeLists.txt
+++ b/Simbody/sharedTarget/CMakeLists.txt
@@ -28,6 +28,14 @@ if(BUILD_UNVERSIONED_LIBRARIES)
                      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
     
+    if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
+        # This removes the need for downstream projects to use
+        # `include_directories(${Simbody_INCLUDE_DIR})`. However, this ability
+        # was only introduced in CMake 3.0.
+        target_include_directories(${SHARED_TARGET} INTERFACE
+            $<INSTALL_INTERFACE:${SIMBODY_INCLUDE_INSTALL_DIR}>
+            )
+    endif()
 
 endif(BUILD_UNVERSIONED_LIBRARIES)
 
@@ -56,5 +64,11 @@ if(BUILD_VERSIONED_LIBRARIES)
                      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    
+    if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
+        target_include_directories(${SHARED_TARGET_VN} INTERFACE
+            $<INSTALL_INTERFACE:${SIMBODY_INCLUDE_INSTALL_DIR}>
+            )
+    endif()
         
 endif(BUILD_VERSIONED_LIBRARIES)

--- a/Simbody/staticTarget/CMakeLists.txt
+++ b/Simbody/staticTarget/CMakeLists.txt
@@ -28,6 +28,15 @@ if(BUILD_UNVERSIONED_LIBRARIES)
                      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+    if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
+        # This removes the need for downstream projects to use
+        # `include_directories(${Simbody_INCLUDE_DIR})`. However, this ability
+        # was only introduced in CMake 3.0.
+        target_include_directories(${STATIC_TARGET} INTERFACE
+            $<INSTALL_INTERFACE:${SIMBODY_INCLUDE_INSTALL_DIR}>
+            )
+    endif()
+
 endif(BUILD_UNVERSIONED_LIBRARIES)
 
 
@@ -55,5 +64,11 @@ if(BUILD_VERSIONED_LIBRARIES)
                      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
                      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
                      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+    if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
+        target_include_directories(${STATIC_TARGET_VN} INTERFACE
+            $<INSTALL_INTERFACE:${SIMBODY_INCLUDE_INSTALL_DIR}>
+            )
+    endif()
 
 endif(BUILD_VERSIONED_LIBRARIES)

--- a/Simbody/staticTarget/CMakeLists.txt
+++ b/Simbody/staticTarget/CMakeLists.txt
@@ -29,7 +29,7 @@ if(BUILD_UNVERSIONED_LIBRARIES)
                      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
     if(NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2)
-        # This removes the need for downstream projects to use
+        # This removes the need for client projects to use
         # `include_directories(${Simbody_INCLUDE_DIR})`. However, this ability
         # was only introduced in CMake 3.0.
         target_include_directories(${STATIC_TARGET} INTERFACE

--- a/cmake/SampleCMakeLists.txt
+++ b/cmake/SampleCMakeLists.txt
@@ -15,7 +15,7 @@ set(my_header_files myexe.h)
 # able to guess, you'll need to tell find_package where to look.
 find_package(Simbody REQUIRED)
 
-# This is only necesasry if Simbody was built using CMake older than 3.0.2.
+# This is only necessary if Simbody was built using CMake older than 3.0.2.
 include_directories(${Simbody_INCLUDE_DIR})
 
 add_executable(myexe ${my_source_files} ${my_header_files})

--- a/cmake/SampleCMakeLists.txt
+++ b/cmake/SampleCMakeLists.txt
@@ -15,6 +15,7 @@ set(my_header_files myexe.h)
 # able to guess, you'll need to tell find_package where to look.
 find_package(Simbody REQUIRED)
 
+# This is only necesasry if Simbody was built using CMake older than 3.0.2.
 include_directories(${Simbody_INCLUDE_DIR})
 
 add_executable(myexe ${my_source_files} ${my_header_files})


### PR DESCRIPTION
This PR makes CMake export the directories that should be included by client projects. Therefore, client projects need only `target_link_libraries(<target> SimTKsimbody)` and their library/executable will have Simbody's include directory.

This will be helpful for OpenSim users, who might not expect the need to handle both OpenSim's and Simbody's include directories.