### PR TITLE
ADOLC Ntraits

### DIFF
--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
@@ -1022,14 +1022,12 @@ SimTK_NTRAITS_CONJ_SPEC(double,float);SimTK_NTRAITS_CONJ_SPEC(double,double);
 // no support for conjugate<adouble> at the moment. However, these structs
 // are necessary for compilation.
 #ifdef SimTK_REAL_IS_ADOUBLE
-    template<> template<> struct NTraits< conjugate<float> >::Result<adouble> {
-        typedef conjugate<Widest<float,adouble>::Type> W;
-        typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub;
-    };
+    template<> template<> struct NTraits< conjugate<float> >::Result<adouble>
+    {   typedef conjugate<Widest<float,adouble>::Type> W;
+        typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub; };
     template<> template<> struct NTraits< conjugate<double> >::Result<adouble>
     {   typedef conjugate<Widest<double,adouble>::Type> W;
-        typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub;
-    };
+        typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub; };
 #endif
 
 

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
@@ -153,8 +153,8 @@ template <> struct Narrowest<float,double>             {typedef float  Type; typ
 template <> struct Narrowest<double,float>             {typedef float  Type; typedef float Precision;};
 template <> struct Narrowest<double,double>            {typedef double Type; typedef double Precision;};
 #ifdef SimTK_REAL_IS_ADOUBLE
-    /// Be careful that Narrowest(float,adouble) is adouble since it is the
-    /// narrowest type than can hold the value and the derivative.
+    /// Be careful that Narrowest(float,adouble)::Type is adouble since it is
+    /// the narrowest type than can hold the value and the derivative.
     template <> struct Narrowest<float,adouble>
       {typedef adouble Type; typedef float Precision;};
     template <> struct Narrowest<adouble,float>
@@ -1401,8 +1401,8 @@ template <> class CNT<double> : public NTraits<double> { };
         static bool isNaN   (const T& t) {return SimTK::isNaN(t);}
         static bool isInf   (const T& t) {return SimTK::isInf(t);}
         /* Methods to use for approximate comparisons. Perform comparison in
-        /* the wider of the two precisions, using the default tolerance from
-        /* the narrower of the two precisions. */
+        the wider of the two precisions, using the default tolerance from
+        the narrower of the two precisions. */
         static double getDefaultTolerance()
         {return RTraits<T>::getDefaultTolerance();}
         static bool isNumericallyEqual(const T& t, const float& f)

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
@@ -31,8 +31,8 @@
  * adouble if using ADOL-C but there is no support for complex<adouble> and
  * conjugate<adouble> at the moment). Each of these may be modified by a
  * negator, which does not change the in-memory \e representation but negates
- * the \einterpretation. Thus there are 12 distinct scalar types (more if using
- * ADOL-C): 2 precisions each of real, complex, and conjugate and their
+ * the \e interpretation. Thus there are 12 distinct scalar types (more if
+ * using ADOL-C): 2 precisions each of real, complex, and conjugate and their
  * negators.
  * @verbatim
  *      The Scalar Types
@@ -114,11 +114,16 @@ template <> struct Widest<float,double>             {typedef double      Type;  
 template <> struct Widest<double,float>             {typedef double      Type;  typedef double      Precision;};
 template <> struct Widest<double,double>            {typedef double      Type;  typedef double      Precision;};
 #ifdef SimTK_REAL_IS_ADOUBLE
-    template <> struct Widest<float,adouble>        {typedef adouble     Type;  typedef adouble     Precision;};
-    template <> struct Widest<double,adouble>       {typedef adouble     Type;  typedef adouble     Precision;};
-    template <> struct Widest<adouble,float>        {typedef adouble     Type;  typedef adouble     Precision;};
-    template <> struct Widest<adouble,double>       {typedef adouble     Type;  typedef adouble     Precision;};
-    template <> struct Widest<adouble,adouble>      {typedef adouble     Type;  typedef adouble     Precision;};
+    template <> struct Widest<float,adouble>
+      {typedef adouble     Type;  typedef double     Precision;};
+    template <> struct Widest<double,adouble>
+      {typedef adouble     Type;  typedef double     Precision;};
+    template <> struct Widest<adouble,float>
+      {typedef adouble     Type;  typedef double     Precision;};
+    template <> struct Widest<adouble,double>
+      {typedef adouble     Type;  typedef double     Precision;};
+    template <> struct Widest<adouble,adouble>
+      {typedef adouble     Type;  typedef double     Precision;};
 #endif
 template <class R1, class R2> struct Widest< complex<R1>,complex<R2> > { 
     typedef complex< typename Widest<R1,R2>::Type > Type; 
@@ -150,11 +155,16 @@ template <> struct Narrowest<double,double>            {typedef double Type; typ
 #ifdef SimTK_REAL_IS_ADOUBLE
     /// Be careful that Narrowest(float,adouble) is adouble since it is the
     /// narrowest type than can hold the value and the derivative.
-    template <> struct Narrowest<float,adouble>        {typedef adouble Type; typedef adouble Precision;};
-    template <> struct Narrowest<adouble,float>        {typedef adouble Type; typedef adouble Precision;};
-    template <> struct Narrowest<double,adouble>       {typedef adouble Type; typedef adouble Precision;};
-    template <> struct Narrowest<adouble,double>       {typedef adouble Type; typedef adouble Precision;};
-    template <> struct Narrowest<adouble,adouble>      {typedef adouble Type; typedef adouble Precision;};
+    template <> struct Narrowest<float,adouble>
+      {typedef adouble Type; typedef float Precision;};
+    template <> struct Narrowest<adouble,float>
+      {typedef adouble Type; typedef float Precision;};
+    template <> struct Narrowest<double,adouble>
+      {typedef adouble Type; typedef double Precision;};
+    template <> struct Narrowest<adouble,double>
+      {typedef adouble Type; typedef double Precision;};
+    template <> struct Narrowest<adouble,adouble>
+      {typedef adouble Type; typedef double Precision;};
 #endif
 template <class R1, class R2> struct Narrowest< complex<R1>,complex<R2> > { 
     typedef complex< typename Narrowest<R1,R2>::Type >  Type; 
@@ -189,13 +199,16 @@ public:
 #ifdef SimTK_REAL_IS_ADOUBLE
     template <> class RTraits<adouble> {
     public:
-        static const adouble& getEps()         {static const adouble c=std::numeric_limits<double>::epsilon(); return c;}
-        static const adouble& getSignificant() {static const adouble c=pow(getEps(), 0.875); return c;}
+        static const adouble& getEps() {
+            static const adouble c=std::numeric_limits<double>::epsilon();
+            return c;}
+        static const adouble& getSignificant() {
+            static const adouble c=pow(getEps(), 0.875); return c;}
         /// The default numerical error tolerance is always a double even when
         /// using real as adouble. The rationale was to enable using the
         /// isNumericallyEqual() functions as they are specified. The user
         /// should be careful when using getDefaultTolerance() while taping.
-        static double getDefaultTolerance()    {return getSignificant().value();}
+        static double getDefaultTolerance() {return getSignificant().value();}
     };
 #endif
 
@@ -353,19 +366,22 @@ inline bool isNumericallyEqual(const double& a, const double& b,
     /// real part of the adouble, of type double, is considered. The user
     /// should be careful when using isNumericallyEqual() while taping.
     inline bool isNumericallyEqual(const adouble& a, const double& b,
-                                   double tol = RTraits<adouble>::getDefaultTolerance())
+                                   double tol =
+                                   RTraits<adouble>::getDefaultTolerance())
     {   return isNumericallyEqual(a.value(), b, tol); }
     /// Compare a double with an adouble for approximate equality. Only the
     /// real part of the adouble, of type double, is considered. The user
     /// should be careful when using isNumericallyEqual() while taping.
     inline bool isNumericallyEqual(const double& a, const adouble& b,
-                                   double tol = RTraits<adouble>::getDefaultTolerance())
+                                   double tol =
+                                   RTraits<adouble>::getDefaultTolerance())
     {   return isNumericallyEqual(a, b.value(), tol); }
     /// Compare two adoubles for approximate equality. Only the
     /// real part of the adoubles, of type double, are considered. The user
     /// should be careful when using isNumericallyEqual() while taping.
     inline bool isNumericallyEqual(const adouble& a, const adouble& b,
-                                   double tol = RTraits<adouble>::getDefaultTolerance())
+                                   double tol =
+                                   RTraits<adouble>::getDefaultTolerance())
     {   return isNumericallyEqual(a.value(), b.value(), tol); }
 #endif
 
@@ -378,17 +394,21 @@ inline bool isNumericallyEqual(const double& a, const float& b,
                                double tol = RTraits<float>::getDefaultTolerance())
 {   return isNumericallyEqual(a, (double)b, tol); }
 #ifdef SimTK_REAL_IS_ADOUBLE
-    /// Compare a float and an adouble for approximate equality at float precision.
-    /// Only the real part of the adouble, of type double, is considered. The
-    /// user should be careful when using isNumericallyEqual() while taping.
+    /// Compare a float and an adouble for approximate equality at float
+    /// precision. Only the real part of the adouble, of type double, is
+    /// considered. The user should be careful when using isNumericallyEqual()
+    /// while taping.
     inline bool isNumericallyEqual(const float& a, const adouble& b,
-                                   double tol = RTraits<float>::getDefaultTolerance())
+                                   double tol =
+                                   RTraits<float>::getDefaultTolerance())
     {   return isNumericallyEqual(a, b.value(), tol); }
-    /// Compare a float and an adouble for approximate equality at float precision.
-    /// Only the real part of the adouble, of type double, is considered. The
-    /// user should be careful when using isNumericallyEqual() while taping.
+    /// Compare a float and an adouble for approximate equality at float
+    /// precision. Only the real part of the adouble, of type double, is
+    /// considered. The user should be careful when using isNumericallyEqual()
+    /// while taping.
     inline bool isNumericallyEqual(const adouble& a, const float& b,
-                                   double tol = RTraits<float>::getDefaultTolerance())
+                                   double tol =
+                                   RTraits<float>::getDefaultTolerance())
     {   return isNumericallyEqual(a.value(), b, tol); }
 #endif
 
