### PR TITLE
Change Ipopt namespace to SimTKIpopt

### DIFF
--- a/SimTKmath/Optimizers/src/IpOpt/IpAdaptiveMuUpdate.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpAdaptiveMuUpdate.cpp
@@ -19,7 +19,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpAdaptiveMuUpdate.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpAdaptiveMuUpdate.hpp
@@ -15,7 +15,7 @@
 #include "IpFilter.hpp"
 #include "IpQualityFunctionMuOracle.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Non-monotone mu update.

--- a/SimTKmath/Optimizers/src/IpOpt/IpAlgBuilder.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpAlgBuilder.cpp
@@ -44,7 +44,7 @@
 
 # include "IpLapackSolverInterface.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpAlgBuilder.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpAlgBuilder.hpp
@@ -12,7 +12,7 @@
 #include "IpIpoptAlg.hpp"
 #include "IpReferenced.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Builder to create a complete IpoptAlg object.  This object

--- a/SimTKmath/Optimizers/src/IpOpt/IpAlgStrategy.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpAlgStrategy.hpp
@@ -13,7 +13,7 @@
 #include "IpJournalist.hpp"
 #include "IpIpoptCalculatedQuantities.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** This is the base class for all algorithm strategy objects.  The

--- a/SimTKmath/Optimizers/src/IpOpt/IpAlgTypes.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpAlgTypes.hpp
@@ -12,7 +12,7 @@
 #include "IpTypes.hpp"
 #include "IpException.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /**@name Enumerations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpAlgorithmRegOp.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpAlgorithmRegOp.cpp
@@ -34,7 +34,7 @@
 #include "IpWarmStartIterateInitializer.hpp"
 
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   void RegisterOptions_Algorithm(const SmartPtr<RegisteredOptions>& roptions)

--- a/SimTKmath/Optimizers/src/IpOpt/IpAlgorithmRegOp.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpAlgorithmRegOp.hpp
@@ -11,7 +11,7 @@
 
 #include "IpSmartPtr.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   class RegisteredOptions;
 

--- a/SimTKmath/Optimizers/src/IpOpt/IpAugRestoSystemSolver.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpAugRestoSystemSolver.cpp
@@ -14,7 +14,7 @@
 #include "IpDiagMatrix.hpp"
 #include "IpLowRankUpdateSymMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpAugRestoSystemSolver.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpAugRestoSystemSolver.hpp
@@ -11,7 +11,7 @@
 
 #include "IpAugSystemSolver.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Class that converts the an augmented system with compound restoration

--- a/SimTKmath/Optimizers/src/IpOpt/IpAugSystemSolver.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpAugSystemSolver.hpp
@@ -13,7 +13,7 @@
 #include "IpSymLinearSolver.hpp"
 #include "IpAlgStrategy.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Base class for Solver for the augmented system.  This is the

--- a/SimTKmath/Optimizers/src/IpOpt/IpBacktrackingLSAcceptor.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpBacktrackingLSAcceptor.hpp
@@ -13,7 +13,7 @@
 
 #include "IpAlgStrategy.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Base class for backtracking line search acceptors.

--- a/SimTKmath/Optimizers/src/IpOpt/IpBacktrackingLineSearch.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpBacktrackingLineSearch.cpp
@@ -23,7 +23,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpBacktrackingLineSearch.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpBacktrackingLineSearch.hpp
@@ -16,7 +16,7 @@
 #include "IpRestoPhase.hpp"
 #include "IpConvCheck.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** General implementation of a backtracking line search.  This

--- a/SimTKmath/Optimizers/src/IpOpt/IpBlas.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpBlas.cpp
@@ -129,7 +129,7 @@ extern "C"
                              int transa_len, int diag_len);
 }
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifndef HAVE_CBLAS
   /* Interface to FORTRAN routine DDOT. */

--- a/SimTKmath/Optimizers/src/IpOpt/IpBlas.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpBlas.hpp
@@ -11,7 +11,7 @@
 
 #include "IpUtils.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   // If CBLAS is not available, this is our own interface to the Fortran
   // implementation

--- a/SimTKmath/Optimizers/src/IpOpt/IpCachedResults.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpCachedResults.hpp
@@ -16,7 +16,7 @@
 #include <vector>
 #include <list>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   // Forward Declarations

--- a/SimTKmath/Optimizers/src/IpOpt/IpCompoundMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpCompoundMatrix.cpp
@@ -27,7 +27,7 @@
 
 
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   CompoundMatrix::CompoundMatrix(const CompoundMatrixSpace* owner_space)

--- a/SimTKmath/Optimizers/src/IpOpt/IpCompoundMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpCompoundMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpCompoundSymMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpCompoundSymMatrix.cpp
@@ -29,7 +29,7 @@
 
 
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   CompoundSymMatrix::CompoundSymMatrix(const CompoundSymMatrixSpace* owner_space)

--- a/SimTKmath/Optimizers/src/IpOpt/IpCompoundSymMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpCompoundSymMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpSymMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpCompoundVector.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpCompoundVector.cpp
@@ -40,7 +40,7 @@
 
 #include <limits>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG
@@ -177,7 +177,7 @@ namespace Ipopt
     DBG_ASSERT(vectors_valid_);
     Number max=0.;
     for(Index i=0; i<NComps(); i++) {
-      max = Ipopt::Max(max, ConstComp(i)->Amax());
+      max = SimTKIpopt::Max(max, ConstComp(i)->Amax());
     }
     return max;
   }
@@ -283,7 +283,7 @@ namespace Ipopt
     Number max = -std::numeric_limits<Number>::max();
     for(Index i=0; i<NComps(); i++) {
       if (ConstComp(i)->Dim() != 0) {
-        max = Ipopt::Max(max, ConstComp(i)->Max());
+        max = SimTKIpopt::Max(max, ConstComp(i)->Max());
       }
     }
     return max;
@@ -297,7 +297,7 @@ namespace Ipopt
     Number min = std::numeric_limits<Number>::max();
     for (Index i=0; i<NComps(); i++) {
       if (ConstComp(i)->Dim() != 0) {
-        min = Ipopt::Min(min, ConstComp(i)->Min());
+        min = SimTKIpopt::Min(min, ConstComp(i)->Min());
       }
     }
     return min;
