### PR TITLE
Fix CMake so that examples depend on simbody-visualizer.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -620,6 +620,7 @@ add_subdirectory( SimTKmath )
 # SimTKMATH_INCLUDE_DIRECTORIES now set
 add_subdirectory( Simbody )
 # SimTKSIMBODY_INCLUDE_DIRECTORIES now set(but not used)
+# GUI_NAME now set
 
 if( BUILD_EXAMPLES )
     add_subdirectory( examples )

--- a/Simbody/CMakeLists.txt
+++ b/Simbody/CMakeLists.txt
@@ -160,6 +160,7 @@ if(BUILD_VISUALIZER)
     # in VisualizerProtocol.cpp
     # TODO even that is not sufficient.
     set(GUI_NAME "simbody-visualizer")
+    set(GUI_NAME ${GUI_NAME} PARENT_SCOPE)
     add_subdirectory(Visualizer/simbody-visualizer)
 endif()
 


### PR DESCRIPTION
This PR fixes CMakeLists files so that examples depend on simbody-visualizer. This used to be the behavior, but I think it was broken when examples were moved to the root of the repository. I did this by defining GUI_NAME in the "parent" scope.

I verified locally that this fix works.