@@ -413,13 +433,15 @@ inline bool isNumericallyEqual(int a, const double& b,
     /// part of the adouble, of type double, is considered. The user should be
     /// careful when using isNumericallyEqual() while taping.
     inline bool isNumericallyEqual(const adouble& a, int b,
-                                   double tol = RTraits<adouble>::getDefaultTolerance())
+                                   double tol =
+                                   RTraits<adouble>::getDefaultTolerance())
     {   return isNumericallyEqual(a.value(), b, tol); }
     /// %Test an adouble for approximate equality to an integer. Only the real
     /// part of the adouble, of type double, is considered. The user should be
     /// careful when using isNumericallyEqual() while taping.
     inline bool isNumericallyEqual(int a, const adouble& b,
-                                   double tol = RTraits<adouble>::getDefaultTolerance())
+                                   double tol =
+                                   RTraits<adouble>::getDefaultTolerance())
     {   return isNumericallyEqual(a, b.value(), tol); }
 #endif
 
@@ -494,19 +516,24 @@ isNumericallyEqual(int a, const std::complex<P>& b,
                    double tol = RTraits<P>::getDefaultTolerance())
 {   return isNumericallyEqual(b,a,tol); }
 #ifdef SimTK_REAL_IS_ADOUBLE
-    /// %Test whether a complex number is approximately equal to a particular adouble.
-    /// Only the real part of the adouble, of type double, is considered. The
-    /// user should be careful when using isNumericallyEqual() while taping.
+    /// %Test whether a complex number is approximately equal to a particular
+    /// adouble. Only the real part of the adouble, of type double, is
+    /// considered. The user should be careful when using isNumericallyEqual()
+    /// while taping.
     template <class P> inline bool
     isNumericallyEqual(const std::complex<P>& a, const adouble& b,
-                       double tol = RTraits<typename Narrowest<P,adouble>::Precision>::getDefaultTolerance())
-    {   return isNumericallyEqual(a.real(),b,tol) && isNumericallyEqual(a.imag(),0.,tol); }
-    /// %Test whether a complex number is approximately equal to a particular adouble.
-    /// Only the real part of the adouble, of type double, is considered. The
-    /// user should be careful when using isNumericallyEqual() while taping.
+                       double tol = RTraits<typename Narrowest<P,adouble>::
+                       Precision>::getDefaultTolerance())
+    {   return isNumericallyEqual(a.real(),b,tol) &&
+        isNumericallyEqual(a.imag(),0.,tol); }
+    /// %Test whether a complex number is approximately equal to a particular
+    /// adouble. Only the real part of the adouble, of type double, is
+    /// considered. The user should be careful when using isNumericallyEqual()
+    /// while taping.
     template <class P> inline bool
     isNumericallyEqual(const adouble& a, const std::complex<P>& b,
-                       double tol = RTraits<typename Narrowest<P,adouble>::Precision>::getDefaultTolerance())
+                       double tol = RTraits<typename Narrowest<P,adouble>::
+                       Precision>::getDefaultTolerance())
     {   return isNumericallyEqual(b,a,tol);   }
 #endif
 
@@ -541,19 +568,24 @@ isNumericallyEqual(int a, const conjugate<P>& b,
                    double tol = RTraits<P>::getDefaultTolerance())
 {   return isNumericallyEqual(b,a,tol); }
 #ifdef SimTK_REAL_IS_ADOUBLE
-    /// %Test whether a conjugate number is approximately equal to a particular adouble.
-    /// Only the real part of the adouble, of type double, is considered. The
-    /// user should be careful when using isNumericallyEqual() while taping.
+    /// %Test whether a conjugate number is approximately equal to a particular
+    /// adouble. Only the real part of the adouble, of type double, is
+    /// considered. The user should be careful when using isNumericallyEqual()
+    /// while taping.
     template <class P> inline bool
     isNumericallyEqual(const conjugate<P>& a, const adouble& b,
-                       double tol = RTraits<typename Narrowest<P, adouble>::Precision>::getDefaultTolerance())
-    {   return isNumericallyEqual(a.real(),b,tol) && isNumericallyEqual(a.imag(),0.,tol); }
-    /// %Test whether a conjugate number is approximately equal to a particular adouble.
-    /// Only the real part of the adouble, of type double, is considered. The
-    /// user should be careful when using isNumericallyEqual() while taping.
+                       double tol = RTraits<typename Narrowest<P, adouble>::
+                       Precision>::getDefaultTolerance())
+    {   return isNumericallyEqual(a.real(),b,tol) &&
+        isNumericallyEqual(a.imag(),0.,tol); }
+    /// %Test whether a conjugate number is approximately equal to a particular
+    /// adouble. Only the real part of the adouble, of type double, is
+    /// considered. The user should be careful when using isNumericallyEqual()
+    /// while taping.
     template <class P> inline bool
     isNumericallyEqual(const adouble& a, const conjugate<P>& b,
-                       double tol = RTraits<typename Narrowest<P,adouble>::Precision>::getDefaultTolerance())
+                       double tol = RTraits<typename Narrowest<P,adouble>::
+                       Precision>::getDefaultTolerance())
     {   return isNumericallyEqual(b,a,tol); }
 #endif
 
@@ -702,8 +734,10 @@ public:
     static bool isNumericallyEqual(const T& a, int b) {return SimTK::isNumericallyEqual(a,b);}
     static bool isNumericallyEqual(const T& a, int b, double tol) {return SimTK::isNumericallyEqual(a,b,tol);}
     #ifdef SimTK_REAL_IS_ADOUBLE
-        static bool isNumericallyEqual(const T& a, const adouble& b) {return SimTK::isNumericallyEqual(a,b);}
-        static bool isNumericallyEqual(const T& a, const adouble& b, double tol) {return SimTK::isNumericallyEqual(a,b,tol);}
+        static bool isNumericallyEqual(const T& a, const adouble& b)
+        {    return SimTK::isNumericallyEqual(a,b);  }
+        static bool isNumericallyEqual(const T& a, const adouble& b,
+            double tol) {    return SimTK::isNumericallyEqual(a,b,tol);  }
     #endif
 
     // The rest are the same as the real equivalents, with zero imaginary part.              
@@ -916,8 +950,10 @@ public:
     static bool isNumericallyEqual(const T& a, int b) {return SimTK::isNumericallyEqual(a,b);}
     static bool isNumericallyEqual(const T& a, int b, double tol) {return SimTK::isNumericallyEqual(a,b,tol);}
     #ifdef SimTK_REAL_IS_ADOUBLE
-        static bool isNumericallyEqual(const T& a, const adouble& b) {return SimTK::isNumericallyEqual(a,b);}
-        static bool isNumericallyEqual(const T& a, const adouble& b, double tol) {return SimTK::isNumericallyEqual(a,b,tol);}
+        static bool isNumericallyEqual(const T& a, const adouble& b)
+        {    return SimTK::isNumericallyEqual(a,b);  }
+        static bool isNumericallyEqual(const T& a, const adouble& b,
+            double tol) {    return SimTK::isNumericallyEqual(a,b,tol);  }
     #endif
 
     // The rest are the same as the real equivalents, with zero imaginary part.              
@@ -990,8 +1026,8 @@ SimTK_NTRAITS_CONJ_SPEC(double,float);SimTK_NTRAITS_CONJ_SPEC(double,double);
         typedef conjugate<Widest<float,adouble>::Type> W;
         typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub;
     };
