### PR TITLE
Deprecates some badly-named methods in MobilizedBody::Translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ to ParallelExecutor, mutex state lock.
 * Replaced usages of pthreads with C++11 classes. Removed the following classes:
     - ThreadLocal
     - AtomicInteger
-* Deprecated some badly-named method in MobilizedBody::Translation
+* Deprecated some badly-named methods in MobilizedBody::Translation
   [Issue #604](https://github.com/simbody/simbody/issues/604)
 * (There are more that haven't been added yet)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,12 @@ to ParallelExecutor, mutex state lock.
 * Fixed a bug when compiling on macOS (OSX) with SDK MacOSX10.12.sdk, related
   to the POSIX function `clock_gettime()`.
   [Issue #523](https://github.com/simbody/simbody/issues/523),
-  [PR 524](#https://github.com/simbody/simbody/pull/524)
+  [PR #524](https://github.com/simbody/simbody/pull/524)
 * Replaced usages of pthreads with C++11 classes. Removed the following classes:
     - ThreadLocal
     - AtomicInteger
+* Deprecated some badly-named method in MobilizedBody::Translation
+  [Issue #604](https://github.com/simbody/simbody/issues/604)
 * (There are more that haven't been added yet)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -454,11 +454,8 @@ if(MSVC)
     set(mxcpu ${BUILD_LIMIT_PARALLEL_COMPILES}) # abbreviation
 
     ## C++
-    # Warning 4996 is emitted in DEBUG mode when using std::copy
-    # with raw pointers, as is done in MatrixHelperRep*.h". /wd4996
-    # tells MSVC to ignore this warning.
     set(BUILD_CXX_FLAGS_DEBUG
-    "/D _DEBUG /MDd /Od /Ob0 /RTC1 /Zi /GS- /wd4996 ${CL_INST_SET}") 
+    "/D _DEBUG /MDd /Od /Ob0 /RTC1 /Zi /GS- ${CL_INST_SET}") 
     set(BUILD_CXX_FLAGS_RELEASE
     "/D NDEBUG /MD  /O2 /Ob2 /Oi /GS- ${CL_INST_SET}")
     set(BUILD_CXX_FLAGS_RELWITHDEBINFO

--- a/SimTKcommon/BigMatrix/src/MatrixHelper.cpp
+++ b/SimTKcommon/BigMatrix/src/MatrixHelper.cpp
@@ -21,6 +21,11 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
+// Avoid annoying deprecated warnings regarding std::copy during instatiations.
+#ifdef _MSC_VER
+#pragma warning(disable:4996)
+#endif
+
 #include "SimTKcommon/Scalar.h"
 #include "SimTKcommon/SmallMatrix.h"
 #include "SimTKcommon/TemplatizedLapack.h"
@@ -972,7 +977,6 @@ template class Helper< negator< std::complex<float> > >;    \
 template class Helper< negator< std::complex<double> > >;   \
 template class Helper< negator< conjugate<float> > >;       \
 template class Helper< negator< conjugate<double> > >
-
 
 INSTANTIATE(MatrixHelper);
 INSTANTIATE(MatrixHelperRep);

--- a/SimTKcommon/BigMatrix/src/MatrixHelper.cpp
+++ b/SimTKcommon/BigMatrix/src/MatrixHelper.cpp
@@ -21,7 +21,7 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-// Avoid annoying deprecated warnings regarding std::copy during instatiations.
+// Avoid annoying deprecated warnings regarding std::copy during instantiations.
 #ifdef _MSC_VER
 #pragma warning(disable:4996)
 #endif

--- a/SimTKcommon/sharedTarget/CMakeLists.txt
+++ b/SimTKcommon/sharedTarget/CMakeLists.txt
@@ -16,12 +16,6 @@ if(BUILD_UNVERSIONED_LIBRARIES)
         PROJECT_LABEL "Code - ${SHARED_TARGET}"
         SOVERSION ${SIMBODY_SONAME_VERSION})
     
-    # Warning 4996 is not propagated to downstream targets  
-    if(WIN32 AND NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2) 
-        target_compile_options(${SHARED_TARGET} INTERFACE 
-            "$<$<CONFIG:Debug>:/wd4996>")
-    endif()
-    
     # install library; on Windows .dll's go in bin directory
 
     install(TARGETS ${SHARED_TARGET} EXPORT SimbodyTargets
@@ -59,13 +53,7 @@ if(BUILD_VERSIONED_LIBRARIES)
     set_target_properties(${SHARED_TARGET_VN} PROPERTIES
         PROJECT_LABEL "Code - ${SHARED_TARGET_VN}"
         SOVERSION ${SIMBODY_SONAME_VERSION})
-        
-    # Warning 4996 is not propagated to downstream targets
-    if(WIN32 AND NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2) 
-        target_compile_options(${SHARED_TARGET_VN} INTERFACE 
-            "$<$<CONFIG:Debug>:/wd4996>")
-    endif()
-    
+           
     # install library; on Windows .dll's go in bin directory
 
     install(TARGETS ${SHARED_TARGET_VN} EXPORT SimbodyTargets

--- a/Simbody/include/simbody/internal/MobilizedBody_Translation.h
+++ b/Simbody/include/simbody/internal/MobilizedBody_Translation.h
@@ -73,46 +73,81 @@ public:
         (void)MobilizedBody::setDefaultOutboardFrame(X_BM); return *this;
     }
 
-    // This is just a nicer name for setting this mobilizer's generalized coordinates,
-    // which together constitute the vector from the F frame's origin to the M
-    // frame's origin, expressed in F.
-
-    // Set the topological default values for the initial q's.
+    /** This is just a nicer name for setting this mobilizer's topological
+    default generalized coordinates q, which together constitute the vector
+    p_FM from the F frame's origin Fo to the M frame's origin Mo, expressed
+    in F. */
     Translation& setDefaultTranslation(const Vec3& p_FM) {
         return setDefaultQ(p_FM);
     }
 
-    // Get the topological default values for the initial q's.
+    /** Get the topological default values for the initial q's. **/
     const Vec3& getDefaultTranslation() const {
         return getDefaultQ();
     }
 
-    // Set the current value of q's in the given State. Note that this is
-    // the *cross-mobilizer* translation, not location in the Ground frame.
-    void setMobilizerTranslation(State& s, const Vec3& p_FM) const {
+    /** Set the current value of q's in the given State. Note that this is
+    the _cross-mobilizer_ translation vector p_FM, not location in the Ground
+    frame. **/
+    void setTranslation(State& s, const Vec3& p_FM) const {
         setQ(s,p_FM);
     }
 
-    // Get the current value of the q's for this mobilizer from the given State.
-    const Vec3& getMobilizerTranslation(const State& s) const {
+    /** Get the current value of the q's for this mobilizer from the given
+    State. This is the _cross-mobilizer_ translation vector p_FM, not location
+    in the Ground frame. **/
+    const Vec3& getTranslation(const State& s) const {
         return getQ(s);
     }
 
-
-    // Set the current value of u's in the given State. Note that this is
-    // the *cross-mobilizer* velocity v_FM, not velocity in the Ground frame.
-    void setMobilizerVelocity(State& s, const Vec3& v_FM) const {
+    /** Set the current value of u's in the given State. Note that this is
+    the _cross-mobilizer_ velocity vector v_FM, not velocity in the Ground
+    frame. **/
+    void setVelocity(State& s, const Vec3& v_FM) const {
         setU(s,v_FM);
     }
 
-    // Get the current value of the u's for this mobilizer from the given State.
-    const Vec3& getMobilizerVelocity(const State& s) const {
+    /** Get the current value of the u's for this mobilizer from the given
+    State. For this Translation mobilizer, this is v_FM the linear velocity
+    of the M frame origin Mo in the F frame. **/
+    const Vec3& getVelocity(const State& s) const {
         return getU(s);
     }
 
-    // Get the value of the udot's for this mobilizer from the given State.
-    const Vec3& getMobilizerAcceleration(const State& s) const {
+    /** Get the current value of the udot's for this mobilizer from the given
+    State, which must be realized to the Acceleration stage. For this
+    Translation mobilizer, this is a_FM the linear acceleration of the M frame
+    origin Mo in the F frame. **/
+    const Vec3& getAcceleration(const State& s) const {
         return getUDot(s);
+    }
+
+    // These methods were misnamed and created some confusion with similar
+    // methods in the MobilizedBody base class. See issue #604.
+
+    DEPRECATED_14("use setTranslation() instead")
+    void setMobilizerTranslation(State& s, const Vec3& p_FM) const {
+        setTranslation(s,p_FM);
+    }
+
+    DEPRECATED_14("use getTranslation() instead")
+    const Vec3& getMobilizerTranslation(const State& s) const {
+        return getTranslation(s);
+    }
+
+    DEPRECATED_14("use setVelocity() instead")
+    void setMobilizerVelocity(State& s, const Vec3& v_FM) const {
+        setVelocity(s,v_FM);
+    }
+
+    DEPRECATED_14("use getVelocity() instead")
+    const Vec3& getMobilizerVelocity(const State& s) const {
+        return getVelocity(s);
+    }
+
+    DEPRECATED_14("use getAcceleration() instead")
+    const Vec3& getMobilizerAcceleration(const State& s) const {
+        return getAcceleration(s);
     }
 
     // Generic default state Topology methods.

--- a/Simbody/tests/TestMobilizedBody.cpp
+++ b/Simbody/tests/TestMobilizedBody.cpp
@@ -239,13 +239,13 @@ void testBushing() {
 
     State state = system.realizeTopology();
     p1.setQ(state, Vec6(.1,.2,.3,1,2,3));
-    dummy0.setMobilizerTranslation(state, Vec3(1,2,3));
+    dummy0.setTranslation(state, Vec3(1,2,3));
     dummy1.setAngle(state, .1);
     dummy2.setAngle(state, .2);
     p2.setAngle(state, .3);
 
     p1.setU(state, Vec6(1, 2, 3, -.1, -.2, -.3));
-    dummy0.setMobilizerVelocity(state, Vec3(-.1, -.2, -.3));
+    dummy0.setVelocity(state, Vec3(-.1, -.2, -.3));
     dummy1.setRate(state, 1);
     dummy2.setRate(state, 2);
     p2.setRate(state, 3);


### PR DESCRIPTION
The Translation mobilizer had some methods whose names were confusingly similar to methods in the MobilizedBody base class, causing unnecessary confusion. This PR changes those names and deprecates the bad ones.

I also had to re-enable the deprecation warning C4996 in Visual Studio. That had been disabled globally meaning the DEPRECATION_14 macro was non-functional. I switched to locally disabling the warning in the one .cpp file that seemed to be instantiating the troublesome code. I *think* that avoids the problem altogether but I'm not 100% sure.

Fixes #604. Fixes #607.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/608)
<!-- Reviewable:end -->
