### PR TITLE
Include GLUT header directory

### DIFF
--- a/Simbody/Visualizer/simbody-visualizer/CMakeLists.txt
+++ b/Simbody/Visualizer/simbody-visualizer/CMakeLists.txt
@@ -42,6 +42,10 @@ add_executable(${GUI_NAME}
     simbody-visualizer.cpp lodepng.cpp lodepng.h
     ${GLUT32_HEADERS}) # only on Windows
 
+if(NOT WIN32)
+    target_include_directories(${GUI_NAME} PRIVATE ${GLUT_INCLUDE_DIR})
+endif()
+
 # If building as debug, append the debug postfix to the name of the executable.
 # CMAKE_DEBUG_POSTFIX only affects non-executable targets, but we use its value
 # to set the postfix for this executable.


### PR DESCRIPTION
This PR attempts to address #511 by explicitly including the GLUT header directory.

I tested locally in an Ubuntu VM in which I installed GLUT via Anaconda, not via apt-get. All tests except TestCoustomConstraints passed, and I was able to run examples that depended on the visualizer.

I tried testing via conda-forge/staged-recipes (https://github.com/conda-forge/staged-recipes/pull/4770), but could not proceed because we require a more recent GCC than what is readily available (https://circleci.com/gh/conda-forge/staged-recipes/22676?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/611)
<!-- Reviewable:end -->