@@ -362,7 +362,7 @@ namespace Ipopt
 
     Number alpha = 1.;
     for(Index i=0; i<NComps(); i++) {
-      alpha = Ipopt::Min(alpha,
+      alpha = SimTKIpopt::Min(alpha,
                          ConstComp(i)->FracToBound(*comp_delta->GetComp(i), tau));
     }
     return alpha;

--- a/SimTKmath/Optimizers/src/IpOpt/IpCompoundVector.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpCompoundVector.hpp
@@ -13,7 +13,7 @@
 #include "IpVector.hpp"
 #include <vector>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpConvCheck.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpConvCheck.hpp
@@ -11,7 +11,7 @@
 
 #include "IpAlgStrategy.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Base class for checking the algorithm

--- a/SimTKmath/Optimizers/src/IpOpt/IpDebug.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpDebug.cpp
@@ -11,7 +11,7 @@
 #include "IpDebug.hpp"
 #include "IpJournalist.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   Index DebugJournalistWrapper::indentation_level_ = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpDefaultIterateInitializer.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpDefaultIterateInitializer.cpp
@@ -8,7 +8,7 @@
 
 #include "IpDefaultIterateInitializer.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpDefaultIterateInitializer.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpDefaultIterateInitializer.hpp
@@ -12,7 +12,7 @@
 #include "IpIterateInitializer.hpp"
 #include "IpEqMultCalculator.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Class implementing the default initialization procedure (based

--- a/SimTKmath/Optimizers/src/IpOpt/IpDenseGenMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpDenseGenMatrix.cpp
@@ -10,7 +10,7 @@
 #include "IpBlas.hpp"
 #include "IpLapack.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpDenseGenMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpDenseGenMatrix.hpp
@@ -14,7 +14,7 @@
 #include "IpDenseVector.hpp"
 #include "IpDenseSymMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpDenseSymMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpDenseSymMatrix.cpp
@@ -11,7 +11,7 @@
 #include "IpDenseGenMatrix.hpp"
 #include "IpBlas.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpDenseSymMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpDenseSymMatrix.hpp
@@ -14,7 +14,7 @@
 #include "IpMultiVectorMatrix.hpp"
 #include "IpDenseVector.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpDenseVector.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpDenseVector.cpp
@@ -21,7 +21,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG
@@ -295,25 +295,25 @@ namespace Ipopt
       DBG_ASSERT(Dim() == dense_x->Dim());
       if (homogeneous_) {
         if (dense_x->homogeneous_) {
-          scalar_ = Ipopt::Max(scalar_, dense_x->scalar_);
+          scalar_ = SimTKIpopt::Max(scalar_, dense_x->scalar_);
         }
         else {
           homogeneous_ = false;
           Number* vals = values_allocated();
           for (Index i=0; i<Dim(); i++) {
-            vals[i] = Ipopt::Max(scalar_, values_x[i]);
+            vals[i] = SimTKIpopt::Max(scalar_, values_x[i]);
           }
         }
       }
       else {
         if (dense_x->homogeneous_) {
           for (Index i=0; i<Dim(); i++) {
-            values_[i] = Ipopt::Max(values_[i], dense_x->scalar_);
+            values_[i] = SimTKIpopt::Max(values_[i], dense_x->scalar_);
           }
         }
         else {
           for (Index i=0; i<Dim(); i++) {
-            values_[i] = Ipopt::Max(values_[i], values_x[i]);
+            values_[i] = SimTKIpopt::Max(values_[i], values_x[i]);
           }
         }
       }
@@ -331,25 +331,25 @@ namespace Ipopt
       DBG_ASSERT(Dim() == dense_x->Dim());
       if (homogeneous_) {
         if (dense_x->homogeneous_) {
-          scalar_ = Ipopt::Min(scalar_, dense_x->scalar_);
+          scalar_ = SimTKIpopt::Min(scalar_, dense_x->scalar_);
         }
         else {
           homogeneous_ = false;
           Number* vals = values_allocated();
           for (Index i=0; i<Dim(); i++) {
-            vals[i] = Ipopt::Min(scalar_, values_x[i]);
+            vals[i] = SimTKIpopt::Min(scalar_, values_x[i]);
           }
         }
       }
       else {
         if (dense_x->homogeneous_) {
           for (Index i=0; i<Dim(); i++) {
-            values_[i] = Ipopt::Min(values_[i], dense_x->scalar_);
+            values_[i] = SimTKIpopt::Min(values_[i], dense_x->scalar_);
           }
         }
         else {
           for (Index i=0; i<Dim(); i++) {
-            values_[i] = Ipopt::Min(values_[i], values_x[i]);
+            values_[i] = SimTKIpopt::Min(values_[i], values_x[i]);
           }
         }
       }
@@ -417,7 +417,7 @@ namespace Ipopt
     else {
       max = values_[0];
       for (Index i=1; i<Dim(); i++) {
-        max = Ipopt::Max(values_[i], max);
+        max = SimTKIpopt::Max(values_[i], max);
       }
     }
     return max;
@@ -436,7 +436,7 @@ namespace Ipopt
     else {
       min = values_[0];
       for (Index i=1; i<Dim(); i++) {
-        min = Ipopt::Min(values_[i], min);
+        min = SimTKIpopt::Min(values_[i], min);
       }
     }
     return min;
@@ -934,13 +934,13 @@ namespace Ipopt
     if (homogeneous_) {
       if (dense_delta->homogeneous_) {
         if (dense_delta->scalar_<0.) {
-          alpha = Ipopt::Min(alpha, -tau/dense_delta->scalar_ * scalar_);
+          alpha = SimTKIpopt::Min(alpha, -tau/dense_delta->scalar_ * scalar_);
         }
       }
       else {
         for (Index i=0; i<Dim(); i++) {
           if (values_delta[i]<0.) {
-            alpha = Ipopt::Min(alpha, -tau/values_delta[i] * scalar_);
+            alpha = SimTKIpopt::Min(alpha, -tau/values_delta[i] * scalar_);
           }
         }
       }
@@ -949,14 +949,14 @@ namespace Ipopt
       if (dense_delta->homogeneous_) {
         if (dense_delta->scalar_<0.) {
           for (Index i=0; i<Dim(); i++) {
-            alpha = Ipopt::Min(alpha, -tau/dense_delta->scalar_ * values_x[i]);
+            alpha = SimTKIpopt::Min(alpha, -tau/dense_delta->scalar_ * values_x[i]);
           }
         }
       }
       else {
         for (Index i=0; i<Dim(); i++) {
           if (values_delta[i]<0.) {
-            alpha = Ipopt::Min(alpha, -tau/values_delta[i] * values_x[i]);
+            alpha = SimTKIpopt::Min(alpha, -tau/values_delta[i] * values_x[i]);
           }
         }
       }

--- a/SimTKmath/Optimizers/src/IpOpt/IpDenseVector.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpDenseVector.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpVector.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpDiagMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpDiagMatrix.cpp
@@ -8,7 +8,7 @@
 
 #include "IpDiagMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   DiagMatrix::DiagMatrix(const SymMatrixSpace* owner_space)

--- a/SimTKmath/Optimizers/src/IpOpt/IpDiagMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpDiagMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpSymMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Class for diagonal matrices.  The diagonal is stored as a

--- a/SimTKmath/Optimizers/src/IpOpt/IpEqMultCalculator.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpEqMultCalculator.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpAlgStrategy.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /** Base Class for objects that compute estimates for the equality
    *  constraint multipliers y_c and y_d.  For example, this is the

--- a/SimTKmath/Optimizers/src/IpOpt/IpExactHessianUpdater.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpExactHessianUpdater.cpp
@@ -10,7 +10,7 @@
 
 #include "IpExactHessianUpdater.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpExactHessianUpdater.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpExactHessianUpdater.hpp
@@ -11,7 +11,7 @@
 
 #include "IpHessianUpdater.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Implementation of the HessianUpdater for the use of exact second

--- a/SimTKmath/Optimizers/src/IpOpt/IpException.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpException.hpp
@@ -16,7 +16,7 @@
  *  and a set of macros to help with exceptions 
  */
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** This is the base class for all exceptions.  The easiest way to

--- a/SimTKmath/Optimizers/src/IpOpt/IpExpansionMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpExpansionMatrix.cpp
@@ -9,7 +9,7 @@
 #include "IpExpansionMatrix.hpp"
 #include "IpDenseVector.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpExpansionMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpExpansionMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpFilter.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpFilter.cpp
@@ -9,7 +9,7 @@
 #include "IpFilter.hpp"
 #include "IpJournalist.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpFilter.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpFilter.hpp
@@ -14,7 +14,7 @@
 #include <list>
 #include <vector>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Class for one filter entry. */

--- a/SimTKmath/Optimizers/src/IpOpt/IpFilterLSAcceptor.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpFilterLSAcceptor.cpp
@@ -23,7 +23,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpFilterLSAcceptor.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpFilterLSAcceptor.hpp
@@ -14,7 +14,7 @@
 #include "IpBacktrackingLSAcceptor.hpp"
 #include "IpPDSystemSolver.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Filter line search.  This class implements the filter line

--- a/SimTKmath/Optimizers/src/IpOpt/IpGenTMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpGenTMatrix.cpp
@@ -10,7 +10,7 @@
 #include "IpDenseVector.hpp"
 #include "IpBlas.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   GenTMatrix::GenTMatrix(const GenTMatrixSpace* owner_space)

--- a/SimTKmath/Optimizers/src/IpOpt/IpGenTMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpGenTMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpGradientScaling.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpGradientScaling.cpp
@@ -19,7 +19,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   void GradientScaling::RegisterOptions(const SmartPtr<RegisteredOptions>& roptions)

--- a/SimTKmath/Optimizers/src/IpOpt/IpGradientScaling.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpGradientScaling.hpp
@@ -12,7 +12,7 @@
 #include "IpNLPScaling.hpp"
 #include "IpNLP.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /** This class does problem scaling by setting the
    *  scaling parameters based on the maximum of the

--- a/SimTKmath/Optimizers/src/IpOpt/IpHessianUpdater.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpHessianUpdater.hpp
@@ -11,7 +11,7 @@
 
 #include "IpAlgStrategy.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Abstract base class for objects responsible for updating the

--- a/SimTKmath/Optimizers/src/IpOpt/IpIdentityMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIdentityMatrix.cpp
@@ -8,7 +8,7 @@
 
 #include "IpIdentityMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   IdentityMatrix::IdentityMatrix(const SymMatrixSpace* owner_space)

--- a/SimTKmath/Optimizers/src/IpOpt/IpIdentityMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIdentityMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpSymMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Class for Matrices which are multiples of the identity matrix.

--- a/SimTKmath/Optimizers/src/IpOpt/IpInterfacesRegOp.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpInterfacesRegOp.cpp
@@ -11,7 +11,7 @@
 #include "IpIpoptApplication.hpp"
 #include "IpTNLPAdapter.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   void RegisterOptions_Interfaces(const SmartPtr<RegisteredOptions>& roptions)

--- a/SimTKmath/Optimizers/src/IpOpt/IpInterfacesRegOp.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpInterfacesRegOp.hpp
@@ -11,7 +11,7 @@
 
 #include "IpSmartPtr.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   class RegisteredOptions;
 

--- a/SimTKmath/Optimizers/src/IpOpt/IpIpoptAlg.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIpoptAlg.cpp
@@ -11,7 +11,7 @@
 #include "IpRestoPhase.hpp"
 #include "IpOrigIpoptNLP.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpIpoptAlg.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIpoptAlg.hpp
@@ -22,7 +22,7 @@
 #include "IpHessianUpdater.hpp"
 #include "IpEqMultCalculator.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** @name Exceptions */

--- a/SimTKmath/Optimizers/src/IpOpt/IpIpoptApplication.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIpoptApplication.cpp
@@ -31,7 +31,7 @@
 
 #include <fstream>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpIpoptApplication.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIpoptApplication.hpp
@@ -17,7 +17,7 @@
 /* Return codes for the Optimize call for an application */
 #include "IpReturnCodes.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   DECLARE_STD_EXCEPTION(IPOPT_APPLICATION_ERROR);
 

--- a/SimTKmath/Optimizers/src/IpOpt/IpIpoptCalculatedQuantities.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIpoptCalculatedQuantities.cpp
@@ -23,7 +23,7 @@
 
 #include <limits>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpIpoptCalculatedQuantities.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIpoptCalculatedQuantities.hpp
@@ -12,7 +12,7 @@
 #include "IpIpoptNLP.hpp"
 #include "IpIpoptData.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Norm types */

--- a/SimTKmath/Optimizers/src/IpOpt/IpIpoptData.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIpoptData.cpp
@@ -9,7 +9,7 @@
 #include "IpIpoptData.hpp"
 #include "IpIpoptNLP.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   IpoptData::IpoptData()

--- a/SimTKmath/Optimizers/src/IpOpt/IpIpoptData.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIpoptData.hpp
@@ -15,7 +15,7 @@
 #include "IpRegOptions.hpp"
 #include "IpTimingStatistics.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* Forward declaration */

--- a/SimTKmath/Optimizers/src/IpOpt/IpIpoptNLP.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIpoptNLP.hpp
@@ -13,7 +13,7 @@
 #include "IpJournalist.hpp"
 #include "IpNLPScaling.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   // forward declarations
   class IteratesVector;

--- a/SimTKmath/Optimizers/src/IpOpt/IpIterateInitializer.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIterateInitializer.hpp
@@ -14,7 +14,7 @@
 #include "IpIpoptData.hpp"
 #include "IpIpoptCalculatedQuantities.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Base class for all methods for initializing the iterates.

--- a/SimTKmath/Optimizers/src/IpOpt/IpIteratesVector.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIteratesVector.cpp
@@ -8,7 +8,7 @@
 
 #include "IpIteratesVector.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   IteratesVector::IteratesVector(const IteratesVectorSpace* owner_space, bool create_new)

--- a/SimTKmath/Optimizers/src/IpOpt/IpIteratesVector.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIteratesVector.hpp
@@ -11,7 +11,7 @@
 
 #include "IpCompoundVector.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /* forward declarations */
   class IteratesVectorSpace;

--- a/SimTKmath/Optimizers/src/IpOpt/IpIterationOutput.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpIterationOutput.hpp
@@ -14,7 +14,7 @@
 #include "IpIpoptData.hpp"
 #include "IpIpoptCalculatedQuantities.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Base class for objects that do the output summary per iteration.

--- a/SimTKmath/Optimizers/src/IpOpt/IpJournalist.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpJournalist.cpp
@@ -27,7 +27,7 @@
 #pragma warning(disable:4996)
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   Journalist::Journalist()

--- a/SimTKmath/Optimizers/src/IpOpt/IpJournalist.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpJournalist.hpp
@@ -27,7 +27,7 @@
 #include <string>
 #include <vector>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   // forward declarations

--- a/SimTKmath/Optimizers/src/IpOpt/IpLapack.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLapack.cpp
@@ -55,7 +55,7 @@ extern "C"
                              int jobz_len, int uplo_len);
 }
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /* Interface to FORTRAN routine DPOTRS. */
   void IpLapackDpotrs(Index ndim, Index nrhs, const Number *a, Index lda,

--- a/SimTKmath/Optimizers/src/IpOpt/IpLapack.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLapack.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpException.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   DECLARE_STD_EXCEPTION(LAPACK_NOT_INCLUDED);
 

--- a/SimTKmath/Optimizers/src/IpOpt/IpLapackSolverInterface.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLapackSolverInterface.cpp
@@ -14,7 +14,7 @@
 #define DGETRS   dgetrs_
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpLapackSolverInterface.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLapackSolverInterface.hpp
@@ -4,7 +4,7 @@
 
 #include "IpSparseSymLinearSolverInterface.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Interface to the linear solver Lapack, derived from

--- a/SimTKmath/Optimizers/src/IpOpt/IpLeastSquareMults.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLeastSquareMults.cpp
@@ -8,7 +8,7 @@
 
 #include "IpLeastSquareMults.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpLeastSquareMults.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLeastSquareMults.hpp
@@ -12,7 +12,7 @@
 #include "IpAugSystemSolver.hpp"
 #include "IpEqMultCalculator.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Class for calculator for the least-square equality constraint

--- a/SimTKmath/Optimizers/src/IpOpt/IpLimMemQuasiNewtonUpdater.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLimMemQuasiNewtonUpdater.cpp
@@ -21,7 +21,7 @@
 
 #include <limits>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpLimMemQuasiNewtonUpdater.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLimMemQuasiNewtonUpdater.hpp
@@ -16,7 +16,7 @@
 #include "IpDenseGenMatrix.hpp"
 #include "IpDenseSymMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Implementation of the HessianUpdater for limit-memory

--- a/SimTKmath/Optimizers/src/IpOpt/IpLineSearch.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLineSearch.hpp
@@ -12,7 +12,7 @@
 #include "IpAlgStrategy.hpp"
 #include "IpIpoptCalculatedQuantities.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Base class for line search objects.

--- a/SimTKmath/Optimizers/src/IpOpt/IpLinearSolversRegOp.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLinearSolversRegOp.cpp
@@ -12,7 +12,7 @@
 #include "IpTSymLinearSolver.hpp"
 
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   void RegisterOptions_LinearSolvers(const SmartPtr<RegisteredOptions>& roptions)

--- a/SimTKmath/Optimizers/src/IpOpt/IpLinearSolversRegOp.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLinearSolversRegOp.hpp
@@ -11,7 +11,7 @@
 
 #include "IpSmartPtr.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   class RegisteredOptions;
 

--- a/SimTKmath/Optimizers/src/IpOpt/IpLoqoMuOracle.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLoqoMuOracle.cpp
@@ -28,7 +28,7 @@
 
 
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpLoqoMuOracle.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLoqoMuOracle.hpp
@@ -11,7 +11,7 @@
 
 #include "IpMuOracle.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Implementation of the LOQO formula for computing the

--- a/SimTKmath/Optimizers/src/IpOpt/IpLowRankAugSystemSolver.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLowRankAugSystemSolver.cpp
@@ -9,7 +9,7 @@
 #include "IpLowRankAugSystemSolver.hpp"
 #include "IpLowRankUpdateSymMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpLowRankAugSystemSolver.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLowRankAugSystemSolver.hpp
@@ -14,7 +14,7 @@
 #include "IpMultiVectorMatrix.hpp"
 #include "IpDiagMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Solver for the augmented system with LowRankUpdateSymMatrix

--- a/SimTKmath/Optimizers/src/IpOpt/IpLowRankUpdateSymMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLowRankUpdateSymMatrix.cpp
@@ -8,7 +8,7 @@
 
 #include "IpLowRankUpdateSymMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpLowRankUpdateSymMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLowRankUpdateSymMatrix.hpp
@@ -13,7 +13,7 @@
 #include "IpSymMatrix.hpp"
 #include "IpMultiVectorMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpMatrix.cpp
@@ -8,7 +8,7 @@
 
 #include "IpMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   void Matrix::MultVector(Number alpha, const Vector& x, Number beta,
                           Vector& y) const

