### PR TITLE
Upon shutting down the visualizer GUI, stop listening for GUI events

### DIFF
--- a/Simbody/Visualizer/src/VisualizerProtocol.cpp
+++ b/Simbody/Visualizer/src/VisualizerProtocol.cpp
@@ -168,6 +168,9 @@ static void readDataFromPipe(int srcPipe, unsigned char* buffer, int bytes) {
     int totalRead = 0;
     int oldCancelType;
     while (totalRead < bytes) {
+        // Changing the cancel type is a workaround for Windows, which does not
+        // mark system calls as "cancellation points"; see:
+        // https://www.sourceware.org/pthreads-win32/manual/pthread_cancel.html
         pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &oldCancelType);
         totalRead += READ(srcPipe, buffer + totalRead, bytes - totalRead);
         pthread_setcanceltype(oldCancelType, NULL);

--- a/Simbody/Visualizer/src/VisualizerProtocol.h
+++ b/Simbody/Visualizer/src/VisualizerProtocol.h
@@ -159,6 +159,7 @@ private:
     // assigned visualizer cache index.
     mutable std::map<const void*, unsigned short> meshes;
     mutable pthread_mutex_t sceneLock;
+    mutable pthread_t eventListenerThread;
 };
 }
 


### PR DESCRIPTION
This PR solves an issue that occurs when using OpenSim bindings in MATLAB with the Simbody Visualizer: MATLAB uses 100% CPU even after the OpenSim model (and thus the `SimTK::Visualizer`) is destructed. This was because the visualizer spawns a thread to listen to GUI events and this thread is not cancelled after destructing the visualizer. This PR causes shutting down the visualizer to cancel the event listening thread.

Due to an issue with the POSIX Threads for Windows library, we had to surround `READ` with some additional pthreads code; see [here](https://www.sourceware.org/pthreads-win32/manual/pthread_cancel.html):

> POSIX specifies that a number of system calls (basically, all system calls that may block, such as read(2) , write(2) , wait(2) , etc.) and library functions that may call these system calls (e.g. fprintf(3) ) are cancellation points. Pthreads-win32 is not integrated enough with the C library to implement this, and thus none of the C library functions is a cancellation point.

> A workaround for these calls is to temporarily switch to asynchronous cancellation (assuming full asynchronous cancellation support is installed). So, checking for cancellation during a read system call, for instance, can be achieved as follows:

> 
```c++
pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, &oldCancelType);
read(fd, buffer, length);
pthread_setcanceltype(oldCancelType, NULL);
```

@carmichaelong and I worked on this together. However, neither of us are very familiar with pthreads; if there is a better solution, please let us know. We considered having the GUI send a signal telling the thread to `pthread_exit()`, but that seemed roundabout (the simulator telling the visualizer to tell the simulator's listener to exit).

We have tested this locally on Windows and macOS, and have verified that multiple examples still work as expected.