-    template<> template<> struct NTraits< conjugate<double> >::Result<adouble> {
-        typedef conjugate<Widest<double,adouble>::Type> W;
+    template<> template<> struct NTraits< conjugate<double> >::Result<adouble>
+    {   typedef conjugate<Widest<double,adouble>::Type> W;
         typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub;
     };
 #endif
@@ -1260,9 +1296,11 @@ template <> class CNT<double> : public NTraits<double> { };
         typedef T                ScalarNormSq;
         template <class P> struct Result {
             typedef typename CNT<P>::template Result<adouble>::Mul Mul;
-            typedef typename CNT< typename CNT<P>::THerm >::template Result<adouble>::Mul Dvd;
+            typedef typename CNT< typename CNT<P>::THerm >::template
+                Result<adouble>::Mul Dvd;
             typedef typename CNT<P>::template Result<adouble>::Add Add;
-            typedef typename CNT< typename CNT<P>::TNeg >::template Result<adouble>::Add Sub;
+            typedef typename CNT< typename CNT<P>::TNeg >::template
+                Result<adouble>::Add Sub;
         };
         template <class P> struct Substitute {
             typedef P Type;
@@ -1290,11 +1328,15 @@ template <> class CNT<double> : public NTraits<double> { };
         static const T& real(const T& t) { return t; }
         static T&       real(T& t)       { return t; }
         static const T& imag(const T&)   { return getZero(); }
-        static T&       imag(T&)         { assert(false); return *reinterpret_cast<T*>(0); }
-        static const TNeg& negate(const T& t) {return reinterpret_cast<const TNeg&>(t);}
+        static T&       imag(T&)
+            { assert(false); return *reinterpret_cast<T*>(0); }
+        static const TNeg& negate(const T& t)
+            {return reinterpret_cast<const TNeg&>(t);}
         static       TNeg& negate(T& t) {return reinterpret_cast<TNeg&>(t);}
-        static const THerm& transpose(const T& t) {return reinterpret_cast<const THerm&>(t);}
-        static       THerm& transpose(T& t) {return reinterpret_cast<THerm&>(t);}
+        static const THerm& transpose(const T& t)
+            {return reinterpret_cast<const THerm&>(t);}
+        static       THerm& transpose(T& t)
+            {return reinterpret_cast<THerm&>(t);}
         static const TPosTrans& positionalTranspose(const T& t)
             {return reinterpret_cast<const TPosTrans&>(t);}
         static       TPosTrans& positionalTranspose(T& t)
@@ -1315,7 +1357,8 @@ template <> class CNT<double> : public NTraits<double> { };
         static TSqrt        sqrt(const T& t)    {return ::sqrt(t);}
         static TAbs         abs(const T& t)     {return ::fabs(t);}
         static const TStandard& standardize(const T& t) {return t;}
-        static TNormalize normalize(const T& t) {return (t>0?(T)1:(t<0?(T)-1:getNaN()));}
+        static TNormalize normalize(const T& t)
+            {return (t>0?(T)1:(t<0?(T)-1:getNaN()));}
         static TInvert      invert(const T& t)  {return T(1)/t;}
         static T    sin(const T& t)     {return ::sin(t);}
         static T    cos(const T& t)     {return ::cos(t);}
@@ -1334,77 +1377,133 @@ template <> class CNT<double> : public NTraits<double> { };
         static T    max(const T& t, const T& t2) {return ::fmax(t,t2);}
         static T    min(const T& t, const T& t2) {return ::fmin(t,t2);}
         static T    log10(const T& t)   {return ::log10(t);}
-        /* properties of this floating point representation, with memory addresses */
-        static const T& getEps()          {static const T c=RTraits<T>::getEps();                     return c;}
-        static const T& getSignificant()  {static const T c=RTraits<T>::getSignificant();             return c;}
-        static const T& getNaN()          {static const T c=std::numeric_limits<double>::quiet_NaN(); return c;}
-        static const T& getInfinity()     {static const T c=std::numeric_limits<double>::infinity();  return c;}
-        static const T& getLeastPositive(){static const T c=std::numeric_limits<double>::min();       return c;}
-        static const T& getMostPositive() {static const T c=std::numeric_limits<double>::max();       return c;}
-        static const T& getLeastNegative(){static const T c=-std::numeric_limits<double>::min();      return c;}
-        static const T& getMostNegative() {static const T c=-std::numeric_limits<double>::max();      return c;}
-        static const T& getSqrtEps()      {static const T c=sqrt(getEps());                           return c;}
-        static const T& getTiny()         {static const T c=pow(getEps(), (double)1.25L);             return c;}
+        /* properties of this floating point representation, with memory
+        /* addresses */
+        static const T& getEps()
+        {static const T c=RTraits<T>::getEps();                     return c;}
+        static const T& getSignificant()
+        {static const T c=RTraits<T>::getSignificant();             return c;}
+        static const T& getNaN()
+        {static const T c=std::numeric_limits<double>::quiet_NaN(); return c;}
+        static const T& getInfinity()
+        {static const T c=std::numeric_limits<double>::infinity();  return c;}
+        static const T& getLeastPositive()
+        {static const T c=std::numeric_limits<double>::min();       return c;}
+        static const T& getMostPositive()
+        {static const T c=std::numeric_limits<double>::max();       return c;}
+        static const T& getLeastNegative()
+        {static const T c=-std::numeric_limits<double>::min();      return c;}
+        static const T& getMostNegative()
+        {static const T c=-std::numeric_limits<double>::max();      return c;}
+        static const T& getSqrtEps()
+        {static const T c=sqrt(getEps());                           return c;}
+        static const T& getTiny()
+        {static const T c=pow(getEps(), (double)1.25L);             return c;}
         static bool isFinite(const T& t) {return SimTK::isFinite(t);}
         static bool isNaN   (const T& t) {return SimTK::isNaN(t);}
         static bool isInf   (const T& t) {return SimTK::isInf(t);}
-        /* Methods to use for approximate comparisons. Perform comparison in the wider of the two */
-        /* precisions, using the default tolerance from the narrower of the two precisions.       */
-        static double getDefaultTolerance() {return RTraits<T>::getDefaultTolerance();}
-        static bool isNumericallyEqual(const T& t, const float& f) {return SimTK::isNumericallyEqual(t,f);}
-        static bool isNumericallyEqual(const T& t, const double& d) {return SimTK::isNumericallyEqual(t,d);}
-        static bool isNumericallyEqual(const T& t, const adouble& d) {return SimTK::isNumericallyEqual(t,d);}
-        static bool isNumericallyEqual(const T& t, int i) {return SimTK::isNumericallyEqual(t,i);}
+        /* Methods to use for approximate comparisons. Perform comparison in
+        /* the wider of the two precisions, using the default tolerance from
+        /* the narrower of the two precisions. */
+        static double getDefaultTolerance()
+        {return RTraits<T>::getDefaultTolerance();}
+        static bool isNumericallyEqual(const T& t, const float& f)
+        {return SimTK::isNumericallyEqual(t,f);}
+        static bool isNumericallyEqual(const T& t, const double& d)
+        {return SimTK::isNumericallyEqual(t,d);}
+        static bool isNumericallyEqual(const T& t, const adouble& d)
+        {return SimTK::isNumericallyEqual(t,d);}
+        static bool isNumericallyEqual(const T& t, int i)
+        {return SimTK::isNumericallyEqual(t,i);}
         /* Here the tolerance is given so we don't have to figure it out. */
-        static bool isNumericallyEqual(const T& t, const float& f, double tol){return SimTK::isNumericallyEqual(t,f,tol);}
-        static bool isNumericallyEqual(const T& t, const double& d, double tol){return SimTK::isNumericallyEqual(t,d,tol);}
-        static bool isNumericallyEqual(const T& t, const adouble& d, double tol){return SimTK::isNumericallyEqual(t,d,tol);}
-        static bool isNumericallyEqual(const T& t, int i, double tol){return SimTK::isNumericallyEqual(t,i,tol);}
+        static bool isNumericallyEqual(const T& t, const float& f, double tol)
+        {return SimTK::isNumericallyEqual(t,f,tol);}
+        static bool isNumericallyEqual(const T& t, const double& d, double tol)
+        {return SimTK::isNumericallyEqual(t,d,tol);}
+        static bool isNumericallyEqual(const T& t, const adouble& d,
+            double tol) {return SimTK::isNumericallyEqual(t,d,tol);}
+        static bool isNumericallyEqual(const T& t, int i, double tol)
+        {return SimTK::isNumericallyEqual(t,i,tol);}
         /* Carefully calculated constants with convenient memory addresses. */
-        static const T& getZero()         {static const T c=(T)(0);               return c;}
-        static const T& getOne()          {static const T c=(T)(1);               return c;}
-        static const T& getMinusOne()     {static const T c=(T)(-1);              return c;}
-        static const T& getTwo()          {static const T c=(T)(2);               return c;}
-        static const T& getThree()        {static const T c=(T)(3);               return c;}
-        static const T& getOneHalf()      {static const T c=(T)(0.5L);            return c;}
-        static const T& getOneThird()     {static const T c=(T)(1.L/3.L);         return c;}
-        static const T& getOneFourth()    {static const T c=(T)(0.25L);           return c;}
-        static const T& getOneFifth()     {static const T c=(T)(0.2L);            return c;}
-        static const T& getOneSixth()     {static const T c=(T)(1.L/6.L);         return c;}
-        static const T& getOneSeventh()   {static const T c=(T)(1.L/7.L);         return c;}
-        static const T& getOneEighth()    {static const T c=(T)(0.125L);          return c;}
-        static const T& getOneNinth()     {static const T c=(T)(1.L/9.L);         return c;}
-        static const T& getPi()           {static const T c=(T)(SimTK_PI);        return c;}
-        static const T& getOneOverPi()    {static const T c=(T)(1.L/SimTK_PI);    return c;}
-        static const T& getE()            {static const T c=(T)(SimTK_E);         return c;}
-        static const T& getLog2E()        {static const T c=(T)(SimTK_LOG2E);     return c;}
-        static const T& getLog10E()       {static const T c=(T)(SimTK_LOG10E);    return c;}
-        static const T& getSqrt2()        {static const T c=(T)(SimTK_SQRT2);     return c;}
-        static const T& getOneOverSqrt2() {static const T c=(T)(1.L/SimTK_SQRT2); return c;}
-        static const T& getSqrt3()        {static const T c=(T)(SimTK_SQRT3);     return c;}
-        static const T& getOneOverSqrt3() {static const T c=(T)(1.L/SimTK_SQRT3); return c;}
-        static const T& getCubeRoot2()    {static const T c=(T)(SimTK_CBRT2);     return c;}
-        static const T& getCubeRoot3()    {static const T c=(T)(SimTK_CBRT3);     return c;}
-        static const T& getLn2()          {static const T c=(T)(SimTK_LN2);       return c;}
-        static const T& getLn10()         {static const T c=(T)(SimTK_LN10);      return c;}
+        static const T& getZero()
+        {static const T c=(T)(0);               return c;}
+        static const T& getOne()
+        {static const T c=(T)(1);               return c;}
+        static const T& getMinusOne()
+        {static const T c=(T)(-1);              return c;}
+        static const T& getTwo()
+        {static const T c=(T)(2);               return c;}
+        static const T& getThree()
+        {static const T c=(T)(3);               return c;}
+        static const T& getOneHalf()
+        {static const T c=(T)(0.5L);            return c;}
+        static const T& getOneThird()
+        {static const T c=(T)(1.L/3.L);         return c;}
+        static const T& getOneFourth()
+        {static const T c=(T)(0.25L);           return c;}
+        static const T& getOneFifth()
+        {static const T c=(T)(0.2L);            return c;}
+        static const T& getOneSixth()
+        {static const T c=(T)(1.L/6.L);         return c;}
+        static const T& getOneSeventh()
+        {static const T c=(T)(1.L/7.L);         return c;}
+        static const T& getOneEighth()
+        {static const T c=(T)(0.125L);          return c;}
+        static const T& getOneNinth()
+        {static const T c=(T)(1.L/9.L);         return c;}
+        static const T& getPi()
+        {static const T c=(T)(SimTK_PI);        return c;}
+        static const T& getOneOverPi()
+        {static const T c=(T)(1.L/SimTK_PI);    return c;}
+        static const T& getE()
+        {static const T c=(T)(SimTK_E);         return c;}
+        static const T& getLog2E()
+        {static const T c=(T)(SimTK_LOG2E);     return c;}
+        static const T& getLog10E()
+        {static const T c=(T)(SimTK_LOG10E);    return c;}
+        static const T& getSqrt2()
+        {static const T c=(T)(SimTK_SQRT2);     return c;}
+        static const T& getOneOverSqrt2()
+        {static const T c=(T)(1.L/SimTK_SQRT2); return c;}
+        static const T& getSqrt3()
+        {static const T c=(T)(SimTK_SQRT3);     return c;}
+        static const T& getOneOverSqrt3()
+        {static const T c=(T)(1.L/SimTK_SQRT3); return c;}
+        static const T& getCubeRoot2()
+        {static const T c=(T)(SimTK_CBRT2);     return c;}
+        static const T& getCubeRoot3()
+        {static const T c=(T)(SimTK_CBRT3);     return c;}
+        static const T& getLn2()
+        {static const T c=(T)(SimTK_LN2);       return c;}
+        static const T& getLn10()
+        {static const T c=(T)(SimTK_LN10);      return c;}
         /* integer digit counts useful for formatted input and output */
-        static int getNumDigits()         {static const int c=(int)(log10(1/getEps()).value() -0.5); return c;}
-        static int getLosslessNumDigits() {static const int c=(int)(log10(1/getTiny()).value()+0.5); return c;}
+        static int getNumDigits()
+        {static const int c=(int)(log10(1/getEps()).value() -0.5); return c;}
+        static int getLosslessNumDigits()
+        {static const int c=(int)(log10(1/getTiny()).value()+0.5); return c;}
     };
     template<> struct NTraits<adouble>::Result<float>
-      {typedef Widest<adouble, float>::Type Mul; typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
+      {typedef Widest<adouble, float>::Type Mul;
+      typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
     template<> struct NTraits<adouble>::Result<double>
-      {typedef Widest<adouble, double>::Type Mul; typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
+      {typedef Widest<adouble, double>::Type Mul;
+      typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
     template<> struct NTraits<adouble>::Result<adouble>
-      {typedef Widest<adouble,adouble>::Type Mul;typedef Mul Dvd;typedef Mul Add;typedef Mul Sub;};
+      {typedef Widest<adouble,adouble>::Type Mul;
+      typedef Mul Dvd;typedef Mul Add;typedef Mul Sub;};
     template<> struct NTraits<adouble>::Result<complex<float> >
-      {typedef Widest<adouble, complex<float> >::Type Mul; typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
+      {typedef Widest<adouble, complex<float> >::Type Mul;
+      typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
     template<> struct NTraits<adouble>::Result<complex<double> >
-      {typedef Widest<adouble, complex<double> >::Type Mul; typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
+      {typedef Widest<adouble, complex<double> >::Type Mul;
+      typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
     template<> struct NTraits<adouble>::Result<conjugate<float> >
-      {typedef conjugate<Widest<adouble, float>::Type> Mul; typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
+      {typedef conjugate<Widest<adouble, float>::Type> Mul;
+      typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
     template<> struct NTraits<adouble>::Result<conjugate<double> >
-      {typedef conjugate<Widest<adouble, double>::Type> Mul; typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
+      {typedef conjugate<Widest<adouble, double>::Type> Mul;
+      typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
 
     /// Specializations of CNT for numeric types.
     template <> class CNT<adouble> : public NTraits<adouble> { };

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
@@ -1271,7 +1271,11 @@ template <> class CNT<double> : public NTraits<double> { };
     adub log10(const badouble&);
     adub fabs(const badouble&);
     adub fmax(const badouble&, const badouble&);
+    adub fmax(double, const badouble&);
+    adub fmax(const badouble&, double);
     adub fmin(const badouble&, const badouble&);
+    adub fmin(double, const badouble&);
+    adub fmin(const badouble&, double);
 
     namespace SimTK {
 
@@ -1384,8 +1388,12 @@ template <> class CNT<double> : public NTraits<double> { };
         static T    sinh(const T& t)    {return ::sinh(t);}
         static T    cosh(const T& t)    {return ::cosh(t);}
         static T    tanh(const T& t)    {return ::tanh(t);}
-        static T    max(const T& t, const T& t2) {return ::fmax(t,t2);}
-        static T    min(const T& t, const T& t2) {return ::fmin(t,t2);}
+        template <typename T1, typename T2>
+        static T max(const T1& t, const T2& t2)
+            {return ::fmax(t,t2);}
+        template <typename T1, typename T2>
+        static T min(const T1& t, const T2& t2)
+            {return ::fmin(t,t2);}
         static T    log10(const T& t)   {return ::log10(t);}
         /* properties of this floating point representation, with memory
         /* addresses */

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
@@ -1225,6 +1225,9 @@ template <> class CNT<double> : public NTraits<double> { };
     adub cosh(const badouble&);
     adub tanh(const badouble&);
     adub log10(const badouble&);
+    adub fabs(const badouble&);
+    adub fmax(const badouble&, const badouble&);
+    adub fmin(const badouble&, const badouble&);
 
     namespace SimTK {
 

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
@@ -25,17 +25,20 @@
  * -------------------------------------------------------------------------- */
 
 /** @file
- * This file contains classes and typedefs needed to provide uniform handling of 
- * floating point numeric values. There are three numeric types: real, complex, 
- * conjugate and each comes in float and double precision. Each of 
- * these may be modified by a negator, which does not change the in-memory 
- * \e representation but negates the \e interpretation. Thus there are 12 
- * distinct scalar types: 2 precisions each of real, complex, and conjugate and 
- * their negators.
+ * This file contains classes and typedefs needed to provide uniform handling of
+ * floating point numeric values. There are three numeric types: real, complex,
+ * conjugate and each comes in float and double precision (real can also be
+ * adouble if using ADOL-C but there is no support for complex<adouble> and
+ * conjugate<adouble> at the moment). Each of these may be modified by a
+ * negator, which does not change the in-memory \e representation but negates
+ * the \einterpretation. Thus there are 12 distinct scalar types (more if using
+ * ADOL-C): 2 precisions each of real, complex, and conjugate and their
+ * negators.
  * @verbatim
  *      The Scalar Types
  *      ----------------
- *      Here is a complete taxonomy of the scalar types we support.
+ *      Here is a complete (not including ADOL-C cases) taxonomy of the scalar
+ *      types we support.
  *
  *      <scalar>    ::= <number> | negator< <number> >
  *      <number>    ::= <standard> | <conjugate>
@@ -49,6 +52,9 @@
 
 #include "SimTKcommon/Constants.h"
 #include "SimTKcommon/internal/CompositeNumericalTypes.h"
+#ifdef SimTK_REAL_IS_ADOUBLE
+    #include "SimTKcommon/internal/ExceptionMacros.h"
+#endif
 
 #include <cstddef>
 #include <cassert>
@@ -81,6 +87,9 @@ template <class R> class NTraits< complex<R> >;
 template <class R> class NTraits< conjugate<R> >;
 template <> class NTraits<float>;
 template <> class NTraits<double>;
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template <> class NTraits<adouble>;
+#endif
 
 // This is an adaptor for numeric types which negates the apparent values. A
 // negator<N> has exactly the same internal representation as a numeric value N, 
@@ -93,8 +102,8 @@ template <> class NTraits<double>;
 template <class N> class negator;      // Only defined for numbers
 
 /// This class is specialized for all 16 combinations of standard types
-/// (that is, real and complex types in each of two precisions)
-/// and has typedefs "Type" which is the appropriate "widened"
+/// (that is, real and complex types in each of two precisions; more if using
+/// ADOL-C) and has typedefs "Type" which is the appropriate "widened"
 /// type for use when R1 & R2 appear in an operation together, and
 /// "Precision" which is the wider precision (float,double). 
 /// For example, if R1=complex< float > and R2=double, Widest<R1,R2>::Type is
@@ -104,6 +113,13 @@ template <> struct Widest<float,float>              {typedef float       Type;  
 template <> struct Widest<float,double>             {typedef double      Type;  typedef double      Precision;};
 template <> struct Widest<double,float>             {typedef double      Type;  typedef double      Precision;};
 template <> struct Widest<double,double>            {typedef double      Type;  typedef double      Precision;};
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template <> struct Widest<float,adouble>        {typedef adouble     Type;  typedef adouble     Precision;};
+    template <> struct Widest<double,adouble>       {typedef adouble     Type;  typedef adouble     Precision;};
+    template <> struct Widest<adouble,float>        {typedef adouble     Type;  typedef adouble     Precision;};
+    template <> struct Widest<adouble,double>       {typedef adouble     Type;  typedef adouble     Precision;};
+    template <> struct Widest<adouble,adouble>      {typedef adouble     Type;  typedef adouble     Precision;};
+#endif
 template <class R1, class R2> struct Widest< complex<R1>,complex<R2> > { 
     typedef complex< typename Widest<R1,R2>::Type > Type; 
     typedef typename Widest<R1,R2>::Precision       Precision; 
@@ -118,8 +134,8 @@ template <class R1, class R2> struct Widest< R1,complex<R2> > {
 };
 
 /// This class is specialized for all 16 combinations of standard types
-/// (that is, real and complex types in each of two precisions)
-/// and has typedefs "Type" which is the appropriate "narrowed"
+/// (that is, real and complex types in each of two precisions; more if using
+/// ADOL-C) and has typedefs "Type" which is the appropriate "narrowed"
 /// type for use when R1 & R2 appear in an operation together where the
 /// result must be of the narrower precision, and "Precision" which is
 /// the expected precision of the result (float,
@@ -131,6 +147,15 @@ template <> struct Narrowest<float,float>              {typedef float  Type; typ
 template <> struct Narrowest<float,double>             {typedef float  Type; typedef float Precision;};
 template <> struct Narrowest<double,float>             {typedef float  Type; typedef float Precision;};
 template <> struct Narrowest<double,double>            {typedef double Type; typedef double Precision;};
+#ifdef SimTK_REAL_IS_ADOUBLE
+    /// Be careful that Narrowest(float,adouble) is adouble since it is the
+    /// narrowest type than can hold the value and the derivative.
+    template <> struct Narrowest<float,adouble>        {typedef adouble Type; typedef adouble Precision;};
+    template <> struct Narrowest<adouble,float>        {typedef adouble Type; typedef adouble Precision;};
+    template <> struct Narrowest<double,adouble>       {typedef adouble Type; typedef adouble Precision;};
+    template <> struct Narrowest<adouble,double>       {typedef adouble Type; typedef adouble Precision;};
+    template <> struct Narrowest<adouble,adouble>      {typedef adouble Type; typedef adouble Precision;};
+#endif
 template <class R1, class R2> struct Narrowest< complex<R1>,complex<R2> > { 
     typedef complex< typename Narrowest<R1,R2>::Type >  Type; 
     typedef typename Narrowest<R1,R2>::Precision        Precision;
@@ -161,6 +186,18 @@ public:
     static const double& getSignificant() {static const double c=std::pow(getEps(), 0.875); return c;}
     static double getDefaultTolerance()   {return getSignificant();}
 };
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template <> class RTraits<adouble> {
+    public:
+        static const adouble& getEps()         {static const adouble c=std::numeric_limits<double>::epsilon(); return c;}
+        static const adouble& getSignificant() {static const adouble c=pow(getEps(), 0.875); return c;}
+        /// The default numerical error tolerance is always a double even when
+        /// using real as adouble. The rationale was to enable using the
+        /// isNumericallyEqual() functions as they are specified. The user
+        /// should be careful when using getDefaultTolerance() while taping.
+        static double getDefaultTolerance()    {return getSignificant().value();}
+    };
+#endif
 
 /**
  * @defgroup isNaN isNaN()
@@ -169,7 +206,8 @@ public:
  * isNaN(x) provides a reliable way to determine if x is one of the "not a 
  * number" floating point forms. Comparing x==NaN does not work because any 
  * relational operation involving NaN always return false, even (NaN==NaN)! 
- * This routine is specialized for all SimTK scalar types:
+ * This routine is specialized for all SimTK scalar types (the list below does
+ * not include ADOL-C cases):
  *  - float, double
  *  - std::complex<P>        (P is one of the above precisions)
  *  - SimTK::conjugate<P>
@@ -182,6 +220,9 @@ public:
 //@{
 inline bool isNaN(const float& x)  {return std::isnan(x);}
 inline bool isNaN(const double& x) {return std::isnan(x);}
+#ifdef SimTK_REAL_IS_ADOUBLE
+    inline bool isNaN(const adouble& x) {return std::isnan(x.value());}
+#endif
 
 template <class P> inline bool
 isNaN(const std::complex<P>& x)
@@ -198,9 +239,9 @@ isNaN(const conjugate<P>& x)
  *
  * isFinite(x) provides a reliable way to determine if x is a "normal"
  * floating point number, meaning not a NaN or +/- Infinity.
- * This routine is specialized for all SimTK scalar types:
- * float, double, std::complex<P>, SimTK::conjugate<P>,
- * and SimTK::negator<T>, where T is any of the above. For
+ * This routine is specialized for all SimTK scalar types (the following list
+ * does not include ADOL-C cases): float, double, std::complex<P>,
+ * SimTK::conjugate<P>, and SimTK::negator<T>, where T is any of the above. For
  * complex and conjugate types, isFinite() returns true if
  * the real and imaginary parts are both finite.
  */
@@ -208,6 +249,9 @@ isNaN(const conjugate<P>& x)
 //@{
 inline bool isFinite(const float&  x) {return std::isfinite(x);}
 inline bool isFinite(const double& x) {return std::isfinite(x);}
+#ifdef SimTK_REAL_IS_ADOUBLE
+    inline bool isFinite(const adouble& x) {return std::isfinite(x.value());}
+#endif
 
 template <class P> inline bool
 isFinite(const std::complex<P>& x)
@@ -224,9 +268,9 @@ isFinite(const conjugate<P>& x)
  *
  * isInf(x) provides a reliable way to determine if x is one of
  * the two infinities (either negative or positive).
- * This routine is specialized for all SimTK scalar types:
- * float, double std::complex<P>, SimTK::conjugate<P>,
- * and SimTK::negator<T>, where T is any of the above. For
+ * This routine is specialized for all SimTK scalar types (the following list
+ * does not include ADOL-C cases): float, double std::complex<P>,
+ * SimTK::conjugate<P>, and SimTK::negator<T>, where T is any of the above. For
  * complex and conjugate types, isInf() returns true if both
  * components are infinite, or one is infinite and the other
  * finite. That is, isInf() will never return true if one
@@ -236,6 +280,9 @@ isFinite(const conjugate<P>& x)
 //@{
 inline bool isInf(const float&  x) {return std::isinf(x);}
 inline bool isInf(const double& x) {return std::isinf(x);}
+#ifdef SimTK_REAL_IS_ADOUBLE
+    inline bool isInf(const adouble& x) {return std::isinf(x.value());}
+#endif
 
 template <class P> inline bool
 isInf(const std::complex<P>& x) {
@@ -301,6 +348,26 @@ inline bool isNumericallyEqual(const double& a, const double& b,
 {   if (isNaN(a)) return isNaN(b); else if (isNaN(b)) return false;
     const double scale = std::max(std::max(std::abs(a),std::abs(b)), 1.);
     return std::abs(a-b) <= scale*tol; }
+#ifdef SimTK_REAL_IS_ADOUBLE
+    /// Compare a double with an adouble for approximate equality. Only the
+    /// real part of the adouble, of type double, is considered. The user
+    /// should be careful when using isNumericallyEqual() while taping.
+    inline bool isNumericallyEqual(const adouble& a, const double& b,
+                                   double tol = RTraits<adouble>::getDefaultTolerance())
+    {   return isNumericallyEqual(a.value(), b, tol); }
+    /// Compare a double with an adouble for approximate equality. Only the
+    /// real part of the adouble, of type double, is considered. The user
+    /// should be careful when using isNumericallyEqual() while taping.
+    inline bool isNumericallyEqual(const double& a, const adouble& b,
+                                   double tol = RTraits<adouble>::getDefaultTolerance())
+    {   return isNumericallyEqual(a, b.value(), tol); }
+    /// Compare two adoubles for approximate equality. Only the
+    /// real part of the adoubles, of type double, are considered. The user
+    /// should be careful when using isNumericallyEqual() while taping.
+    inline bool isNumericallyEqual(const adouble& a, const adouble& b,
+                                   double tol = RTraits<adouble>::getDefaultTolerance())
+    {   return isNumericallyEqual(a.value(), b.value(), tol); }
+#endif
 
 /// Compare a float and a double for approximate equality at float precision.
 inline bool isNumericallyEqual(const float& a, const double& b, 
@@ -310,6 +377,20 @@ inline bool isNumericallyEqual(const float& a, const double& b,
 inline bool isNumericallyEqual(const double& a, const float& b, 
                                double tol = RTraits<float>::getDefaultTolerance())
 {   return isNumericallyEqual(a, (double)b, tol); }
+#ifdef SimTK_REAL_IS_ADOUBLE
+    /// Compare a float and an adouble for approximate equality at float precision.
+    /// Only the real part of the adouble, of type double, is considered. The
+    /// user should be careful when using isNumericallyEqual() while taping.
+    inline bool isNumericallyEqual(const float& a, const adouble& b,
+                                   double tol = RTraits<float>::getDefaultTolerance())
+    {   return isNumericallyEqual(a, b.value(), tol); }
+    /// Compare a float and an adouble for approximate equality at float precision.
+    /// Only the real part of the adouble, of type double, is considered. The
+    /// user should be careful when using isNumericallyEqual() while taping.
+    inline bool isNumericallyEqual(const adouble& a, const float& b,
+                                   double tol = RTraits<float>::getDefaultTolerance())
+    {   return isNumericallyEqual(a.value(), b, tol); }
+#endif
 
 /// %Test a float for approximate equality to an integer.
 inline bool isNumericallyEqual(const float& a, int b,
@@ -327,6 +408,20 @@ inline bool isNumericallyEqual(const double& a, int b,
 inline bool isNumericallyEqual(int a, const double& b,
                                double tol = RTraits<double>::getDefaultTolerance())
 {   return isNumericallyEqual((double)a, b, tol); }
+#ifdef SimTK_REAL_IS_ADOUBLE
+    /// %Test an adouble for approximate equality to an integer. Only the real
+    /// part of the adouble, of type double, is considered. The user should be
+    /// careful when using isNumericallyEqual() while taping.
+    inline bool isNumericallyEqual(const adouble& a, int b,
+                                   double tol = RTraits<adouble>::getDefaultTolerance())
+    {   return isNumericallyEqual(a.value(), b, tol); }
+    /// %Test an adouble for approximate equality to an integer. Only the real
+    /// part of the adouble, of type double, is considered. The user should be
+    /// careful when using isNumericallyEqual() while taping.
+    inline bool isNumericallyEqual(int a, const adouble& b,
+                                   double tol = RTraits<adouble>::getDefaultTolerance())
+    {   return isNumericallyEqual(a, b.value(), tol); }
+#endif
 
 /// Compare two complex numbers for approximate equality, using the numerical 
 /// accuracy expectation of the narrower of the two precisions in the case of mixed 
@@ -398,6 +493,22 @@ template <class P> inline bool
 isNumericallyEqual(int a, const std::complex<P>& b, 
                    double tol = RTraits<P>::getDefaultTolerance())
 {   return isNumericallyEqual(b,a,tol); }
+#ifdef SimTK_REAL_IS_ADOUBLE
+    /// %Test whether a complex number is approximately equal to a particular adouble.
+    /// Only the real part of the adouble, of type double, is considered. The
+    /// user should be careful when using isNumericallyEqual() while taping.
+    template <class P> inline bool
+    isNumericallyEqual(const std::complex<P>& a, const adouble& b,
+                       double tol = RTraits<typename Narrowest<P,adouble>::Precision>::getDefaultTolerance())
+    {   return isNumericallyEqual(a.real(),b,tol) && isNumericallyEqual(a.imag(),0.,tol); }
+    /// %Test whether a complex number is approximately equal to a particular adouble.
+    /// Only the real part of the adouble, of type double, is considered. The
+    /// user should be careful when using isNumericallyEqual() while taping.
+    template <class P> inline bool
+    isNumericallyEqual(const adouble& a, const std::complex<P>& b,
+                       double tol = RTraits<typename Narrowest<P,adouble>::Precision>::getDefaultTolerance())
+    {   return isNumericallyEqual(b,a,tol);   }
+#endif
 
 /// %Test whether a conjugate number is approximately equal to a particular real float.
 template <class P> inline bool 
@@ -429,6 +540,22 @@ template <class P> inline bool
 isNumericallyEqual(int a, const conjugate<P>& b, 
                    double tol = RTraits<P>::getDefaultTolerance())
 {   return isNumericallyEqual(b,a,tol); }
+#ifdef SimTK_REAL_IS_ADOUBLE
+    /// %Test whether a conjugate number is approximately equal to a particular adouble.
+    /// Only the real part of the adouble, of type double, is considered. The
+    /// user should be careful when using isNumericallyEqual() while taping.
+    template <class P> inline bool
+    isNumericallyEqual(const conjugate<P>& a, const adouble& b,
+                       double tol = RTraits<typename Narrowest<P, adouble>::Precision>::getDefaultTolerance())
+    {   return isNumericallyEqual(a.real(),b,tol) && isNumericallyEqual(a.imag(),0.,tol); }
+    /// %Test whether a conjugate number is approximately equal to a particular adouble.
+    /// Only the real part of the adouble, of type double, is considered. The
+    /// user should be careful when using isNumericallyEqual() while taping.
+    template <class P> inline bool
+    isNumericallyEqual(const adouble& a, const conjugate<P>& b,
+                       double tol = RTraits<typename Narrowest<P,adouble>::Precision>::getDefaultTolerance())
+    {   return isNumericallyEqual(b,a,tol); }
+#endif
 
 //@}
 
@@ -574,6 +701,10 @@ public:
     static bool isNumericallyEqual(const T& a, const double& b, double tol) {return SimTK::isNumericallyEqual(a,b,tol);}
     static bool isNumericallyEqual(const T& a, int b) {return SimTK::isNumericallyEqual(a,b);}
     static bool isNumericallyEqual(const T& a, int b, double tol) {return SimTK::isNumericallyEqual(a,b,tol);}
+    #ifdef SimTK_REAL_IS_ADOUBLE
+        static bool isNumericallyEqual(const T& a, const adouble& b) {return SimTK::isNumericallyEqual(a,b);}
+        static bool isNumericallyEqual(const T& a, const adouble& b, double tol) {return SimTK::isNumericallyEqual(a,b,tol);}
+    #endif
 
     // The rest are the same as the real equivalents, with zero imaginary part.              
     static const T& getZero()         {static const T c(NTraits<R>::getZero());         return c;}
@@ -623,6 +754,20 @@ template<> template<> struct NTraits< complex<T1> >::Result< conjugate<T2> > {  
 SimTK_BNTCMPLX_SPEC(float,float);SimTK_BNTCMPLX_SPEC(float,double);
 SimTK_BNTCMPLX_SPEC(double,float);SimTK_BNTCMPLX_SPEC(double,double);
 #undef SimTK_BNTCMPLX_SPEC
+
+// The SimTK_BNTCMPLX_SPEC macro is not used with ADOL-C because there is no
+// support for complex<adouble> at the moment. However, these structs
+// are necessary for compilation.
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template<> template<> struct NTraits< complex<float> >::Result<adouble> {
+        typedef Widest< complex<float>,adouble >::Type W;
+        typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub;
+    };
+    template<> template<> struct NTraits< complex<double> >::Result<adouble> {
+        typedef Widest< complex<double>,adouble >::Type W;
+        typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub;
+    };
+#endif
 
 
 // conjugate -- should be instantiated only for float, double.
@@ -770,6 +915,10 @@ public:
     static bool isNumericallyEqual(const T& a, const double& b, double tol) {return SimTK::isNumericallyEqual(a,b,tol);}
     static bool isNumericallyEqual(const T& a, int b) {return SimTK::isNumericallyEqual(a,b);}
     static bool isNumericallyEqual(const T& a, int b, double tol) {return SimTK::isNumericallyEqual(a,b,tol);}
+    #ifdef SimTK_REAL_IS_ADOUBLE
+        static bool isNumericallyEqual(const T& a, const adouble& b) {return SimTK::isNumericallyEqual(a,b);}
+        static bool isNumericallyEqual(const T& a, const adouble& b, double tol) {return SimTK::isNumericallyEqual(a,b,tol);}
+    #endif
 
     // The rest are the same as the real equivalents, with zero imaginary part.              
     static const T& getZero()         {static const T c(NTraits<R>::getZero());         return c;}
@@ -833,6 +982,20 @@ SimTK_NTRAITS_CONJ_SPEC(float,float);SimTK_NTRAITS_CONJ_SPEC(float,double);
 SimTK_NTRAITS_CONJ_SPEC(double,float);SimTK_NTRAITS_CONJ_SPEC(double,double);
 #undef SimTK_NTRAITS_CONJ_SPEC 
 
+// The SimTK_NTRAITS_CONJ_SPEC macro is not used with ADOL-C because there is
+// no support for conjugate<adouble> at the moment. However, these structs
+// are necessary for compilation.
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template<> template<> struct NTraits< conjugate<float> >::Result<adouble> {
+        typedef conjugate<Widest<float,adouble>::Type> W;
+        typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub;
+    };
+    template<> template<> struct NTraits< conjugate<double> >::Result<adouble> {
+        typedef conjugate<Widest<double,adouble>::Type> W;
+        typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub;
+    };
+#endif
+
 
 // Specializations for real numbers.
 // For real scalar R, op result types are:
@@ -841,6 +1004,17 @@ SimTK_NTRAITS_CONJ_SPEC(double,float);SimTK_NTRAITS_CONJ_SPEC(double,double);
 //   Typeof(R+P) = Typeof(P+R)
 //   typeof(R-P) = Typeof(P::TNeg + R)
 // These must be specialized for P=Real and P=Complex.
+
+// Specialization for adouble. The macro is empty when real is not adouble.
+#ifdef SimTK_REAL_IS_ADOUBLE
+    #define SimTK_DEFINE_REAL_NTRAITS_ADOLC(R) \
+    template<> struct NTraits<R>::Result<adouble>{ \
+        typedef Widest<R, adouble>::Type Mul; \
+        typedef Mul Dvd; typedef Mul Add; typedef Mul Sub; };
+#else
+    #define SimTK_DEFINE_REAL_NTRAITS_ADOLC(R)
+#endif
+
 #define SimTK_DEFINE_REAL_NTRAITS(R)            \
 template <> class NTraits<R> {                  \
 public:                                         \
@@ -919,6 +1093,27 @@ public:                                         \
     static const TStandard& standardize(const T& t) {return t;}             \
     static TNormalize normalize(const T& t) {return (t>0?T(1):(t<0?T(-1):getNaN()));} \
     static TInvert invert(const T& t) {return T(1)/t;}                      \
+    /** Method to use when we want to use a variable as a double */     \
+    /** but this variable may be of type double or adouble       */     \
+    static const T& value(const T& t) {return t;}                           \
+    static T&   value(T& t)        {return t;}                           \
+    static T    sin(const T& t)    {return std::sin(t);}                 \
+    static T    cos(const T& t)    {return std::cos(t);}                 \
+    static T    floor(const T& t)  {return std::floor(t);}               \
+    static T    pow(const T& t, const T& order) {return std::pow(t,order);} \
+    static T    exp(const T& t)    {return std::exp(t);}                 \
+    static T    log(const T& t)    {return std::log(t);}                 \
+    static T    tan(const T& t)    {return std::tan(t);}                 \
+    static T    asin(const T& t)   {return std::asin(t);}                \
+    static T    acos(const T& t)   {return std::acos(t);}                \
+    static T    atan(const T& t)   {return std::atan(t);}                \
+    static T    atan2(const T& t,const T& t2) {return std::atan2(t,t2);} \
+    static T    sinh(const T& t)   {return std::sinh(t); }               \
+    static T    cosh(const T& t)   {return std::cosh(t); }               \
+    static T    tanh(const T& t)   {return std::tanh(t); }               \
+    static T    max(const T& t,const T& t2) {return std::max(t,t2);}     \
+    static T    min(const T& t,const T& t2) {return std::min(t,t2);}     \
+    static T    log10(const T& t) {return std::log10(t);}                \
     /* properties of this floating point representation, with memory addresses */     \
     static const T& getEps()          {return RTraits<T>::getEps();}                                    \
     static const T& getSignificant()  {return RTraits<T>::getSignificant();}                            \
@@ -985,7 +1180,8 @@ template<> struct NTraits<R>::Result<complex<double> > \
 template<> struct NTraits<R>::Result<conjugate<float> > \
   {typedef conjugate<Widest<R,float>::Type> Mul;typedef Mul Dvd;typedef Mul Add;typedef Mul Sub;}; \
 template<> struct NTraits<R>::Result<conjugate<double> > \
-  {typedef conjugate<Widest<R,double>::Type> Mul;typedef Mul Dvd;typedef Mul Add;typedef Mul Sub;}
+  {typedef conjugate<Widest<R,double>::Type> Mul;typedef Mul Dvd;typedef Mul Add;typedef Mul Sub;}; \
+SimTK_DEFINE_REAL_NTRAITS_ADOLC(R);
 
 #if defined(__clang__)
 #pragma clang diagnostic push
@@ -1008,5 +1204,210 @@ template <> class CNT<double> : public NTraits<double> { };
 
 
 } // namespace SimTK
+
+#ifdef SimTK_REAL_IS_ADOUBLE
+    // Must declare certain friend functions of adouble in the global namespace
+    // so that they are visible within NTraits<adouble>.
+    // https://stackoverflow.com/questions/18449855/c-friend-function-hidden-by-class-function/18451369
+    adub sqrt(const badouble&);
+    adub sin(const badouble&);
+    adub cos(const badouble&);
+    adub floor(const badouble&);
+    adouble pow(const badouble&, const badouble&);
+    adub exp(const badouble&);
+    adub log(const badouble&);
+    adub tan(const badouble&);
+    adub asin(const badouble&);
+    adub acos(const badouble&);
+    adub atan(const badouble&);
+    adouble atan2(const badouble&, const badouble&);
+    adub sinh(const badouble&);
+    adub cosh(const badouble&);
+    adub tanh(const badouble&);
+    adub log10(const badouble&);
+
+    namespace SimTK {
+
+    // Definition for adouble only
+    template <> class NTraits<adouble> {
+    public:
+        typedef adouble          T;
+        typedef negator<T>       TNeg;
+        typedef T                TWithoutNegator;
+        typedef T                TReal;
+        typedef T                TImag;
+        typedef complex<T>       TComplex;
+        typedef T                THerm;
+        typedef T                TPosTrans;
+        typedef T                TSqHermT;
+        typedef T                TSqTHerm;
+        typedef T                TElement;
+        typedef T                TRow;
+        typedef T                TCol;
+        typedef T                TSqrt;
+        typedef T                TAbs;
+        typedef T                TStandard;
+        typedef T                TInvert;
+        typedef T                TNormalize;
+        typedef T                Scalar;
+        typedef T                ULessScalar;
+        typedef T                Number;
+        typedef T                StdNumber;
+        typedef T                Precision;
+        typedef T                ScalarNormSq;
+        template <class P> struct Result {
+            typedef typename CNT<P>::template Result<adouble>::Mul Mul;
+            typedef typename CNT< typename CNT<P>::THerm >::template Result<adouble>::Mul Dvd;
+            typedef typename CNT<P>::template Result<adouble>::Add Add;
+            typedef typename CNT< typename CNT<P>::TNeg >::template Result<adouble>::Add Sub;
+        };
+        template <class P> struct Substitute {
+            typedef P Type;
+        };
+        enum {
+            NRows               = 1,
+            NCols               = 1,
+            RowSpacing          = 1,
+            ColSpacing          = 1,
+            NPackedElements     = 1,
+            NActualElements     = 1,
+            NActualScalars      = 1,
+            ImagOffset          = 0,
+            RealStrideFactor    = 1,
+            ArgDepth            = SCALAR_DEPTH,
+            IsScalar            = 1,
+            IsULessScalar       = 1,
+            IsNumber            = 1,
+            IsStdNumber         = 1,
+            IsPrecision         = 1,
+            SignInterpretation  = 1
+        };
+        static const T* getData(const T& t) { return &t; }
+        static T*       updData(T& t)       { return &t; }
+        static const T& real(const T& t) { return t; }
+        static T&       real(T& t)       { return t; }
+        static const T& imag(const T&)   { return getZero(); }
+        static T&       imag(T&)         { assert(false); return *reinterpret_cast<T*>(0); }
+        static const TNeg& negate(const T& t) {return reinterpret_cast<const TNeg&>(t);}
+        static       TNeg& negate(T& t) {return reinterpret_cast<TNeg&>(t);}
+        static const THerm& transpose(const T& t) {return reinterpret_cast<const THerm&>(t);}
+        static       THerm& transpose(T& t) {return reinterpret_cast<THerm&>(t);}
+        static const TPosTrans& positionalTranspose(const T& t)
+            {return reinterpret_cast<const TPosTrans&>(t);}
+        static       TPosTrans& positionalTranspose(T& t)
+            {return reinterpret_cast<TPosTrans&>(t);}
+        static const TWithoutNegator& castAwayNegatorIfAny(const T& t)
+            {return reinterpret_cast<const TWithoutNegator&>(t);}
+        static       TWithoutNegator& updCastAwayNegatorIfAny(T& t)
+            {return reinterpret_cast<TWithoutNegator&>(t);}
+        /** Method to use when we want to use a variable as a double
+        but this variable may be of type double or adouble. The user
+        cannot use this method when taping */
+        static double value(const T& t) {
+            SimTK_ADOLC_NO_TAPING_ALLOWED_ALWAYS;
+            return t.value();
+        }
+        static ScalarNormSq scalarNormSqr(const T& t) {return t*t;}
+        /* The global functions used below are defined by ADOL-C */
+        static TSqrt        sqrt(const T& t)    {return ::sqrt(t);}
+        static TAbs         abs(const T& t)     {return ::fabs(t);}
+        static const TStandard& standardize(const T& t) {return t;}
+        static TNormalize normalize(const T& t) {return (t>0?(T)1:(t<0?(T)-1:getNaN()));}
+        static TInvert      invert(const T& t)  {return T(1)/t;}
+        static T    sin(const T& t)     {return ::sin(t);}
+        static T    cos(const T& t)     {return ::cos(t);}
+        static T    floor(const T& t)   {return ::floor(t);}
+        static T    pow(const T& t, const T& order) {return ::pow(t, order);}
+        static T    exp(const T& t)     {return ::exp(t);}
+        static T    log(const T& t)     {return ::log(t);}
+        static T    tan(const T& t)     {return ::tan(t);}
+        static T    asin(const T& t)    {return ::asin(t);}
+        static T    acos(const T& t)    {return ::acos(t);}
+        static T    atan(const T& t)    {return ::atan(t);}
+        static T    atan2(const T& t, const T& t2) {return ::atan2(t,t2);}
+        static T    sinh(const T& t)    {return ::sinh(t);}
+        static T    cosh(const T& t)    {return ::cosh(t);}
+        static T    tanh(const T& t)    {return ::tanh(t);}
+        static T    max(const T& t, const T& t2) {return ::fmax(t,t2);}
+        static T    min(const T& t, const T& t2) {return ::fmin(t,t2);}
+        static T    log10(const T& t)   {return ::log10(t);}
+        /* properties of this floating point representation, with memory addresses */
+        static const T& getEps()          {static const T c=RTraits<T>::getEps();                     return c;}
+        static const T& getSignificant()  {static const T c=RTraits<T>::getSignificant();             return c;}
+        static const T& getNaN()          {static const T c=std::numeric_limits<double>::quiet_NaN(); return c;}
+        static const T& getInfinity()     {static const T c=std::numeric_limits<double>::infinity();  return c;}
+        static const T& getLeastPositive(){static const T c=std::numeric_limits<double>::min();       return c;}
+        static const T& getMostPositive() {static const T c=std::numeric_limits<double>::max();       return c;}
+        static const T& getLeastNegative(){static const T c=-std::numeric_limits<double>::min();      return c;}
+        static const T& getMostNegative() {static const T c=-std::numeric_limits<double>::max();      return c;}
+        static const T& getSqrtEps()      {static const T c=sqrt(getEps());                           return c;}
+        static const T& getTiny()         {static const T c=pow(getEps(), (double)1.25L);             return c;}
+        static bool isFinite(const T& t) {return SimTK::isFinite(t);}
+        static bool isNaN   (const T& t) {return SimTK::isNaN(t);}
+        static bool isInf   (const T& t) {return SimTK::isInf(t);}
+        /* Methods to use for approximate comparisons. Perform comparison in the wider of the two */
+        /* precisions, using the default tolerance from the narrower of the two precisions.       */
+        static double getDefaultTolerance() {return RTraits<T>::getDefaultTolerance();}
+        static bool isNumericallyEqual(const T& t, const float& f) {return SimTK::isNumericallyEqual(t,f);}
+        static bool isNumericallyEqual(const T& t, const double& d) {return SimTK::isNumericallyEqual(t,d);}
+        static bool isNumericallyEqual(const T& t, const adouble& d) {return SimTK::isNumericallyEqual(t,d);}
+        static bool isNumericallyEqual(const T& t, int i) {return SimTK::isNumericallyEqual(t,i);}
+        /* Here the tolerance is given so we don't have to figure it out. */
+        static bool isNumericallyEqual(const T& t, const float& f, double tol){return SimTK::isNumericallyEqual(t,f,tol);}
+        static bool isNumericallyEqual(const T& t, const double& d, double tol){return SimTK::isNumericallyEqual(t,d,tol);}
+        static bool isNumericallyEqual(const T& t, const adouble& d, double tol){return SimTK::isNumericallyEqual(t,d,tol);}
+        static bool isNumericallyEqual(const T& t, int i, double tol){return SimTK::isNumericallyEqual(t,i,tol);}
+        /* Carefully calculated constants with convenient memory addresses. */
+        static const T& getZero()         {static const T c=(T)(0);               return c;}
+        static const T& getOne()          {static const T c=(T)(1);               return c;}
+        static const T& getMinusOne()     {static const T c=(T)(-1);              return c;}
+        static const T& getTwo()          {static const T c=(T)(2);               return c;}
+        static const T& getThree()        {static const T c=(T)(3);               return c;}
+        static const T& getOneHalf()      {static const T c=(T)(0.5L);            return c;}
+        static const T& getOneThird()     {static const T c=(T)(1.L/3.L);         return c;}
+        static const T& getOneFourth()    {static const T c=(T)(0.25L);           return c;}
+        static const T& getOneFifth()     {static const T c=(T)(0.2L);            return c;}
+        static const T& getOneSixth()     {static const T c=(T)(1.L/6.L);         return c;}
+        static const T& getOneSeventh()   {static const T c=(T)(1.L/7.L);         return c;}
+        static const T& getOneEighth()    {static const T c=(T)(0.125L);          return c;}
+        static const T& getOneNinth()     {static const T c=(T)(1.L/9.L);         return c;}
+        static const T& getPi()           {static const T c=(T)(SimTK_PI);        return c;}
+        static const T& getOneOverPi()    {static const T c=(T)(1.L/SimTK_PI);    return c;}
+        static const T& getE()            {static const T c=(T)(SimTK_E);         return c;}
+        static const T& getLog2E()        {static const T c=(T)(SimTK_LOG2E);     return c;}
+        static const T& getLog10E()       {static const T c=(T)(SimTK_LOG10E);    return c;}
+        static const T& getSqrt2()        {static const T c=(T)(SimTK_SQRT2);     return c;}
+        static const T& getOneOverSqrt2() {static const T c=(T)(1.L/SimTK_SQRT2); return c;}
+        static const T& getSqrt3()        {static const T c=(T)(SimTK_SQRT3);     return c;}
+        static const T& getOneOverSqrt3() {static const T c=(T)(1.L/SimTK_SQRT3); return c;}
+        static const T& getCubeRoot2()    {static const T c=(T)(SimTK_CBRT2);     return c;}
+        static const T& getCubeRoot3()    {static const T c=(T)(SimTK_CBRT3);     return c;}
+        static const T& getLn2()          {static const T c=(T)(SimTK_LN2);       return c;}
+        static const T& getLn10()         {static const T c=(T)(SimTK_LN10);      return c;}
+        /* integer digit counts useful for formatted input and output */
+        static int getNumDigits()         {static const int c=(int)(log10(1/getEps()).value() -0.5); return c;}
+        static int getLosslessNumDigits() {static const int c=(int)(log10(1/getTiny()).value()+0.5); return c;}
+    };
+    template<> struct NTraits<adouble>::Result<float>
+      {typedef Widest<adouble, float>::Type Mul; typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
+    template<> struct NTraits<adouble>::Result<double>
+      {typedef Widest<adouble, double>::Type Mul; typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
+    template<> struct NTraits<adouble>::Result<adouble>
+      {typedef Widest<adouble,adouble>::Type Mul;typedef Mul Dvd;typedef Mul Add;typedef Mul Sub;};
+    template<> struct NTraits<adouble>::Result<complex<float> >
+      {typedef Widest<adouble, complex<float> >::Type Mul; typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
+    template<> struct NTraits<adouble>::Result<complex<double> >
+      {typedef Widest<adouble, complex<double> >::Type Mul; typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
+    template<> struct NTraits<adouble>::Result<conjugate<float> >
+      {typedef conjugate<Widest<adouble, float>::Type> Mul; typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
+    template<> struct NTraits<adouble>::Result<conjugate<double> >
+      {typedef conjugate<Widest<adouble, double>::Type> Mul; typedef Mul Dvd; typedef Mul Add; typedef Mul Sub;};
+
+    /// Specializations of CNT for numeric types.
+    template <> class CNT<adouble> : public NTraits<adouble> { };
+
+    } // namespace SimTK
+
+#endif // SimTK_REAL_IS_ADOUBLE
 
 #endif //SimTK_SIMMATRIX_NTRAITS_H_

--- a/SimTKcommon/include/SimTKcommon/internal/Exception.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Exception.h
@@ -304,6 +304,15 @@ public:
     virtual ~Cant() throw() { }
 };
 
+class ADOLCTapingNotAllowed : public Base {
+public:
+    ADOLCTapingNotAllowed(const char* fn, int ln) : Base(fn, ln)
+    {
+        setMessage("Cannot use ADOL-C tape on undifferentiable code");
+    }
+    virtual ~ADOLCTapingNotAllowed() throw() { }
+};
+
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif

--- a/SimTKcommon/include/SimTKcommon/internal/ExceptionMacros.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ExceptionMacros.h
@@ -75,6 +75,19 @@
 
 #include "SimTKcommon/internal/common.h"
 #include "SimTKcommon/internal/Exception.h"
+#ifdef SimTK_REAL_IS_ADOUBLE
+    #ifdef _MSC_VER
+        // Ignore warnings from ADOL-C headers.
+        #pragma warning(push)
+        // 'argument': conversion from 'size_t' to 'locint', possible loss of data.
+        #pragma warning(disable: 4267)
+    #endif
+    #include <adolc/adolc.h> // for isTaping() ADOL-C driver
+    typedef double SimTK_Real;
+    #ifdef _MSC_VER
+        #pragma warning(pop)
+    #endif
+#endif
 
 #include <string>
 #include <iostream>
@@ -376,6 +389,17 @@
     #define SimTK_ASSERT3(cond,msg,a1,a2,a3) SimTK_ASSERT3_ALWAYS(cond,msg,a1,a2,a3)
     #define SimTK_ASSERT4(cond,msg,a1,a2,a3,a4) SimTK_ASSERT4_ALWAYS(cond,msg,a1,a2,a3,a4)
     #define SimTK_ASSERT5(cond,msg,a1,a2,a3,a4,a5) SimTK_ASSERT5_ALWAYS(cond,msg,a1,a2,a3,a4,a5)
+#endif
+
+// ---------------------------------ADOL-C-------------------------------------
+// This exception is to be used for situations in which a user attempts to tape
+// (ie wants to get derivatives) through undifferentiable code. It is fine to
+// switch between adouble and double as long as the user is not expecting to
+// get derivatives.
+// ----------------------------------------------------------------------------
+#ifdef SimTK_REAL_IS_ADOUBLE
+#define SimTK_ADOLC_NO_TAPING_ALLOWED_ALWAYS \
+        do{if(isTaping())SimTK_THROW(SimTK::Exception::ADOLCTapingNotAllowed);}while(false)
 #endif
 
 

--- a/SimTKcommon/include/SimTKcommon/internal/ExceptionMacros.h
+++ b/SimTKcommon/include/SimTKcommon/internal/ExceptionMacros.h
@@ -75,19 +75,6 @@
 
 #include "SimTKcommon/internal/common.h"
 #include "SimTKcommon/internal/Exception.h"
-#ifdef SimTK_REAL_IS_ADOUBLE
-    #ifdef _MSC_VER
-        // Ignore warnings from ADOL-C headers.
-        #pragma warning(push)
-        // 'argument': conversion from 'size_t' to 'locint', possible loss of data.
-        #pragma warning(disable: 4267)
-    #endif
-    #include <adolc/adolc.h> // for isTaping() ADOL-C driver
-    typedef double SimTK_Real;
-    #ifdef _MSC_VER
-        #pragma warning(pop)
-    #endif
-#endif
 
 #include <string>
 #include <iostream>

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -120,10 +120,11 @@ or any other Index type to an argument expecting a certain Index type. **/
         #ifdef _MSC_VER
             // Ignore warnings from ADOL-C headers.
             #pragma warning(push)
-            // 'argument': conversion from 'size_t' to 'locint', possible loss of data.
+            // 'argument': conversion from 'size_t' to 'locint', possible loss 
+            // of data.
             #pragma warning(disable: 4267)
         #endif
-        #include <adolc/adouble.h>
+        #include <adolc/adolc.h>
         typedef double SimTK_Real;
         #ifdef _MSC_VER
             #pragma warning(pop)

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -103,7 +103,7 @@ void testNTraitsADOLC() {
     float xf = (float)-9.45;
     adouble yad = -9;
     int yi = -9;
-    std::complex<float> cf(xf, 0.);
+    std::complex<float> cf(xf,0.);
     std::complex<double> cd(xd,0.);
     SimTK::conjugate<float> cjf(xf,0);
     SimTK::conjugate<double> cjd(xd,0.);

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -8,7 +8,7 @@
  *                                                                            *
  * Portions copyright (c) 2010-17 Stanford University and the Authors.        *
  * Authors: Antoine Falisse                                                   *
- * Contributors:                                                              *
+ * Contributors: Michael Sherman, Chris Dembia                                                              *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *
@@ -28,7 +28,6 @@
 #include <iostream>
 using std::cout;
 using std::endl;
-using std::cin;
 
 using namespace SimTK;
 
@@ -104,14 +103,10 @@ void testNTraitsADOLC() {
     float xf = (float)-9.45;
     adouble yad = -9;
     int yi = -9;
-    std::complex<float> cf;
-    cf = std::complex<float>(xf,0.);
-    std::complex<double> cd;
-    cd = std::complex<double>(xd,0.);
-    SimTK::conjugate<float> cjf;
-    cjf = SimTK::conjugate<float>(xf,0);
-    SimTK::conjugate<double> cjd;
-    cjd = SimTK::conjugate<double>(xd,0.);
+    std::complex<float> cf(xf, 0.);
+    std::complex<double> cd(xd,0.);
+    SimTK::conjugate<float> cjf(xf,0);
+    SimTK::conjugate<double> cjd(xd,0.);
     SimTK_TEST(isNumericallyEqual(xad,xd));
     SimTK_TEST(isNumericallyEqual(xd,xad));
     SimTK_TEST(isNumericallyEqual(xad,xad));
@@ -121,12 +116,12 @@ void testNTraitsADOLC() {
     SimTK_TEST(isNumericallyEqual(yi,yad));
     SimTK_TEST(isNumericallyEqual(cd,xad));
     SimTK_TEST(isNumericallyEqual(xad,cd));
-    SimTK_TEST(isNumericallyEqual(cf,xad,1e-7));
-    SimTK_TEST(isNumericallyEqual(xad,cf,1e-7));
+    SimTK_TEST(isNumericallyEqual(cf,xad));
+    SimTK_TEST(isNumericallyEqual(xad,cf));
     SimTK_TEST(isNumericallyEqual(cjd,xad));
     SimTK_TEST(isNumericallyEqual(xad,cjd));
-    SimTK_TEST(isNumericallyEqual(cjf,xad,1e-7));
-    SimTK_TEST(isNumericallyEqual(xad,cjf,1e-7));
+    SimTK_TEST(isNumericallyEqual(cjf,xad));
+    SimTK_TEST(isNumericallyEqual(xad,cjf));
 }
 
 // This test should throw an exception when using value() while taping
@@ -136,7 +131,9 @@ void testExceptionTaping() {
     SimTK_TEST(b == 5);
 
     trace_on(0);
-    double c = NTraits<adouble>::value(a);
+    SimTK_TEST_MUST_THROW_EXC(NTraits<adouble>::value(a),
+        SimTK::Exception::ADOLCTapingNotAllowed
+    );
     trace_off();
 }
 
@@ -144,11 +141,6 @@ int main() {
     SimTK_START_TEST("TestADOLCCommon");
         SimTK_SUBTEST(testDerivativeADOLC);
         SimTK_SUBTEST(testNTraitsADOLC);
-        try {
-            SimTK_SUBTEST(testExceptionTaping);
-        }
-        catch (const std::exception& e) {
-            cout << "exception: " << e.what() << endl;
-        }
+        SimTK_SUBTEST(testExceptionTaping);
     SimTK_END_TEST();
 }


### PR DESCRIPTION
+@Sherm1, +@chrisdembia. This PR contains the changes in `NTraits.h` necessary to build Simbody with ADOLC. Since a new exception was introduced and used in `NTraits.h`, I also included `Exception.h` and `ExceptionMacros.h` in the PR. This PR also contains various tests in `TestADOLCCommon.cpp` verifying that `NTraits<adouble>` works properly. I might need some guidance to design additional tests to make sure all is fine. Note that this PR is based on another PR (ADOLC common #600 ) that is still in review. Therefore, changes in other files should disappear when that former PR is merged.

I have attempted to include all previous comments. In particular:
- I have followed the suggestions of @Sherm1 regarding `isNumericallyEqual()`.
- I have tried to adjust the comments to take ADOL-C cases into account. I do not know whether we want to specifically mention each additional case or just mention that more cases exist when using ADOL-C. I have chosen the second approach.
- I wanted to include free function templates to reduce text as suggested by @chrisdembia but it did not work out at first attempt. I had errors when `T=SimTK::Vector` (or `RowVector`, `Matrix`). This mostly occurred in tests but also for example in Assembler (line 568 with `abs`). I also had errors related to ambiguous calls (eg `TestBicubicSurface` line 585 with `min`) . I had defined the templates for example as follows: `template <typename T> T abs(const T& v) { return NTraits<T>::abs(v); }`. I decided not to include the free function templates for now but this is open to discussion.

Here are a few additional remarks:
- When testing `isNumericallyEqual(complex<float>,adouble)` and `isNumericallyEqual(conjugate<float>,adouble)`, I had to specify a tolerance to get it working. Tolerances smaller than 1e-7 resulted in failure. I am not sure whether this is expected.
- To avoid warnings related to ADOL-C, I included the same few lines in `ExceptionMacros.h` (where `adolc/adolc.h` is included) as in `common.h` (where `adolc/adouble.h` is included). This seems like code duplication but I do not know how else to do.
- There are still lines longer than 80 characters. I did it on purpose in cases like `Widest` . Please let me know if I should change that.

Questions:
- For unit tests, do you want them all in different cpps or I can just add them in `TestADOLCCommon.cpp` as it is for now?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/603)
<!-- Reviewable:end -->