--- a/SimTKmath/Optimizers/src/IpOpt/IpMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpMatrix.hpp
@@ -11,7 +11,7 @@
 
 #include "IpVector.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpMonotoneMuUpdate.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpMonotoneMuUpdate.cpp
@@ -19,7 +19,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpMonotoneMuUpdate.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpMonotoneMuUpdate.hpp
@@ -13,7 +13,7 @@
 #include "IpLineSearch.hpp"
 #include "IpRegOptions.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Monotone Mu Update. This class implements the standard monotone mu update

--- a/SimTKmath/Optimizers/src/IpOpt/IpMuOracle.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpMuOracle.hpp
@@ -11,7 +11,7 @@
 
 #include "IpAlgStrategy.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Abstract Base Class for classes that are able to compute a

--- a/SimTKmath/Optimizers/src/IpOpt/IpMuUpdate.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpMuUpdate.hpp
@@ -11,7 +11,7 @@
 
 #include "IpAlgStrategy.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /** Abstract Base Class for classes that implement methods for computing
    *  the barrier and fraction-to-the-boundary rule parameter for the

--- a/SimTKmath/Optimizers/src/IpOpt/IpMultiVectorMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpMultiVectorMatrix.cpp
@@ -19,7 +19,7 @@
 
 
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpMultiVectorMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpMultiVectorMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpNLP.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpNLP.hpp
@@ -18,7 +18,7 @@
 #include "IpAlgTypes.hpp"
 #include "IpReturnCodes.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   // forward declarations
   class IpoptData;

