### PR TITLE
ADOLC Common

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ endif()
 include(GNUInstallDirs)
 
 # Include CMake macros that we wrote to reduce duplication in this project.
-include(cmake/simbody_macros.cmake)
+include(cmake/SimbodyMacros.cmake)
 
 # Declare the option for code coverage
 option(SIMBODY_COVERAGE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ endif()
 # Include GNUInstallDirs to get canonical paths
 include(GNUInstallDirs)
 
+# Include CMake macros that we wrote to reduce duplication in this project.
+include(cmake/simbody_macros.cmake)
+
 # Declare the option for code coverage
 option(SIMBODY_COVERAGE
        "Adding ability to assess test coverage (requires gcc or clang)."
@@ -575,6 +578,7 @@ if(BUILD_ADOLC_LIBRARIES)
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
     find_package(ADOLC REQUIRED)
     include_directories("${ADOLC_INCLUDES}")
+    simbody_copy_dlls(ADOLC "${ADOLC_DIR}/bin")
 endif()
 
 #

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -105,12 +105,30 @@ or any other Index type to an argument expecting a certain Index type. **/
 #   define SimTK_DEFAULT_PRECISION 2
 #endif
 
+#if (SimTK_DEFAULT_PRECISION != 2) && SimTK_REAL_IS_ADOUBLE
+    #error MUST USE DOUBLE PRECISION WITH ADOL-C ADOUBLE.
+#endif
+
 #if   (SimTK_DEFAULT_PRECISION == 1)
 /** This type is for use in C; in C++ use SimTK::Real instead. */
     typedef float SimTK_Real;
 #elif (SimTK_DEFAULT_PRECISION == 2)
 /** This type is for use in C; in C++ use SimTK::Real instead. */
-    typedef double SimTK_Real;
+    #ifndef SimTK_REAL_IS_ADOUBLE
+        typedef double SimTK_Real;
+    #else
+        #ifdef _MSC_VER
+            // Ignore warnings from ADOL-C headers.
+            #pragma warning(push)
+            // 'argument': conversion from 'size_t' to 'locint', possible loss of data.
+            #pragma warning(disable: 4267)
+        #endif
+        #include <adolc/adouble.h>
+        typedef double SimTK_Real;
+        #ifdef _MSC_VER
+            #pragma warning(pop)
+        #endif
+    #endif
 #elif (SimTK_DEFAULT_PRECISION == 4)
 /** This type is for use in C; in C++ use SimTK::Real instead. */
     typedef long double SimTK_Real;
@@ -168,6 +186,7 @@ or any other Index type to an argument expecting a certain Index type. **/
     #pragma warning(disable:4251) /*no DLL interface for type of member of exported class*/
     #pragma warning(disable:4275) /*no DLL interface for base class of exported class*/
     #pragma warning(disable:4345) /*warning about PODs being default-initialized*/
+    #pragma warning(disable:4800) /*warning about forcing value to bool true or false*/
 
 
     /* Until VS2015 struct timespec was missing from <ctime> so is faked here 
@@ -750,6 +769,9 @@ types to specialize the IsFloatingType struct template for those types. **/
 SimTK_SPECIALIZE_FLOATING_TYPE(float); 
 SimTK_SPECIALIZE_FLOATING_TYPE(double); 
 SimTK_SPECIALIZE_FLOATING_TYPE(long double); 
+#ifdef SimTK_REAL_IS_ADOUBLE
+    SimTK_SPECIALIZE_FLOATING_TYPE(adouble);
+#endif
 
 /** Compile-time type test: is this the void type?. **/
 template <class T> struct IsVoidType {
@@ -926,6 +948,9 @@ SimTK_NICETYPENAME_LITERAL(std::complex<double>);
 SimTK_NICETYPENAME_LITERAL(std::complex<long double>); 
 SimTK_NICETYPENAME_LITERAL(SimTK::FalseType);
 SimTK_NICETYPENAME_LITERAL(SimTK::TrueType); 
+#ifdef SimTK_REAL_IS_ADOUBLE
+    SimTK_NICETYPENAME_LITERAL(adouble);
+#endif
 
 
 #endif /* C++ stuff */

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -120,10 +120,11 @@ or any other Index type to an argument expecting a certain Index type. **/
         #ifdef _MSC_VER
             // Ignore warnings from ADOL-C headers.
             #pragma warning(push)
-            // 'argument': conversion from 'size_t' to 'locint', possible loss of data.
+            // 'argument': conversion from 'size_t' to 'locint', possible loss
+            // of data.
             #pragma warning(disable: 4267)
         #endif
-        #include <adolc/adouble.h>
+        #include <adolc/adolc.h>
         typedef double SimTK_Real;
         #ifdef _MSC_VER
             #pragma warning(pop)

--- a/SimTKcommon/tests/CMakeLists.txt
+++ b/SimTKcommon/tests/CMakeLists.txt
@@ -23,10 +23,10 @@ add_subdirectory(adhoc)
 
 file(GLOB ALL_REGR_TESTS "*.cpp")
 set(REGR_TESTS ${ALL_REGR_TESTS})
-# TestAutodiffADOLCCommon was designed to test the ADOL-C libraries only
+# TestADOLCCommon was designed to test the ADOL-C libraries only
 # and is therefore excluded from the tests of the shared and static libraries.
-# file(GLOB ADOLC_SPECIFIC_TESTS "*TestAutodiffADOLCCommon*")
-# list(REMOVE_ITEM REGR_TESTS ${ADOLC_SPECIFIC_TESTS})
+file(GLOB ADOLC_SPECIFIC_TESTS "*TestADOLCCommon*")
+list(REMOVE_ITEM REGR_TESTS ${ADOLC_SPECIFIC_TESTS})
 
 foreach(TEST_PROG ${REGR_TESTS})
     get_filename_component(TEST_ROOT ${TEST_PROG} NAME_WE)

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -39,22 +39,19 @@ void testDerivativeADOLC() {
     xp[0] = -2.3;
 
     trace_on(1);
-    adouble* x = new adouble;
-    adouble* y = new adouble;
-    x[0] <<= xp[0];
-    y[0] = 3*pow(x[0],3)+cos(x[0])+1;
-    double y0[1];
-    y[0] >>= y0[0];
+    adouble x;
+    adouble y;
+    x <<= xp[0];
+    y = 3*pow(x,3)+cos(x)+1;
+    double y0;
+    y >>= y0;
     trace_off();
 
     double** J;
     J = myalloc(1,1);
     jacobian(1, 1, 1, xp, J);
-    SimTK_TEST(J[0][0] == 9*pow(x[0],2)-sin(x[0]));
-
+    SimTK_TEST(J[0][0] == 9*pow(x,2)-sin(x));
     myfree(J);
-    delete y;
-    delete x;
 }
 
 int main() {

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -32,14 +32,15 @@ using std::cin;
 
 using namespace SimTK;
 
-// Test derivative with ADOLC
+// Test derivative of simple function with ADOLC
 void testAdouble() {
-    double* xp = new double[1];
+    double xp[1];
     xp[0] = -2.3;
-    adouble* x = new adouble[1];
+
     trace_on(1);
+    adouble* x = new adouble[1];
+    adouble* y = new adouble[1];
     x[0] <<= xp[0];
-    adouble y[1];
     y[0] = 3 * pow(x[0],3) + cos(x[0]) + 1;
     double y0[1];
     y[0] >>= y0[0];
@@ -49,6 +50,9 @@ void testAdouble() {
     J = myalloc(1,1);
     jacobian(1, 1, 1, xp, J);
     SimTK_TEST(J[0][0] == 48.355705212176716);
+
+    delete[] y;
+    delete[] x;
 }
 
 int main() {

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -23,7 +23,7 @@
 
 #include "SimTKcommon.h"
 #include "SimTKcommon/Testing.h"
-#include <adolc\adolc.h>
+#include <adolc/adolc.h> // for jacobian() ADOLC driver
 
 #include <iostream>
 using std::cout;
@@ -32,16 +32,17 @@ using std::cin;
 
 using namespace SimTK;
 
-// Test derivative of simple function with ADOLC
-void testAdouble() {
+// Test derivative of simple function with ADOLC without Simbody; just to make
+// sure that ADOLC is included properly
+void testDerivativeADOLC() {
     double xp[1];
     xp[0] = -2.3;
 
     trace_on(1);
-    adouble* x = new adouble[1];
-    adouble* y = new adouble[1];
+    adouble* x = new adouble;
+    adouble* y = new adouble;
     x[0] <<= xp[0];
-    y[0] = 3 * pow(x[0],3) + cos(x[0]) + 1;
+    y[0] = 3*pow(x[0],3)+cos(x[0])+1;
     double y0[1];
     y[0] >>= y0[0];
     trace_off();
@@ -49,14 +50,15 @@ void testAdouble() {
     double** J;
     J = myalloc(1,1);
     jacobian(1, 1, 1, xp, J);
-    SimTK_TEST(J[0][0] == 48.355705212176716);
+    SimTK_TEST(J[0][0] == 9*pow(x[0],2)-sin(x[0]));
 
-    delete[] y;
-    delete[] x;
+    myfree(J);
+    delete y;
+    delete x;
 }
 
 int main() {
     SimTK_START_TEST("TestADOLCCommon");
-        SimTK_SUBTEST(testAdouble);
+        SimTK_SUBTEST(testDerivativeADOLC);
     SimTK_END_TEST();
 }

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -1,0 +1,58 @@
+/* -------------------------------------------------------------------------- *
+ *                       Simbody(tm): SimTKcommon                             *
+ * -------------------------------------------------------------------------- *
+ * This is part of the SimTK biosimulation toolkit originating from           *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
+ *                                                                            *
+ * Portions copyright (c) 2010-17 Stanford University and the Authors.        *
+ * Authors: Antoine Falisse                                                   *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "SimTKcommon.h"
+#include "SimTKcommon/Testing.h"
+#include <adolc\adolc.h>
+
+#include <iostream>
+using std::cout;
+using std::endl;
+using std::cin;
+
+using namespace SimTK;
+
+// Test derivative with ADOLC
+void testAdouble() {
+    double* xp = new double[1];
+    xp[0] = -2.3;
+    adouble* x = new adouble[1];
+    trace_on(1);
+    x[0] <<= xp[0];
+    adouble y[1];
+    y[0] = 3 * pow(x[0],3) + cos(x[0]) + 1;
+    double y0[1];
+    y[0] >>= y0[0];
+    trace_off();
+
+    double** J;
+    J = myalloc(1,1);
+    jacobian(1, 1, 1, xp, J);
+    SimTK_TEST(J[0][0] == 48.355705212176716);
+}
+
+int main() {
+    SimTK_START_TEST("TestADOLCCommon");
+        SimTK_SUBTEST(testAdouble);
+    SimTK_END_TEST();
+}

--- a/cmake/SimbodyMacros.cmake
+++ b/cmake/SimbodyMacros.cmake
@@ -31,7 +31,7 @@ function(simbody_copy_dlls DEP_NAME DEP_INSTALL_DIR)
             COMMENT "Copying DLLs from ${DEP_INSTALL_DIR} to ${DEST_DIR}:${DLL_NAMES}")
         add_custom_target(Copy_${DEP_NAME}_DLLs ALL DEPENDS ${DLLS_DEST})
         set_target_properties(Copy_${DEP_NAME}_DLLs PROPERTIES
-            PROJECT_LABEL "Copy ${DEP_NAME} DLLs" FOLDER "simbody")
+            PROJECT_LABEL "Copy ${DEP_NAME} DLLs")
         install(FILES ${DLLS} DESTINATION ${CMAKE_INSTALL_BINDIR})
     endif()
 endfunction()

--- a/cmake/Simbody_macros.cmake
+++ b/cmake/Simbody_macros.cmake
@@ -1,0 +1,37 @@
+# These CMake functions serve to reduce duplication across CMakeLists.txt files.
+
+include(CMakeParseArguments)
+
+# Copy DLL files from a dependency's installation into Simbody's
+# build and install directories. This is a Windows-specific function enabled 
+# only on Windows. The intention is to allow the runtime loader to find all 
+# the required DLLs without editing the PATH environment variable.
+# Copied from OpenSimMacros.cmake.
+# In the future, we could use the VS_USER_PROPS_CXX property instead
+# https://gitlab.kitware.com/cmake/cmake/commit/ef121ca0c33fb4931007c38b22c046998694b052
+function(simbody_copy_dlls DEP_NAME DEP_INSTALL_DIR)
+    # On Windows, copy dlls into the Simbody binary directory.
+    if(WIN32)
+        file(GLOB_RECURSE DLLS ${DEP_INSTALL_DIR}/*.dll)
+        if(NOT DLLS)
+            message(FATAL_ERROR "Zero DLLs found in directory "
+                                "${DEP_INSTALL_DIR}.")
+        endif()
+        set(DEST_DIR "${CMAKE_BINARY_DIR}/${CMAKE_CFG_INTDIR}")
+        set(DLL_NAMES "")
+        foreach(DLL IN LISTS DLLS)
+            get_filename_component(DLL_NAME ${DLL} NAME)
+            list(APPEND DLLS_DEST "${DEST_DIR}/${DLL_NAME}")
+            set(DLL_NAMES "${DLL_NAMES} ${DLL_NAME}")
+        endforeach()
+        add_custom_command(OUTPUT ${DLLS_DEST}
+            COMMAND ${CMAKE_COMMAND} -E make_directory ${DEST_DIR}
+            COMMAND ${CMAKE_COMMAND} -E copy ${DLLS} ${DEST_DIR}
+            DEPENDS ${DLLS}
+            COMMENT "Copying DLLs from ${DEP_INSTALL_DIR} to ${DEST_DIR}:${DLL_NAMES}")
+        add_custom_target(Copy_${DEP_NAME}_DLLs ALL DEPENDS ${DLLS_DEST})
+        set_target_properties(Copy_${DEP_NAME}_DLLs PROPERTIES
+            PROJECT_LABEL "Copy ${DEP_NAME} DLLs" FOLDER "simbody")
+        install(FILES ${DLLS} DESTINATION ${CMAKE_INSTALL_BINDIR})
+    endif()
+endfunction()


### PR DESCRIPTION
+@sherm1, +@chrisdembia. This PR contains the changes in `common.h` that will enable setting`Real `as `adouble` when building Simbody with ADOLC. However, for now, `Real `is still set to `double ` so that we can build Simbody with ADOLC in CI and have tests. There are a couple of additional minor changes in `common.h`. This PR also contains some changes in the CMake files that were needed to copy the ADOLC dll that is needed in tests relying on ADOLC drivers. `simbody_cmake_macros` has been directly copied from one of @chrisdembia's projects.  Finally, this PR contains a simple test case that does some trivial use of `adouble `, ie it computes the derivative of a simple function. Please let me know if you would like to see other tests in this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/600)
<!-- Reviewable:end -->
