### PR TITLE
[appveyor] Disable publishing to AppVeyor's NuGet feed from pull requests

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,9 @@ os: Visual Studio 2015
 
 platform: x64
 
+# No need to run CI on the branch if we're also running CI for a PR.
+skip_branch_with_pr: true
+
 nuget:
   disable_publish_on_pr: true
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,9 @@ os: Visual Studio 2015
 
 platform: x64
 
+nuget:
+  - disable_publish_on_pr: true
+
 environment:
   matrix:
     - CMAKE_GENERATOR: "Visual Studio 14 2015"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ os: Visual Studio 2015
 platform: x64
 
 nuget:
-  - disable_publish_on_pr: true
+  disable_publish_on_pr: true
 
 environment:
   matrix:


### PR DESCRIPTION
AppVeyor lets us upload Simbody binaries to AppVeyor's servers, using our NuGet "feed" provided by AppVeyor. As-is, strangers can open PRs on Simbody to push arbitrary things to our NuGet feed. This PR prevents that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/578)
<!-- Reviewable:end -->