--- a/SimTKmath/Optimizers/src/IpOpt/IpNLPScaling.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpNLPScaling.cpp
@@ -8,7 +8,7 @@
 
 #include "IpNLPScaling.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpNLPScaling.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpNLPScaling.hpp
@@ -15,7 +15,7 @@
 #include "IpOptionsList.hpp"
 #include "IpRegOptions.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /** This is the abstract base class for problem scaling.
    *  It is repsonsible for determining the scaling factors

--- a/SimTKmath/Optimizers/src/IpOpt/IpObserver.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpObserver.cpp
@@ -8,7 +8,7 @@
 
 #include "IpObserver.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG_OBSERVER
   const Index Observer::dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpObserver.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpObserver.hpp
@@ -14,7 +14,7 @@
 #include <vector>
 #include <algorithm>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /** Forward declarations */
   class Subject;

--- a/SimTKmath/Optimizers/src/IpOpt/IpOptErrorConvCheck.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpOptErrorConvCheck.cpp
@@ -8,7 +8,7 @@
 
 #include "IpOptErrorConvCheck.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpOptErrorConvCheck.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpOptErrorConvCheck.hpp
@@ -11,7 +11,7 @@
 
 #include "IpConvCheck.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Brief Class Description.

--- a/SimTKmath/Optimizers/src/IpOpt/IpOptionsList.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpOptionsList.cpp
@@ -37,7 +37,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   bool OptionsList::SetStringValue(const std::string& tag,

--- a/SimTKmath/Optimizers/src/IpOpt/IpOptionsList.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpOptionsList.hpp
@@ -17,7 +17,7 @@
 #include <iostream>
 #include <map>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /** Exception that can be used to indicate errors with options */
   DECLARE_STD_EXCEPTION(OPTION_INVALID);

--- a/SimTKmath/Optimizers/src/IpOpt/IpOrigIpoptNLP.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpOrigIpoptNLP.cpp
@@ -11,7 +11,7 @@
 #include "IpIpoptData.hpp"
 #include "IpIpoptCalculatedQuantities.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpOrigIpoptNLP.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpOrigIpoptNLP.hpp
@@ -13,7 +13,7 @@
 #include "IpException.hpp"
 #include "IpTimingStatistics.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** enumeration for the Hessian information type. */

--- a/SimTKmath/Optimizers/src/IpOpt/IpOrigIterationOutput.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpOrigIterationOutput.cpp
@@ -28,7 +28,7 @@
 
 
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   OrigIterationOutput::OrigIterationOutput()
   {}

--- a/SimTKmath/Optimizers/src/IpOpt/IpOrigIterationOutput.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpOrigIterationOutput.hpp
@@ -11,7 +11,7 @@
 
 #include "IpIterationOutput.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Class for the iteration summary output for the original NLP.

--- a/SimTKmath/Optimizers/src/IpOpt/IpPDFullSpaceSolver.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpPDFullSpaceSolver.cpp
@@ -9,7 +9,7 @@
 #include "IpPDFullSpaceSolver.hpp"
 #include "IpDebug.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
 #ifdef IP_DEBUG

--- a/SimTKmath/Optimizers/src/IpOpt/IpPDFullSpaceSolver.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpPDFullSpaceSolver.hpp
@@ -13,7 +13,7 @@
 #include "IpAugSystemSolver.hpp"
 #include "IpPDPerturbationHandler.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** This is the implemetation of the Primal-Dual System, using the

--- a/SimTKmath/Optimizers/src/IpOpt/IpPDPerturbationHandler.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpPDPerturbationHandler.cpp
@@ -18,7 +18,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpPDPerturbationHandler.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpPDPerturbationHandler.hpp
@@ -11,7 +11,7 @@
 
 #include "IpAlgStrategy.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Class for handling the perturbation factors delta_x, delta_s,

--- a/SimTKmath/Optimizers/src/IpOpt/IpPDSystemSolver.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpPDSystemSolver.hpp
@@ -14,7 +14,7 @@
 #include "IpAlgStrategy.hpp"
 #include "IpIteratesVector.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Pure Primal Dual System Solver Base Class.

--- a/SimTKmath/Optimizers/src/IpOpt/IpProbingMuOracle.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpProbingMuOracle.cpp
@@ -28,7 +28,7 @@
 
 
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpProbingMuOracle.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpProbingMuOracle.hpp
@@ -12,7 +12,7 @@
 #include "IpMuOracle.hpp"
 #include "IpPDSystemSolver.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Implementation of the probing strategy for computing the

--- a/SimTKmath/Optimizers/src/IpOpt/IpQualityFunctionMuOracle.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpQualityFunctionMuOracle.cpp
@@ -27,7 +27,7 @@
 
 
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpQualityFunctionMuOracle.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpQualityFunctionMuOracle.hpp
@@ -13,7 +13,7 @@
 #include "IpPDSystemSolver.hpp"
 #include "IpIpoptCalculatedQuantities.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Implementation of the probing strategy for computing the

--- a/SimTKmath/Optimizers/src/IpOpt/IpReferenced.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpReferenced.hpp
@@ -14,7 +14,7 @@
 
 #include <list>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Psydo-class, from which everything has to inherit that wants to

--- a/SimTKmath/Optimizers/src/IpOpt/IpRegOptions.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRegOptions.cpp
@@ -38,7 +38,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   Index RegisteredOption::next_counter_ = 1;

--- a/SimTKmath/Optimizers/src/IpOpt/IpRegOptions.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRegOptions.hpp
@@ -16,7 +16,7 @@
 
 #include <map>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   enum RegisteredOptionType

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoFilterConvCheck.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoFilterConvCheck.cpp
@@ -11,7 +11,7 @@
 #include "IpRestoIpoptNLP.hpp"
 #include "IpRestoPhase.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoFilterConvCheck.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoFilterConvCheck.hpp
@@ -12,7 +12,7 @@
 #include "IpOptErrorConvCheck.hpp"
 #include "IpFilterLSAcceptor.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Convergence check for the restoration phase as called by the

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoIpoptNLP.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoIpoptNLP.cpp
@@ -25,7 +25,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoIpoptNLP.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoIpoptNLP.hpp
@@ -20,7 +20,7 @@
 #include "IpZeroMatrix.hpp"
 #include "IpOrigIpoptNLP.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** This class maps the traditional NLP into

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoIterateInitializer.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoIterateInitializer.cpp
@@ -10,7 +10,7 @@
 #include "IpRestoIpoptNLP.hpp"
 #include "IpDefaultIterateInitializer.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoIterateInitializer.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoIterateInitializer.hpp
@@ -12,7 +12,7 @@
 #include "IpIterateInitializer.hpp"
 #include "IpEqMultCalculator.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /** Class implementing the default initialization procedure (based
    *  on user options) for the iterates.  It is used at the very

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoIterationOutput.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoIterationOutput.cpp
@@ -29,7 +29,7 @@
 
 
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   RestoIterationOutput::RestoIterationOutput(const SmartPtr<OrigIterationOutput>& resto_orig_iteration_output)
       :

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoIterationOutput.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoIterationOutput.hpp
@@ -12,7 +12,7 @@
 #include "IpIterationOutput.hpp"
 #include "IpOrigIterationOutput.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Class for the iteration summary output for the restoration

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoMinC_1Nrm.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoMinC_1Nrm.cpp
@@ -11,7 +11,7 @@
 #include "IpRestoIpoptNLP.hpp"
 #include "IpDefaultIterateInitializer.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoMinC_1Nrm.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoMinC_1Nrm.hpp
