### PR TITLE
ADOLC negator

### DIFF
--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
@@ -1341,8 +1341,16 @@ template <> class CNT<double> : public NTraits<double> { };
         static const T& real(const T& t) { return t; }
         static T&       real(T& t)       { return t; }
         static const T& imag(const T&)   { return getZero(); }
+#if defined(__clang__)
+#pragma clang diagnostic push
+// The function `T& imag(T&)` generates a null-dereference warning.
+#pragma clang diagnostic ignored "-Wnull-dereference"
+#endif
         static T&       imag(T&)
             { assert(false); return *reinterpret_cast<T*>(0); }
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
         static const TNeg& negate(const T& t)
             {return reinterpret_cast<const TNeg&>(t);}
         static       TNeg& negate(T& t) {return reinterpret_cast<TNeg&>(t);}

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
@@ -1022,14 +1022,12 @@ SimTK_NTRAITS_CONJ_SPEC(double,float);SimTK_NTRAITS_CONJ_SPEC(double,double);
 // no support for conjugate<adouble> at the moment. However, these structs
 // are necessary for compilation.
 #ifdef SimTK_REAL_IS_ADOUBLE
-    template<> template<> struct NTraits< conjugate<float> >::Result<adouble> {
-        typedef conjugate<Widest<float,adouble>::Type> W;
-        typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub;
-    };
+    template<> template<> struct NTraits< conjugate<float> >::Result<adouble>
+    {   typedef conjugate<Widest<float,adouble>::Type> W;
+        typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub; };
     template<> template<> struct NTraits< conjugate<double> >::Result<adouble>
     {   typedef conjugate<Widest<double,adouble>::Type> W;
-        typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub;
-    };
+        typedef W Mul; typedef W Dvd; typedef W Add; typedef W Sub; };
 #endif
 
 

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
@@ -153,8 +153,8 @@ template <> struct Narrowest<float,double>             {typedef float  Type; typ
 template <> struct Narrowest<double,float>             {typedef float  Type; typedef float Precision;};
 template <> struct Narrowest<double,double>            {typedef double Type; typedef double Precision;};
 #ifdef SimTK_REAL_IS_ADOUBLE
-    /// Be careful that Narrowest(float,adouble) is adouble since it is the
-    /// narrowest type than can hold the value and the derivative.
+    /// Be careful that Narrowest(float,adouble)::Type is adouble since it is
+    /// the narrowest type than can hold the value and the derivative.
     template <> struct Narrowest<float,adouble>
       {typedef adouble Type; typedef float Precision;};
     template <> struct Narrowest<adouble,float>
@@ -1401,8 +1401,8 @@ template <> class CNT<double> : public NTraits<double> { };
         static bool isNaN   (const T& t) {return SimTK::isNaN(t);}
         static bool isInf   (const T& t) {return SimTK::isInf(t);}
         /* Methods to use for approximate comparisons. Perform comparison in
-        /* the wider of the two precisions, using the default tolerance from
-        /* the narrower of the two precisions. */
+        the wider of the two precisions, using the default tolerance from
+        the narrower of the two precisions. */
         static double getDefaultTolerance()
         {return RTraits<T>::getDefaultTolerance();}
         static bool isNumericallyEqual(const T& t, const float& f)

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
@@ -1271,7 +1271,11 @@ template <> class CNT<double> : public NTraits<double> { };
     adub log10(const badouble&);
     adub fabs(const badouble&);
     adub fmax(const badouble&, const badouble&);
+    adub fmax(double, const badouble&);
+    adub fmax(const badouble&, double);
     adub fmin(const badouble&, const badouble&);
+    adub fmin(double, const badouble&);
+    adub fmin(const badouble&, double);
 
     namespace SimTK {
 
@@ -1384,8 +1388,12 @@ template <> class CNT<double> : public NTraits<double> { };
         static T    sinh(const T& t)    {return ::sinh(t);}
         static T    cosh(const T& t)    {return ::cosh(t);}
         static T    tanh(const T& t)    {return ::tanh(t);}
-        static T    max(const T& t, const T& t2) {return ::fmax(t,t2);}
-        static T    min(const T& t, const T& t2) {return ::fmin(t,t2);}
+        template <typename T1, typename T2>
+        static T max(const T1& t, const T2& t2)
+            {return ::fmax(t,t2);}
+        template <typename T1, typename T2>
+        static T min(const T1& t, const T2& t2)
+            {return ::fmin(t,t2);}
         static T    log10(const T& t)   {return ::log10(t);}
         /* properties of this floating point representation, with memory
         /* addresses */

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
@@ -1305,7 +1305,7 @@ template <> class CNT<double> : public NTraits<double> { };
         typedef T                ULessScalar;
         typedef T                Number;
         typedef T                StdNumber;
-        typedef T                Precision;
+        typedef double           Precision;
         typedef T                ScalarNormSq;
         template <class P> struct Result {
             typedef typename CNT<P>::template Result<adouble>::Mul Mul;

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/NTraits.h
@@ -1366,6 +1366,9 @@ template <> class CNT<double> : public NTraits<double> { };
             {return reinterpret_cast<const TWithoutNegator&>(t);}
         static       TWithoutNegator& updCastAwayNegatorIfAny(T& t)
             {return reinterpret_cast<TWithoutNegator&>(t);}
+        /** Method to use when we want to cast an adouble. This method calls
+        value() when casting an adouble to another scalar type, which prevents
+        taping */
         template <typename TRet>
         static TRet cast(const T& t,
             typename std::enable_if<std::is_same<TRet, adouble>::value>::type*

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/negator.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/negator.h
@@ -223,7 +223,7 @@ public:
     negator(int                t) {v = -N((typename NTraits<N>::Precision)t);}
     negator(const float&       t) {v = -N((typename NTraits<N>::Precision)t);}
     negator(const double&      t) {v = -N((typename NTraits<N>::Precision)t);}
-    negator(const adouble&     t) {v = NTraits<adouble>::cast<N>(t);}
+    negator(const adouble&     t) {v = -(NTraits<adouble>::cast<N>(t));}
 
     // Some of these may not compile if instantiated -- you can't cast a complex
     // to a float, for example.

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/negator.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/negator.h
@@ -69,7 +69,7 @@ template <class N> class negator;   // negator is only defined for numbers.
 /**
  * negator<N>, where N is a number type (real, complex, conjugate), is represented in 
  * memory identically to N, but behaves as though multiplied by -1, though at zero
- * cost. Only negators instantiated with the six (more if using ADOl-C) number
+ * cost. Only negators instantiated with the six (more if using ADOL-C) number
  * types (real, complex, conjugate) are allowed.
  */ 
 template <class NUMBER> 

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/negator.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/negator.h
@@ -223,7 +223,24 @@ public:
     negator(int                t) {v = -N((typename NTraits<N>::Precision)t);}
     negator(const float&       t) {v = -N((typename NTraits<N>::Precision)t);}
     negator(const double&      t) {v = -N((typename NTraits<N>::Precision)t);}
-    negator(const adouble&     t) {v = -(NTraits<adouble>::cast<N>(t));}
+    #ifdef SimTK_REAL_IS_ADOUBLE
+        // Allow converting an adouble to negator<N>.
+        // If N is adouble, then simply negate the adouble.
+        // (T is actually unused; just needed for the SFINAE).
+        template <typename T,
+            typename std::enable_if<
+                std::is_same<T, adouble>::value && 
+                std::is_same<N, adouble>::value, int>::type = 0>
+        negator(const adouble& t)
+        {   v = -N(t); }
+        // If N is not adouble, we must call value() (this prevents taping).
+        template <typename T,
+            typename std::enable_if<
+                std::is_same<T, adouble>::value &&
+                !std::is_same<N, adouble>::value, int>::type = 0>
+        negator(const adouble& t)
+        {v = -N((typename NTraits<N>::Precision)NTraits<adouble>::value(t));}
+    #endif
 
     // Some of these may not compile if instantiated -- you can't cast a complex
     // to a float, for example.

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/negator.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/negator.h
@@ -229,7 +229,7 @@ public:
         // (T is actually unused; just needed for the SFINAE).
         template <typename T,
             typename std::enable_if<
-                std::is_same<T, adouble>::value && 
+                std::is_same<T, adouble>::value &&
                 std::is_same<N, adouble>::value, int>::type = 0>
         negator(const adouble& t)
         {   v = -N(t); }

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/negator.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/negator.h
@@ -226,19 +226,18 @@ public:
     #ifdef SimTK_REAL_IS_ADOUBLE
         // Allow converting an adouble to negator<N>.
         // If N is adouble, then simply negate the adouble.
-        // (T is actually unused; just needed for the SFINAE).
-        template <typename T,
+        template <typename NN,
             typename std::enable_if<
-                std::is_same<T, adouble>::value &&
+                std::is_same<NN, adouble>::value &&
                 std::is_same<N, adouble>::value, int>::type = 0>
-        negator(const adouble& t)
+        negator(const NN& t)
         {   v = -N(t); }
         // If N is not adouble, we must call value() (this prevents taping).
-        template <typename T,
+        template <typename NN,
             typename std::enable_if<
-                std::is_same<T, adouble>::value &&
+                std::is_same<NN, adouble>::value &&
                 !std::is_same<N, adouble>::value, int>::type = 0>
-        negator(const adouble& t)
+        negator(const NN& t)
         {v = -N((typename NTraits<N>::Precision)NTraits<adouble>::value(t));}
     #endif
 

--- a/SimTKcommon/Scalar/include/SimTKcommon/internal/negator.h
+++ b/SimTKcommon/Scalar/include/SimTKcommon/internal/negator.h
@@ -28,9 +28,9 @@
  * This file defines the negator<N> template which is an adaptor for
  * the numeric types N (Real, Complex, conjugate). negator must NOT
  * be instantiated for anything other than these three types (each
- * of which comes in three precisions). negator<N> is guaranteed to
- * have the same memory layout as N, except that the stored values
- * represent the *negative* value of that number.
+ * of which comes in two precisions; more if using ADOL-C). negator<N> is
+ * guaranteed to have the same memory layout as N, except that the stored
+ * values represent the *negative* value of that number.
  *
  * This is part of the SimTK Scalar package, which forms the basis
  * for composite numerical types like vectors and matrices. The negator
@@ -41,7 +41,8 @@
  *
  * The Scalar Types
  * ----------------
- * Here is a complete taxonomy of the scalar types we support.
+ * Here is a complete (not including ADOL-C cases) taxonomy of the scalar
+ * types we support.
  *
  * <scalar>    ::= <number> | negator< <number> >
  * <number>    ::= <standard> | <conjugate>
@@ -68,8 +69,8 @@ template <class N> class negator;   // negator is only defined for numbers.
 /**
  * negator<N>, where N is a number type (real, complex, conjugate), is represented in 
  * memory identically to N, but behaves as though multiplied by -1, though at zero
- * cost. Only negators instantiated with the nine number types (real, complex, 
- * conjugate) are allowed.
+ * cost. Only negators instantiated with the six (more if using ADOl-C) number
+ * types (real, complex, conjugate) are allowed.
  */ 
 template <class NUMBER> 
 class SimTK_SimTKCOMMON_EXPORT negator {
@@ -222,6 +223,11 @@ public:
     negator(int                t) {v = -N((typename NTraits<N>::Precision)t);}
     negator(const float&       t) {v = -N((typename NTraits<N>::Precision)t);}
     negator(const double&      t) {v = -N((typename NTraits<N>::Precision)t);}
+    #ifdef SimTK_REAL_IS_ADOUBLE
+        negator(const adouble& t) {
+            v = -N((typename NTraits<N>::Precision)NTraits<adouble>::value(t));
+        }
+    #endif
 
     // Some of these may not compile if instantiated -- you can't cast a complex
     // to a float, for example.
@@ -271,6 +277,9 @@ template <class N2> friend class negator;
 //@{
 inline bool isNaN(const negator<float>&  x) {return isNaN(-x);}
 inline bool isNaN(const negator<double>& x) {return isNaN(-x);}
+#ifdef SimTK_REAL_IS_ADOUBLE
+    inline bool isNaN(const negator<adouble>& x) {return isNaN(-x);}
+#endif
 template <class P> inline bool
 isNaN(const negator< std::complex<P> >& x) {return isNaN(-x);}
 template <class P> inline bool
@@ -284,6 +293,9 @@ isNaN(const negator< conjugate<P> >&    x) {return isNaN(-x);}
 //@{
 inline bool isFinite(const negator<float>&  x) {return isFinite(-x);}
 inline bool isFinite(const negator<double>& x) {return isFinite(-x);}
+#ifdef SimTK_REAL_IS_ADOUBLE
+    inline bool isFinite(const negator<adouble>& x) {return isFinite(-x);}
+#endif
 template <class P> inline bool
 isFinite(const negator< std::complex<P> >& x) {return isFinite(-x);}
 template <class P> inline bool
@@ -297,6 +309,9 @@ isFinite(const negator< conjugate<P> >&    x) {return isFinite(-x);}
 //@{
 inline bool isInf(const negator<float>&  x) {return isInf(-x);}
 inline bool isInf(const negator<double>& x) {return isInf(-x);}
+#ifdef SimTK_REAL_IS_ADOUBLE
+    inline bool isInf(const negator<adouble>& x) {return isInf(-x);}
+#endif
 template <class P> inline bool
 isInf(const negator< std::complex<P> >& x) {return isInf(-x);}
 template <class P> inline bool

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -120,7 +120,7 @@ or any other Index type to an argument expecting a certain Index type. **/
         #ifdef _MSC_VER
             // Ignore warnings from ADOL-C headers.
             #pragma warning(push)
-            // 'argument': conversion from 'size_t' to 'locint', possible loss 
+            // 'argument': conversion from 'size_t' to 'locint', possible loss
             // of data.
             #pragma warning(disable: 4267)
         #endif

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -175,6 +175,11 @@ void testNegator() {
     SimTK_TEST(!isFinite((negator<adouble>&)xInf));
     SimTK_TEST(isInf((negator<adouble>&)xInf));
     SimTK_TEST(!isInf((negator<adouble>&)xad));
+    // ensure consistent behavior between double and adouble
+    double a = 5;
+    adouble ad = 5;
+    SimTK_TEST((negator<double>)a == (negator<adouble>)ad);
+    SimTK_TEST((negator<double>&)a == (negator<adouble>&)ad);
 }
 
 // Various unit tests verifying that cast() works properly

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -146,7 +146,8 @@ void testNegator() {
     adouble x;
     adouble y;
     x <<= xp[0];
-    y = (negator<adouble>&)NTraits<adouble>::pow(x,3);
+    auto result = NTraits<adouble>::pow(x,3);
+    y = (negator<adouble>&)result;
     double y0;
     y >>= y0;
     trace_off();

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -146,19 +146,19 @@ void testNegator() {
     adouble x;
     adouble y;
     x <<= xp[0];
-    y = (negator<adouble>&)pow(x,3);
+    y = (negator<adouble>&)x;;
     double y0;
     y >>= y0;
     trace_off();
     // function evaluation
     double f[1];
     function(2, 1, 1, xp, f);
-    SimTK_TEST(f[0] == -8.);
+    SimTK_TEST(f[0] == -2.);
     // derivative evaluation
     double** J;
     J = myalloc(1, 1);
     jacobian(2, 1, 1, xp, J);
-    SimTK_TEST(J[0][0] == -3*pow(x,2));
+    SimTK_TEST(J[0][0] == -1);
     myfree(J);
     // isNumericallyEqual
     adouble xd = 9.45;

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -177,11 +177,31 @@ void testNegator() {
     SimTK_TEST(!isInf((negator<adouble>&)xad));
 }
 
+// Various unit tests verifying that cast() works properly
+void testCast() {
+    // cast an adouble in a double
+    adouble a = 5.;
+    double b = NTraits<adouble>::cast<double>(a);
+    SimTK_TEST(b == a);
+    // cast an adouble in a double when taping, this should throw an exception
+    trace_on(3);
+    SimTK_TEST_MUST_THROW_EXC(NTraits<adouble>::cast<double>(a),
+        SimTK::Exception::ADOLCTapingNotAllowed
+    );
+    trace_off();
+    // cast an adouble in an adouble when taping
+    trace_on(4);
+    adouble c = NTraits<adouble>::cast<adouble>(a);
+    trace_off();
+    SimTK_TEST(c == a);
+}
+
 int main() {
     SimTK_START_TEST("TestADOLCCommon");
         SimTK_SUBTEST(testDerivativeADOLC);
         SimTK_SUBTEST(testNTraitsADOLC);
         SimTK_SUBTEST(testExceptionTaping);
         SimTK_SUBTEST(testNegator);
+        SimTK_SUBTEST(testCast);
     SimTK_END_TEST();
 }

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -146,19 +146,19 @@ void testNegator() {
     adouble x;
     adouble y;
     x <<= xp[0];
-    y = (negator<adouble>&)x;;
+    y = (negator<adouble>&)NTraits<adouble>::pow(x,3);
     double y0;
     y >>= y0;
     trace_off();
     // function evaluation
     double f[1];
     function(2, 1, 1, xp, f);
-    SimTK_TEST(f[0] == -2.);
+    SimTK_TEST(f[0] == -8.);
     // derivative evaluation
     double** J;
     J = myalloc(1, 1);
     jacobian(2, 1, 1, xp, J);
-    SimTK_TEST(J[0][0] == -1);
+    SimTK_TEST(J[0][0] == -3*NTraits<adouble>::pow(x,2));
     myfree(J);
     // isNumericallyEqual
     adouble xd = 9.45;

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -137,10 +137,50 @@ void testExceptionTaping() {
     trace_off();
 }
 
+// Various unit tests verifying that negator<adouble> works properly
+void testNegator() {
+    // Test evaluation of simple function and its derivative
+    double xp[1];
+    xp[0] = 2;
+    trace_on(2);
+    adouble x;
+    adouble y;
+    x <<= xp[0];
+    y = (negator<adouble>&)pow(x,3);
+    double y0;
+    y >>= y0;
+    trace_off();
+    // function evaluation
+    double f[1];
+    function(2, 1, 1, xp, f);
+    SimTK_TEST(f[0] == -8.);
+    // derivative evaluation
+    double** J;
+    J = myalloc(1, 1);
+    jacobian(2, 1, 1, xp, J);
+    SimTK_TEST(J[0][0] == -3*pow(x,2));
+    myfree(J);
+    // isNumericallyEqual
+    adouble xd = 9.45;
+    SimTK_TEST(isNumericallyEqual(-xd,(negator<adouble>&)xd));
+    // isNaN, isFinite, isInf
+    adouble xad = -9.45;
+    adouble xNaN = SimTK::NaN;
+    adouble xInf = SimTK::Infinity;
+    SimTK_TEST(isNaN((negator<adouble>&)xNaN));
+    SimTK_TEST(!isNaN((negator<adouble>&)xad));
+    SimTK_TEST(isFinite((negator<adouble>&)xad));
+    SimTK_TEST(!isFinite((negator<adouble>&)xNaN));
+    SimTK_TEST(!isFinite((negator<adouble>&)xInf));
+    SimTK_TEST(isInf((negator<adouble>&)xInf));
+    SimTK_TEST(!isInf((negator<adouble>&)xad));
+}
+
 int main() {
     SimTK_START_TEST("TestADOLCCommon");
         SimTK_SUBTEST(testDerivativeADOLC);
         SimTK_SUBTEST(testNTraitsADOLC);
         SimTK_SUBTEST(testExceptionTaping);
+        SimTK_SUBTEST(testNegator);
     SimTK_END_TEST();
 }

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -8,7 +8,7 @@
  *                                                                            *
  * Portions copyright (c) 2010-17 Stanford University and the Authors.        *
  * Authors: Antoine Falisse                                                   *
- * Contributors: Michael Sherman, Chris Dembia                                                              *
+ * Contributors: Michael Sherman, Chris Dembia                                *
  *                                                                            *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
  * not use this file except in compliance with the License. You may obtain a  *


### PR DESCRIPTION
+@sherm1, +@chrisdembia. This PR contains the changes in `negator.h` necessary to build Simbody with ADOLC. This PR also contains various tests in `TestADOLCCommon.cpp` verifying that `negator<adouble>` works properly. Note that this PR is based other PRs (ADOLC Ntraits #603 and ADOLC common #600) that are still in review. Changes in other files should thus disappear when those PRs are merged. Please let me know whether I should wait for the other PRs to be merged before going forward.

One remark: as already discussed with @chrisdembia, 
```
negator(const adouble& t) {
            v = -N((typename NTraits<N>::Precision)NTraits<adouble>::value(t));
        }
```
might be problematic but I could not get rid of the `value()` without getting errors. I have tried different options:

- Using the following statement gives me an error (cannot convert from 'const adouble' to 'double')
`negator(const adouble& t) {v = -N((typename NTraits<N>::Precision)t);}`

- Using the following statement gives me an error (cannot convert from 'const adouble' to 'SimTK::conjugate)
`negator(const adouble& t) {v = -N(t);}`

- Using the following statement gives me a warning (conversion from 'double' to 'const std::complex::_Ty)
`negator(const adouble& t) {v = -N(NTraits<adouble>::value(t));}`

- Using the following statement is error and warning free
`negator(const adouble& t) {v = -N((typename NTraits<N>::Precision)NTraits<adouble>::value(t));}`

Here was the conclusion of @chrisdembia:

> Perhaps we can go with the last option until we run into issues with it. I like it because it is safe, as value() will give an exception if taping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/613)
<!-- Reviewable:end -->
