### PR TITLE
Fix MultibodyGraphMaker bug when handling massless bodies

### DIFF
--- a/SimTKmath/include/simmath/MultibodyGraphMaker.h
+++ b/SimTKmath/include/simmath/MultibodyGraphMaker.h
@@ -568,6 +568,8 @@ public:
     defined in the input joint. In that case you should use a reverse joint
     when you build the system. **/
     bool isReversedFromJoint() const {return isReversed;}
+	/** Return the level of the outboard body (Ground is level 0) **/
+	int getLevel() const {return level;}
 
 private:
 friend class MultibodyGraphMaker;

--- a/SimTKmath/include/simmath/MultibodyGraphMaker.h
+++ b/SimTKmath/include/simmath/MultibodyGraphMaker.h
@@ -568,8 +568,8 @@ public:
     defined in the input joint. In that case you should use a reverse joint
     when you build the system. **/
     bool isReversedFromJoint() const {return isReversed;}
-	/** Return the level of the outboard body (Ground is level 0) **/
-	int getLevel() const {return level;}
+    /** Return the level of the outboard body (Ground is level 0) **/
+    int getLevel() const {return level;}
 
 private:
 friend class MultibodyGraphMaker;

--- a/SimTKmath/src/MultibodyGraphMaker.cpp
+++ b/SimTKmath/src/MultibodyGraphMaker.cpp
@@ -613,9 +613,9 @@ findHeaviestUnassignedReverseJoint(int inboardBody) const {
 // TODO: keep a list of unprocessed joints so we don't have to go through
 // all of them again at each level.
 void MultibodyGraphMaker::growTree() {
-    // Record the joints we added during this subtree sweep, and the level
-    // at which they were added. That way if we jumped levels ahead due to
-    // massless bodies we can take credit and keep going rather than quit.
+    // Record the joints for which we added mobilizers during this subtree
+    // sweep. That way if we jumped levels ahead due to massless bodies we
+    // can take credit and keep going rather than quit.
     std::set<int> jointsAdded;
     for (int level=1; ;++level) { // level of outboard (mobilized) body
         bool anyMobilizerAdded = false;

--- a/SimTKmath/src/MultibodyGraphMaker.cpp
+++ b/SimTKmath/src/MultibodyGraphMaker.cpp
@@ -613,27 +613,27 @@ findHeaviestUnassignedReverseJoint(int inboardBody) const {
 // TODO: keep a list of unprocessed joints so we don't have to go through
 // all of them again at each level.
 void MultibodyGraphMaker::growTree() {
-	// Record the joints we added during this subtree sweep, and the level
-	// at which they were added. That way if we jumped levels ahead due to
-	// massless bodies we can take credit and keep going rather than quit.
-	std::set<int> jointsAdded;
+    // Record the joints we added during this subtree sweep, and the level
+    // at which they were added. That way if we jumped levels ahead due to
+    // massless bodies we can take credit and keep going rather than quit.
+    std::set<int> jointsAdded;
     for (int level=1; ;++level) { // level of outboard (mobilized) body
         bool anyMobilizerAdded = false;
         for (int jNum=0; jNum<getNumJoints(); ++jNum) {
             // See if this joint is at the right level (meaning its inboard
             // body is at level-1) and is available to become a mobilizer.
             const Joint& joint = getJoint(jNum);
-			if (joint.hasMobilizer()) {
-				// Already done -- one of ours?
-				if (jointsAdded.count(jNum)) {
-					// We added it during this growTree() call -- is it at
-					// the current level?
-					const Mobilizer& mob = mobilizers[joint.mobilizer];
-					if (mob.getLevel() == level)
-						anyMobilizerAdded = true; // Added one at level.
-				}
-				continue; 
-			}
+            if (joint.hasMobilizer()) {
+                // Already done -- one of ours?
+                if (jointsAdded.count(jNum)) {
+                    // We added it during this growTree() call -- is it at
+                    // the current level?
+                    const Mobilizer& mob = mobilizers[joint.mobilizer];
+                    if (mob.getLevel() == level)
+                        anyMobilizerAdded = true; // Added one at level.
+                }
+                continue; 
+            }
             if (joint.mustBeLoopJoint) continue; // can't be a tree joint
             const Body& parent = getBody(joint.parentBodyNum);
             const Body& child  = getBody(joint.childBodyNum);
@@ -645,7 +645,7 @@ void MultibodyGraphMaker::growTree() {
                 if (child.level != level-1) continue; // not time yet
             } 
             addMobilizerForJoint(jNum);
-			jointsAdded.insert(jNum);
+            jointsAdded.insert(jNum);
             anyMobilizerAdded = true;
 
             // We just made joint jNum a mobilizer. If its outboard body 
@@ -666,13 +666,13 @@ void MultibodyGraphMaker::growTree() {
                 const int jfwd = findHeaviestUnassignedForwardJoint(bNum);
                 if (jfwd>=0 && getBody(getJoint(jfwd).childBodyNum).mass > 0) {
                     addMobilizerForJoint(jfwd);
-					jointsAdded.insert(jfwd);
+                    jointsAdded.insert(jfwd);
                     break;
                 }
                 const int jrev = findHeaviestUnassignedReverseJoint(bNum);
                 if (jrev>=0 && getBody(getJoint(jrev).parentBodyNum).mass > 0) {
                     addMobilizerForJoint(jrev);
-					jointsAdded.insert(jrev);
+                    jointsAdded.insert(jrev);
                     break;
                 }
 
@@ -680,12 +680,12 @@ void MultibodyGraphMaker::growTree() {
                 // body (if there is one) and keep trying.
                 if (jfwd >= 0) {
                     addMobilizerForJoint(jfwd);
-					jointsAdded.insert(jfwd);
+                    jointsAdded.insert(jfwd);
                     continue;
                 }
                 if (jrev >= 0) {
                     addMobilizerForJoint(jrev);
-					jointsAdded.insert(jrev);
+                    jointsAdded.insert(jrev);
                     continue;
                 }
 

--- a/SimTKmath/src/MultibodyGraphMaker.cpp
+++ b/SimTKmath/src/MultibodyGraphMaker.cpp
@@ -29,6 +29,7 @@
 #include "simmath/MultibodyGraphMaker.h"
 
 #include <exception>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <iostream>
@@ -612,13 +613,27 @@ findHeaviestUnassignedReverseJoint(int inboardBody) const {
 // TODO: keep a list of unprocessed joints so we don't have to go through
 // all of them again at each level.
 void MultibodyGraphMaker::growTree() {
+	// Record the joints we added during this subtree sweep, and the level
+	// at which they were added. That way if we jumped levels ahead due to
+	// massless bodies we can take credit and keep going rather than quit.
+	std::set<int> jointsAdded;
     for (int level=1; ;++level) { // level of outboard (mobilized) body
         bool anyMobilizerAdded = false;
         for (int jNum=0; jNum<getNumJoints(); ++jNum) {
             // See if this joint is at the right level (meaning its inboard
             // body is at level-1) and is available to become a mobilizer.
             const Joint& joint = getJoint(jNum);
-            if (joint.hasMobilizer()) continue; // already done
+			if (joint.hasMobilizer()) {
+				// Already done -- one of ours?
+				if (jointsAdded.count(jNum)) {
+					// We added it during this growTree() call -- is it at
+					// the current level?
+					const Mobilizer& mob = mobilizers[joint.mobilizer];
+					if (mob.getLevel() == level)
+						anyMobilizerAdded = true; // Added one at level.
+				}
+				continue; 
+			}
             if (joint.mustBeLoopJoint) continue; // can't be a tree joint
             const Body& parent = getBody(joint.parentBodyNum);
             const Body& child  = getBody(joint.childBodyNum);
@@ -630,6 +645,7 @@ void MultibodyGraphMaker::growTree() {
                 if (child.level != level-1) continue; // not time yet
             } 
             addMobilizerForJoint(jNum);
+			jointsAdded.insert(jNum);
             anyMobilizerAdded = true;
 
             // We just made joint jNum a mobilizer. If its outboard body 
@@ -650,11 +666,13 @@ void MultibodyGraphMaker::growTree() {
                 const int jfwd = findHeaviestUnassignedForwardJoint(bNum);
                 if (jfwd>=0 && getBody(getJoint(jfwd).childBodyNum).mass > 0) {
                     addMobilizerForJoint(jfwd);
+					jointsAdded.insert(jfwd);
                     break;
                 }
                 const int jrev = findHeaviestUnassignedReverseJoint(bNum);
                 if (jrev>=0 && getBody(getJoint(jrev).parentBodyNum).mass > 0) {
                     addMobilizerForJoint(jrev);
+					jointsAdded.insert(jrev);
                     break;
                 }
 
@@ -662,10 +680,12 @@ void MultibodyGraphMaker::growTree() {
                 // body (if there is one) and keep trying.
                 if (jfwd >= 0) {
                     addMobilizerForJoint(jfwd);
+					jointsAdded.insert(jfwd);
                     continue;
                 }
                 if (jrev >= 0) {
                     addMobilizerForJoint(jrev);
+					jointsAdded.insert(jrev);
                     continue;
                 }
 


### PR DESCRIPTION
MultibodyGraphMaker takes bodies and joints and finds a spanning tree. It works breadth-first by adding all the base bodies (level 1, bodies with joints to Ground), then all the bodies with joints to base bodies (level 2), etc. until it reaches a level where it can't find any body. If there are still bodies left one of them needs to be connected to Ground by a free joint, then we can resume.

A massless body modifies this algorithm because we can't end a branch with one. So if we encounter a massless body at level n, rather than wait for level n+1's turn, we continue on lengthening the branch top n+1, n+2, etc. until we hit a massful body. Then we go back to the rest of the level n bodies and move up to n+1.

This PR fixes a bug where the algorithm did not properly keep track of the fact that, while working on level n, it may also have added some bodies at n+1 or higher due to massless bodies. So then when moving on to n+1 it would decide there were no bodies remaining to be added. That meant it would go try to make a new base body by adding a free joint.

The proposed fix is to keep track of all the joints that were added so we can check when at level n+1 if an already-mobilized body was actually added during this same tree sweep and if so count that as a success and keep going.

Resolves issue #537 reported by @aseth1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/592)
<!-- Reviewable:end -->