@@ -13,7 +13,7 @@
 #include "IpIpoptAlg.hpp"
 #include "IpEqMultCalculator.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Restoration Phase that minimizes the 1-norm of the constraint

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoPhase.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoPhase.hpp
@@ -14,7 +14,7 @@
 #include "IpIpoptData.hpp"
 #include "IpIpoptCalculatedQuantities.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** @name Exceptions */

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoRestoPhase.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoRestoPhase.cpp
@@ -9,7 +9,7 @@
 #include "IpRestoRestoPhase.hpp"
 #include "IpRestoIpoptNLP.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoRestoPhase.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoRestoPhase.hpp
@@ -13,7 +13,7 @@
 #include "IpIpoptAlg.hpp"
 #include "IpEqMultCalculator.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Recursive Restoration Phase for the.MinC_1NrmRestorationPhase.

--- a/SimTKmath/Optimizers/src/IpOpt/IpReturnCodes.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpReturnCodes.hpp
@@ -13,7 +13,7 @@
 
 /* include from a common include file */
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #include "IpReturnCodes_inc.h"
 }

--- a/SimTKmath/Optimizers/src/IpOpt/IpScaledMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpScaledMatrix.cpp
@@ -8,7 +8,7 @@
 
 #include "IpScaledMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   ScaledMatrix::ScaledMatrix(const ScaledMatrixSpace* owner_space)

