### PR TITLE
Avoid Winstantiation-after-specialization from AppleClang9

### DIFF
--- a/SimTKcommon/Simulation/src/Measure.cpp
+++ b/SimTKcommon/Simulation/src/Measure.cpp
@@ -35,6 +35,12 @@
 #include <cassert>
 #include <algorithm>
 
+#if defined(__clang__) && __has_warning("-Winstantiation-after-specialization")
+    // Avoid the harmless warning "explicit instantiation of 'Zero' that
+    // occurs after an explicit specialization has no effect"
+    #pragma clang diagnostic ignored "-Winstantiation-after-specialization"
+#endif
+
 namespace SimTK {
 
 // These are here just to make sure they compile.

--- a/SimTKcommon/Simulation/src/Measure.cpp
+++ b/SimTKcommon/Simulation/src/Measure.cpp
@@ -35,10 +35,12 @@
 #include <cassert>
 #include <algorithm>
 
-#if defined(__clang__) && __has_warning("-Winstantiation-after-specialization")
-    // Avoid the harmless warning "explicit instantiation of 'Zero' that
-    // occurs after an explicit specialization has no effect"
-    #pragma clang diagnostic ignored "-Winstantiation-after-specialization"
+#if defined(__clang__)
+    #if __has_warning("-Winstantiation-after-specialization")
+        // Avoid the harmless warning "explicit instantiation of 'Zero' that
+        // occurs after an explicit specialization has no effect"
+        #pragma clang diagnostic ignored "-Winstantiation-after-specialization"
+    #endif
 #endif
 
 namespace SimTK {


### PR DESCRIPTION
This PR fixes #581 by following @sherm1's suggestion to suppress the warning.