### PR TITLE
Visualizer relative search path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ to ParallelExecutor, mutex state lock.
 * Started using RPATH on OSX so that users need not set `DYLD_LIBRARY_PATH` to
   run `simbody-visualizer` or the example executables, regardless of where you
   install Simbody.
+* Improved the ability to find the simbody-visualizer executable when Simbody
+  is installed in non-standard locations or if the Simbody installation is
+  relocated (even to different computers). This enhancement is only for
+  non-Windows operating systems.
 * Fixed a bug when compiling on macOS (OSX) with SDK MacOSX10.12.sdk, related
   to the POSIX function `clock_gettime()`.
   [Issue #523](https://github.com/simbody/simbody/issues/523),

--- a/SimTKcommon/include/SimTKcommon/internal/Pathname.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Pathname.h
@@ -265,6 +265,23 @@ public:
     /// Get the absolute pathname of the directory which contains the 
     /// currently executing program.
     static std::string getThisExecutableDirectory();
+    /// Get the absolute pathname of the directory which contains the
+    /// library/binary from which func was loaded. It is expected that func
+    /// is defined in a dynamically-linked library; if func was statically
+    /// linked into another binary, then this may provide the directory
+    /// containing that binary. The function returns true if the pathname was
+    /// successfully found, and false otherwise. This operation is not 
+    /// available on Windows. Here's an example of getting the directory 
+    /// containing the SimTKcommon library: 
+    /// @code
+    /// std::string libDir;
+    /// if (Pathname::getFunctionLibraryDirectory(
+    ///                 (void*)Pathname::getPathSeparator, libraryDir)) {
+    ///     std::cout << "SimTKcommon is located in " << libDir << std::endl;
+    /// }
+    /// @endcode
+    static bool getFunctionLibraryDirectory(void* func,
+                                            std::string& absolutePathname);
     /// Get the absolute pathname of the current working directory
     /// including a trailing separator character. Windows keeps a current
     /// working directory for each drive which can be optionally specified

--- a/SimTKcommon/src/Pathname.cpp
+++ b/SimTKcommon/src/Pathname.cpp
@@ -467,7 +467,9 @@ bool Pathname::getFunctionLibraryDirectory(void* func,
     #if defined(_WIN32)
         return false;
     #else
-        // Dl_info and dladdr are defined in dlfcn.h
+        // Dl_info and dladdr are defined in dlfcn.h. dladdr() is not POSIX,
+        // but is provided on macOS and in Glibc (at least on Ubuntu). It is
+        // likely not available on all UNIX variants.
         Dl_info dl_info;
         int status = dladdr(func, &dl_info);
         // Returns 0 on error, non-zero on success.

--- a/SimTKcommon/src/Pathname.cpp
+++ b/SimTKcommon/src/Pathname.cpp
@@ -462,6 +462,27 @@ string Pathname::getThisExecutableDirectory() {
     return path;
 }
 
+bool Pathname::getFunctionLibraryDirectory(void* func,
+                                           std::string& path) {
+    #if defined(_WIN32)
+        return false;
+    #else
+        // Dl_info and dladdr are defined in dlfcn.h
+        Dl_info dl_info;
+        int status = dladdr(func, &dl_info);
+        // Returns 0 on error, non-zero on success.
+        if (status == 0) return false;
+
+        // At first, this contains the path to the library file.
+        path = std::string(dl_info.dli_fname);
+        // Remove the filename.
+        std::string component; // not used.
+        removeLastPathComponentInPlace(path, component);
+        path += MyPathSeparator;
+        return true;
+    #endif
+}
+
 string Pathname::getCurrentDriveLetter() {
     #ifdef _WIN32
         const int which = _getdrive();

--- a/SimTKcommon/tests/TestPlugin.cpp
+++ b/SimTKcommon/tests/TestPlugin.cpp
@@ -168,6 +168,23 @@ void testPathname() {
     SimTK_TEST(Pathname::getRootDirectory() == "/");
 #endif
 
+    // Pathname::getFunctionLibraryDirectory().
+    std::string libraryPath;
+    bool status = Pathname::getFunctionLibraryDirectory(
+                (void*)Pathname::getPathSeparator,
+                libraryPath);
+    #ifdef _WIN32
+        // Always returns false; unsupported on Windows.
+        SimTK_TEST(status == false);
+    #else
+        SimTK_TEST(status == true);
+        // For TestPluginStatic, dladdr finds the path to TestPluginStatic
+        // (rather than to a library).
+        std::cout << "Pathname::getFunctionLibraryDirectory() is located in: "
+                  << libraryPath << std::endl;
+    #endif
+
+
     std::string name;
     bool isAbsPath;
     std::string directory, fileName, extension;

--- a/Simbody/CMakeLists.txt
+++ b/Simbody/CMakeLists.txt
@@ -128,6 +128,14 @@ install(FILES ${SIMBODY_DOCS} DESTINATION ${CMAKE_INSTALL_DOCDIR})
 # SIMBODY_VISUALIZER_INSTALL_DIR defined in root CMakeLists.txt
 add_definitions(-DSIMBODY_VISUALIZER_INSTALL_DIR="${SIMBODY_VISUALIZER_INSTALL_DIR}/")
 add_definitions(-DSIMBODY_VISUALIZER_REL_INSTALL_DIR="${SIMBODY_VISUALIZER_REL_INSTALL_DIR}/")
+# Create a relative path from lib dir to dir containing simbody-visualizer;
+# this is used in VisualizerProtocol.cpp (though, only useful on non-Windows).
+file(RELATIVE_PATH lib_dir_to_install_dir
+    "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}" "${CMAKE_INSTALL_PREFIX}")
+set(lib_dir_to_viz_dir
+    "${lib_dir_to_install_dir}${SIMBODY_VISUALIZER_REL_INSTALL_DIR}")
+add_definitions(
+    -DSIMBODY_PATH_FROM_LIBDIR_TO_VIZ_DIR="${lib_dir_to_viz_dir}")
 
 # These are at the end because we want them processed after
 # all the various variables have been set above.

--- a/Simbody/Visualizer/include/simbody/internal/Visualizer.h
+++ b/Simbody/Visualizer/include/simbody/internal/Visualizer.h
@@ -170,11 +170,14 @@ subdirectory of the Simbody installation directory.  However, first we look in
 the same directory as the currently-running executable and, if found, we will
 use that visualizer. If no visualizer is found with the executable, we check if
 environment variables SIMBODY_HOME or SimTK_INSTALL_DIR exist, and look in
-their "bin" subdirectories if so. Then, it checks the installed location of the
-visualizer, as specified when Simbody is compiled. If the visualizer is not
-there, we'll look in platform-specific default locations.  The other
-constructor allows specification of a search path that will be checked before
-attempting to find the installation directory.
+their "bin" (or "libexec/simbody" on UNIX) subdirectories if so. Next, we
+attempt to use the relative path from the SimTKsimbody library to the
+simbody-visualizer (this helps if Simbody is relocated, but does not work on
+Windows, or if using static Simbody libraries). Then, we check the installed
+location of the visualizer, as specified when Simbody is compiled. If the
+visualizer is not there, we'll look in platform-specific default locations.
+The other constructor allows specification of a search path that will be
+checked before attempting to find the installation directory.
 
 If you want to override the name of the visualizer executable for which Simbody
 searches, set the environment variable SIMBODY_VISUALIZER_NAME

--- a/Simbody/Visualizer/src/VisualizerProtocol.cpp
+++ b/Simbody/Visualizer/src/VisualizerProtocol.cpp
@@ -279,6 +279,23 @@ VisualizerProtocol::VisualizerProtocol
                     SIMBODY_VISUALIZER_REL_INSTALL_DIR));
     }
 
+    // Try using the location of SimTKsimbody combined with the path from the
+    // SimTKsimbody library to the simbody-visualizer install location (only
+    // available on non-Windows platforms). We must provide a function that
+    // resides in SimTKsimbody.
+    std::string SimTKsimbodyDir;
+    if (Pathname::getFunctionLibraryDirectory((void*)createPipeSim2Viz,
+                                              SimTKsimbodyDir)) {
+        // We have the path to SimTKsimbody; now we combine this with the path
+        // from SimTKsimbody to simbody-visualizer (this assumes the
+        // installation has not been reorganized from what CMake originally
+        // specified).
+        std::string absPathToVizDir =
+          Pathname::getAbsoluteDirectoryPathnameUsingSpecifiedWorkingDirectory(
+                  SimTKsimbodyDir, SIMBODY_PATH_FROM_LIBDIR_TO_VIZ_DIR);
+        actualSearchPath.push_back(absPathToVizDir);
+    }
+
     // Try the build-time install location:
     actualSearchPath.push_back(SIMBODY_VISUALIZER_INSTALL_DIR);
 


### PR DESCRIPTION
This PR fixes #558: the path from the SimTKsimbody library to the simbody-visualizer is added as a search path in VisualizerProtocol. To facilitate this, I added the function `Pathname::getFunctionLibraryDirectory()`. I also added a small test, and updated the documentation.

I tested this locally on both macOS and Ubuntu 14.04. I was able to rename the install directory and successfully get ChainExample to spawn the visualizer; this behavior was not possible before this PR. I also tested this PR with OpenSim on macOS and was able to verify that OpenSim's MATLAB bindings are able to find simbody-visualizer even if the original simbody install directory no longer exists.

Unfortunately, I realized that this PR may not be sufficient for OpenSim's Python bindings to find simbody-visualizer. This is more of an OpenSim issue though (it depends on how we expect the Python bindings to find the SimTK libraries; do we copy them into the Python package or edit DYLD_LIBRARY_PATH/RPATH?).