--- a/SimTKmath/Optimizers/src/IpOpt/IpScaledMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpScaledMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpSmartPtr.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSmartPtr.hpp
@@ -16,7 +16,7 @@
 # include "IpDebug.hpp"
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Template class for Smart Pointers.

--- a/SimTKmath/Optimizers/src/IpOpt/IpSolveStatistics.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSolveStatistics.cpp
@@ -9,7 +9,7 @@
 #include "IpSolveStatistics.hpp"
 #include "IpIpoptCalculatedQuantities.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   SolveStatistics::SolveStatistics(

--- a/SimTKmath/Optimizers/src/IpOpt/IpSolveStatistics.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSolveStatistics.hpp
@@ -12,7 +12,7 @@
 #include "IpReferenced.hpp"
 #include "IpSmartPtr.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   // forward declaration (to avoid inclusion of too many header files)
   class IpoptNLP;

--- a/SimTKmath/Optimizers/src/IpOpt/IpSparseSymLinearSolverInterface.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSparseSymLinearSolverInterface.hpp
@@ -13,7 +13,7 @@
 #include "IpAlgStrategy.hpp"
 #include "IpSymLinearSolver.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Base class for interfaces to symmetric indefinite linear solvers

--- a/SimTKmath/Optimizers/src/IpOpt/IpStdAugSystemSolver.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpStdAugSystemSolver.cpp
@@ -27,7 +27,7 @@
 
 
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpStdAugSystemSolver.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpStdAugSystemSolver.hpp
@@ -17,7 +17,7 @@
 #include "IpDiagMatrix.hpp"
 #include "IpIdentityMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   DECLARE_STD_EXCEPTION(FATAL_ERROR_IN_LINEAR_SOLVER);

--- a/SimTKmath/Optimizers/src/IpOpt/IpStdCInterface.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpStdCInterface.cpp
@@ -27,7 +27,7 @@ struct IpoptProblemInfo
   Eval_Grad_F_CB eval_grad_f;
   Eval_Jac_G_CB eval_jac_g;
   Eval_H_CB eval_h;
-  Ipopt::SmartPtr<Ipopt::IpoptApplication> app;
+  SimTKIpopt::SmartPtr<SimTKIpopt::IpoptApplication> app;
 };
 
 IpoptProblem CreateIpoptProblem(
@@ -90,7 +90,7 @@ IpoptProblem CreateIpoptProblem(
   retval->eval_jac_g = eval_jac_g;
   retval->eval_h = eval_h;
 
-  retval->app = new Ipopt::IpoptApplication();
+  retval->app = new SimTKIpopt::IpoptApplication();
 
   return retval;
 }
@@ -120,14 +120,14 @@ Bool AddIpoptStrOption(IpoptProblem ipopt_problem, const char* keyword, const ch
 Bool AddIpoptNumOption(IpoptProblem ipopt_problem, const char* keyword, Number val)
 {
   std::string tag(keyword);
-  Ipopt::Number value=val;
+  SimTKIpopt::Number value=val;
   return (Bool) ipopt_problem->app->Options()->SetNumericValue(tag, value);
 }
 
 Bool AddIpoptIntOption(IpoptProblem ipopt_problem, const char* keyword, Int val)
 {
   std::string tag(keyword);
-  Ipopt::Index value=val;
+  SimTKIpopt::Index value=val;
   return (Bool) ipopt_problem->app->Options()->SetIntegerValue(tag, value);
 }
 
@@ -135,7 +135,7 @@ Bool OpenIpoptOutputFile(IpoptProblem ipopt_problem, char* file_name,
                          Int print_level)
 {
   std::string name(file_name);
-  Ipopt::EJournalLevel level = Ipopt::EJournalLevel(print_level);
+  SimTKIpopt::EJournalLevel level = SimTKIpopt::EJournalLevel(print_level);
   return (Bool) ipopt_problem->app->OpenOutputFile(name, level);
 }
 
@@ -149,7 +149,7 @@ enum ApplicationReturnStatus IpoptSolve(
   Number* mult_x_U,
   UserDataPtr user_data)
 {
-  using namespace Ipopt;
+  using namespace SimTKIpopt;
 
   // Initialize and process options
   ipopt_problem->app->Initialize();
@@ -203,12 +203,12 @@ enum ApplicationReturnStatus IpoptSolve(
     skip_optimize = true;
   }
 
-  Ipopt::ApplicationReturnStatus status;
+  SimTKIpopt::ApplicationReturnStatus status;
   if (!skip_optimize) {
     status = ipopt_problem->app->OptimizeTNLP(tnlp);
   }
   else {
-    status = Ipopt::Invalid_Problem_Definition;
+    status = SimTKIpopt::Invalid_Problem_Definition;
   }
 
   delete [] start_x;

--- a/SimTKmath/Optimizers/src/IpOpt/IpStdInterfaceTNLP.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpStdInterfaceTNLP.cpp
@@ -9,7 +9,7 @@
 #include "IpStdInterfaceTNLP.hpp"
 #include "IpBlas.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   StdInterfaceTNLP::StdInterfaceTNLP(Index n_var,
                                      const Number* x_L, const Number* x_U,

--- a/SimTKmath/Optimizers/src/IpOpt/IpStdInterfaceTNLP.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpStdInterfaceTNLP.hpp
@@ -16,7 +16,7 @@
 #include "IpStdCInterface.h"
 #include "IpSmartPtr.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /** Declare excpetion that is thrown when invalid NLP data
    *  is provided */

--- a/SimTKmath/Optimizers/src/IpOpt/IpSumMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSumMatrix.cpp
@@ -25,7 +25,7 @@
 #pragma warning(disable:4996)
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   SumMatrix::SumMatrix(const SumMatrixSpace* owner_space)

--- a/SimTKmath/Optimizers/src/IpOpt/IpSumMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSumMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpSumSymMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSumSymMatrix.cpp
@@ -25,7 +25,7 @@
 #pragma warning(disable:4996)
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   SumSymMatrix::SumSymMatrix(const SumSymMatrixSpace* owner_space)

--- a/SimTKmath/Optimizers/src/IpOpt/IpSumSymMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSumSymMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpSymMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpSymLinearSolver.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSymLinearSolver.hpp
@@ -14,7 +14,7 @@
 #include "IpAlgStrategy.hpp"
 #include <vector>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Enum to report outcome of a linear solve */

--- a/SimTKmath/Optimizers/src/IpOpt/IpSymMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSymMatrix.cpp
@@ -8,7 +8,7 @@
 
 #include "IpSymMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   SymMatrix::SymMatrix(const SymMatrixSpace* owner_space)

--- a/SimTKmath/Optimizers/src/IpOpt/IpSymMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSymMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpSymScaledMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSymScaledMatrix.cpp
@@ -8,7 +8,7 @@
 
 #include "IpSymScaledMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   SymScaledMatrix::SymScaledMatrix(const SymScaledMatrixSpace* owner_space)

--- a/SimTKmath/Optimizers/src/IpOpt/IpSymScaledMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSymScaledMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpSymMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpSymTMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSymTMatrix.cpp
@@ -17,7 +17,7 @@
 
 
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   SymTMatrix::SymTMatrix(const SymTMatrixSpace* owner_space)

--- a/SimTKmath/Optimizers/src/IpOpt/IpSymTMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSymTMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpSymMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /* forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpTNLP.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTNLP.hpp
@@ -15,7 +15,7 @@
 #include "IpAlgTypes.hpp"
 #include "IpReturnCodes.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   // forward declarations
   class IpoptData;

--- a/SimTKmath/Optimizers/src/IpOpt/IpTNLPAdapter.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTNLPAdapter.cpp
@@ -34,7 +34,7 @@
 
 
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpTNLPAdapter.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTNLPAdapter.hpp
@@ -13,7 +13,7 @@
 #include "IpTNLP.hpp"
 #include "IpOrigIpoptNLP.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   // forward declarations

--- a/SimTKmath/Optimizers/src/IpOpt/IpTSymLinearSolver.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTSymLinearSolver.cpp
@@ -9,7 +9,7 @@
 #include "IpTSymLinearSolver.hpp"
 #include "IpTripletHelper.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpTSymLinearSolver.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTSymLinearSolver.hpp
@@ -17,7 +17,7 @@
 #include "IpTripletToDenseConverter.hpp"
 #include <vector>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** General driver for linear solvers for sparse indefinite

--- a/SimTKmath/Optimizers/src/IpOpt/IpTSymScalingMethod.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTSymScalingMethod.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpAlgStrategy.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   DECLARE_STD_EXCEPTION(ERROR_IN_LINEAR_SCALING_METHOD);

--- a/SimTKmath/Optimizers/src/IpOpt/IpTaggedObject.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTaggedObject.cpp
@@ -8,7 +8,7 @@
 
 #include "IpTaggedObject.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   TaggedObject::Tag TaggedObject::unique_tag_ = 1;

--- a/SimTKmath/Optimizers/src/IpOpt/IpTaggedObject.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTaggedObject.hpp
@@ -15,7 +15,7 @@
 #include "IpObserver.hpp"
 #include <limits>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** TaggedObject class.

--- a/SimTKmath/Optimizers/src/IpOpt/IpTimedTask.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTimedTask.hpp
@@ -34,7 +34,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /** This class is used to collect timing information for a
    *  particular task. */

--- a/SimTKmath/Optimizers/src/IpOpt/IpTimingStatistics.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTimingStatistics.cpp
@@ -8,7 +8,7 @@
 
 #include "IpTimingStatistics.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   void
   TimingStatistics::ResetTimes()

--- a/SimTKmath/Optimizers/src/IpOpt/IpTimingStatistics.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTimingStatistics.hpp
@@ -38,7 +38,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /** This class collects all timing statistics for Ipopt.
    */

--- a/SimTKmath/Optimizers/src/IpOpt/IpTripletHelper.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTripletHelper.cpp
@@ -26,7 +26,7 @@
 
 #include "IpBlas.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   Index TripletHelper::GetNumberEntries(const Matrix& matrix)

--- a/SimTKmath/Optimizers/src/IpOpt/IpTripletHelper.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTripletHelper.hpp
@@ -12,7 +12,7 @@
 #include "IpTypes.hpp"
 #include "IpException.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** forward declarations */

--- a/SimTKmath/Optimizers/src/IpOpt/IpTripletToCSRConverter.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTripletToCSRConverter.cpp
@@ -2,7 +2,7 @@
 #include "IpTripletToCSRConverter.hpp"
 #include <list>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpTripletToCSRConverter.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTripletToCSRConverter.hpp
@@ -11,7 +11,7 @@
 
 #include "IpUtils.hpp"
 #include "IpReferenced.hpp"
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Class for converting symmetric matrices given in triplet format

--- a/SimTKmath/Optimizers/src/IpOpt/IpTripletToDenseConverter.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTripletToDenseConverter.cpp
@@ -2,7 +2,7 @@
 #include "IpTripletToDenseConverter.hpp"
 #include <list>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpTripletToDenseConverter.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTripletToDenseConverter.hpp
@@ -4,7 +4,7 @@
 
 #include "IpUtils.hpp"
 #include "IpReferenced.hpp"
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Class for converting symmetric matrices given in triplet format

--- a/SimTKmath/Optimizers/src/IpOpt/IpTypes.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTypes.hpp
@@ -11,7 +11,7 @@
 
 #include "SimTKcommon/internal/common.h"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /** Type of all numbers */
   typedef SimTK::Real Number;

--- a/SimTKmath/Optimizers/src/IpOpt/IpUserScaling.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpUserScaling.cpp
@@ -8,7 +8,7 @@
 
 #include "IpUserScaling.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   void UserScaling::DetermineScalingParametersImpl(

--- a/SimTKmath/Optimizers/src/IpOpt/IpUserScaling.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpUserScaling.hpp
@@ -12,7 +12,7 @@
 #include "IpNLPScaling.hpp"
 #include "IpNLP.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /** This class does problem scaling by getting scaling parameters
    *  from the user (through the NLP interface).

--- a/SimTKmath/Optimizers/src/IpOpt/IpUtils.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpUtils.cpp
@@ -35,7 +35,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   bool IsFiniteNumber(Number val)

--- a/SimTKmath/Optimizers/src/IpOpt/IpUtils.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpUtils.hpp
@@ -13,7 +13,7 @@
 #include "IpTypes.hpp"
 #include "IpDebug.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   inline ipfint Max(ipfint a, ipfint b)

--- a/SimTKmath/Optimizers/src/IpOpt/IpVector.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpVector.cpp
@@ -18,7 +18,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   void Vector::Print(SmartPtr<const Journalist> jnlst,
@@ -110,7 +110,7 @@ namespace Ipopt
 
     Number alpha = inv_alpha_bar->Max();
     if (alpha > 0) {
-      alpha = Ipopt::Min(1/alpha, Number(1));
+      alpha = SimTKIpopt::Min(1/alpha, Number(1));
     }
     else {
       alpha = 1;

--- a/SimTKmath/Optimizers/src/IpOpt/IpVector.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpVector.hpp
@@ -17,7 +17,7 @@
 
 #include <vector>
 
-namespace Ipopt
+namespace SimTKIpopt
 {
   /* forward declarations */
   class VectorSpace;

--- a/SimTKmath/Optimizers/src/IpOpt/IpWarmStartIterateInitializer.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpWarmStartIterateInitializer.cpp
@@ -22,7 +22,7 @@
 # endif
 #endif
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 #ifdef IP_DEBUG
   static const Index dbg_verbosity = 0;

--- a/SimTKmath/Optimizers/src/IpOpt/IpWarmStartIterateInitializer.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpWarmStartIterateInitializer.hpp
@@ -12,7 +12,7 @@
 #include "IpIterateInitializer.hpp"
 #include "IpEqMultCalculator.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Class implementing an initialization procedure for warm starts.

--- a/SimTKmath/Optimizers/src/IpOpt/IpZeroMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpZeroMatrix.cpp
@@ -8,7 +8,7 @@
 
 #include "IpZeroMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   ZeroMatrix::ZeroMatrix(const MatrixSpace* owner_space)

--- a/SimTKmath/Optimizers/src/IpOpt/IpZeroMatrix.hpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpZeroMatrix.hpp
@@ -12,7 +12,7 @@
 #include "IpUtils.hpp"
 #include "IpMatrix.hpp"
 
-namespace Ipopt
+namespace SimTKIpopt
 {
 
   /** Class for Matrices with only zero entries.


### PR DESCRIPTION
This PR fixes #510 by changing the `Ipopt` namespace to `SimTKIpopt`. This allows me to use Simbody with a different Ipopt in my direct collocation software.

An alternative solution is to create an option for users to "bring their own Ipopt" for use by Simbody. Changing the namespace is a quicker fix and prevents "branching" where Simbody is packaged differently on different platforms, etc. Also, Simbody's Optimizer classes provide dense Jacobian and Hessian matrices and Simbody's Ipopt uses a dense linear solver. I'm not sure that the sparse solvers that Ipopt typically uses would perform as well with dense matrices.

I'm not sure what the license implications are of my changes to Ipopt. If preferred, I could create a patch file and have CMake apply a patch to these files, rather than modifying them directly. Not sure if that helps (FYI this license file in the repo may be helpful for thinking about this: https://github.com/simbody/simbody/blob/master/SimTKmath/Optimizers/src/IpOpt/LICENSE.txt).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/580)
<!-- Reviewable:end -->
