### PR TITLE
ADOLC Mat Vec

### DIFF
--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
@@ -1530,11 +1530,7 @@ operator-(const double& l, const Mat<M,N,E,CS,RS>& r)
     typename Mat<M,N,E,CS,RS>::template Result<adouble>::Sub
     operator-(const Mat<M,N,E,CS,RS>& l, const adouble& r)
     { return Mat<M,N,E,CS,RS>::template Result<adouble>::SubOp::perform(l,r); }
-    template <int M, int N, class E, int CS, int RS> inline
-    typename CNT<adouble>::template Result<Mat<M,N,E,CS,RS> >::Sub
-    operator-(const adouble& l, const Mat<M,N,E,CS,RS>& r)
-    { return CNT<adouble>::template
-        Result<Mat<M,N,E,CS,RS> >::SubOp::perform(l,r); }
+    // The operation a-m where a is an adouble and m is a Mat is not supported.
 #endif
 
 // m = m-int, int-m // just convert int to m's precision float

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
@@ -1311,6 +1311,16 @@ template <int M, int N, class E, int CS, int RS> inline
 typename Mat<M,N,E,CS,RS>::template Result<double>::Mul
 operator*(const double& l, const Mat<M,N,E,CS,RS>& r) {return r*l;}
 
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template <int M, int N, class E, int CS, int RS> inline
+    typename Mat<M,N,E,CS,RS>::template Result<adouble>::Mul
+    operator*(const Mat<M,N,E,CS,RS>& l, const adouble& r)
+    { return Mat<M,N,E,CS,RS>::template Result<adouble>::MulOp::perform(l,r); }
+    template <int M, int N, class E, int CS, int RS> inline
+    typename Mat<M,N,E,CS,RS>::template Result<adouble>::Mul
+    operator*(const adouble& l, const Mat<M,N,E,CS,RS>& r) {return r*l;}
+#endif
+
 // m = m*int, int*m -- just convert int to m's precision float
 template <int M, int N, class E, int CS, int RS> inline
 typename Mat<M,N,E,CS,RS>::template Result<typename CNT<E>::Precision>::Mul
@@ -1373,6 +1383,17 @@ template <int M, int N, class E, int CS, int RS> inline
 typename CNT<double>::template Result<Mat<M,N,E,CS,RS> >::Dvd
 operator/(const double& l, const Mat<M,N,E,CS,RS>& r)
 {   return l * r.invert(); }
+
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template <int M, int N, class E, int CS, int RS> inline
+    typename Mat<M,N,E,CS,RS>::template Result<adouble>::Dvd
+    operator/(const Mat<M,N,E,CS,RS>& l, const adouble& r)
+    { return Mat<M,N,E,CS,RS>::template Result<adouble>::DvdOp::perform(l,r); }
+    template <int M, int N, class E, int CS, int RS> inline
+    typename CNT<adouble>::template Result<Mat<M,N,E,CS,RS> >::Dvd
+    operator/(const adouble& l, const Mat<M,N,E,CS,RS>& r)
+    { return l * r.invert(); }
+#endif
 
 // m = m/int, int/m -- just convert int to m's precision float
 template <int M, int N, class E, int CS, int RS> inline
@@ -1438,6 +1459,16 @@ template <int M, int N, class E, int CS, int RS> inline
 typename Mat<M,N,E,CS,RS>::template Result<double>::Add
 operator+(const double& l, const Mat<M,N,E,CS,RS>& r) {return r+l;}
 
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template <int M, int N, class E, int CS, int RS> inline
+    typename Mat<M,N,E,CS,RS>::template Result<adouble>::Add
+    operator+(const Mat<M,N,E,CS,RS>& l, const adouble& r)
+    { return Mat<M,N,E,CS,RS>::template Result<adouble>::AddOp::perform(l,r); }
+    template <int M, int N, class E, int CS, int RS> inline
+    typename Mat<M,N,E,CS,RS>::template Result<adouble>::Add
+    operator+(const adouble& l, const Mat<M,N,E,CS,RS>& r) {return r+l;}
+#endif
+
 // m = m+int, int+m -- just convert int to m's precision float
 template <int M, int N, class E, int CS, int RS> inline
 typename Mat<M,N,E,CS,RS>::template Result<typename CNT<E>::Precision>::Add
@@ -1493,6 +1524,18 @@ template <int M, int N, class E, int CS, int RS> inline
 typename CNT<double>::template Result<Mat<M,N,E,CS,RS> >::Sub
 operator-(const double& l, const Mat<M,N,E,CS,RS>& r)
   { return CNT<double>::template Result<Mat<M,N,E,CS,RS> >::SubOp::perform(l,r); }
+
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template <int M, int N, class E, int CS, int RS> inline
+    typename Mat<M,N,E,CS,RS>::template Result<adouble>::Sub
+    operator-(const Mat<M,N,E,CS,RS>& l, const adouble& r)
+    { return Mat<M,N,E,CS,RS>::template Result<adouble>::SubOp::perform(l,r); }
+    template <int M, int N, class E, int CS, int RS> inline
+    typename CNT<adouble>::template Result<Mat<M,N,E,CS,RS> >::Sub
+    operator-(const adouble& l, const Mat<M,N,E,CS,RS>& r)
+    { return CNT<adouble>::template
+        Result<Mat<M,N,E,CS,RS> >::SubOp::perform(l,r); }
+#endif
 
 // m = m-int, int-m // just convert int to m's precision float
 template <int M, int N, class E, int CS, int RS> inline

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
@@ -1119,6 +1119,16 @@ template <int M, class E, int S> inline
 typename Vec<M,E,S>::template Result<double>::Mul
 operator*(const double& l, const Vec<M,E,S>& r) {return r*l;}
 
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template <int M, class E, int S> inline
+    typename Vec<M,E,S>::template Result<adouble>::Mul
+    operator*(const Vec<M,E,S>& l, const adouble& r)
+    { return Vec<M,E,S>::template Result<adouble>::MulOp::perform(l,r); }
+    template <int M, class E, int S> inline
+    typename Vec<M,E,S>::template Result<adouble>::Mul
+    operator*(const adouble& l, const Vec<M,E,S>& r) {return r*l;}
+#endif
+
 // v = v*int, int*v -- just convert int to v's precision float
 template <int M, class E, int S> inline
 typename Vec<M,E,S>::template Result<typename CNT<E>::Precision>::Mul
@@ -1177,6 +1187,17 @@ template <int M, class E, int S> inline
 typename CNT<double>::template Result<Vec<M,E,S> >::Dvd
 operator/(const double& l, const Vec<M,E,S>& r)
   { return CNT<double>::template Result<Vec<M,E,S> >::DvdOp::perform(l,r); }
+
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template <int M, class E, int S> inline
+    typename Vec<M,E,S>::template Result<adouble>::Dvd
+    operator/(const Vec<M,E,S>& l, const adouble& r)
+    { return Vec<M,E,S>::template Result<adouble>::DvdOp::perform(l,r); }
+    template <int M, class E, int S> inline
+    typename CNT<adouble>::template Result<Vec<M,E,S> >::Dvd
+    operator/(const adouble& l, const Vec<M,E,S>& r)
+    { return CNT<adouble>::template Result<Vec<M,E,S> >::DvdOp::perform(l,r); }
+#endif
 
 // v = v/int, int/v -- just convert int to v's precision float
 template <int M, class E, int S> inline
@@ -1239,6 +1260,16 @@ template <int M, class E, int S> inline
 typename Vec<M,E,S>::template Result<double>::Add
 operator+(const double& l, const Vec<M,E,S>& r) {return r+l;}
 
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template <int M, class E, int S> inline
+    typename Vec<M,E,S>::template Result<adouble>::Add
+    operator+(const Vec<M,E,S>& l, const adouble& r)
+    { return Vec<M,E,S>::template Result<adouble>::AddOp::perform(l,r); }
+    template <int M, class E, int S> inline
+    typename Vec<M,E,S>::template Result<adouble>::Add
+    operator+(const adouble& l, const Vec<M,E,S>& r) {return r+l;}
+#endif
+
 // v = v+int, int+v -- just convert int to v's precision float
 template <int M, class E, int S> inline
 typename Vec<M,E,S>::template Result<typename CNT<E>::Precision>::Add
@@ -1294,6 +1325,17 @@ template <int M, class E, int S> inline
 typename CNT<double>::template Result<Vec<M,E,S> >::Sub
 operator-(const double& l, const Vec<M,E,S>& r)
   { return CNT<double>::template Result<Vec<M,E,S> >::SubOp::perform(l,r); }
+
+#ifdef SimTK_REAL_IS_ADOUBLE
+    template <int M, class E, int S> inline
+    typename Vec<M,E,S>::template Result<adouble>::Sub
+    operator-(const Vec<M,E,S>& l, const adouble& r)
+    { return Vec<M,E,S>::template Result<adouble>::SubOp::perform(l,r); }
+    template <int M, class E, int S> inline
+    typename CNT<adouble>::template Result<Vec<M,E,S> >::Sub
+    operator-(const adouble& l, const Vec<M,E,S>& r)
+    { return CNT<adouble>::template Result<Vec<M,E,S> >::SubOp::perform(l,r); }
+#endif
 
 // v = v-int, int-v // just convert int to v's precision float
 template <int M, class E, int S> inline

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
@@ -1193,10 +1193,7 @@ operator/(const double& l, const Vec<M,E,S>& r)
     typename Vec<M,E,S>::template Result<adouble>::Dvd
     operator/(const Vec<M,E,S>& l, const adouble& r)
     { return Vec<M,E,S>::template Result<adouble>::DvdOp::perform(l,r); }
-    template <int M, class E, int S> inline
-    typename CNT<adouble>::template Result<Vec<M,E,S> >::Dvd
-    operator/(const adouble& l, const Vec<M,E,S>& r)
-    { return CNT<adouble>::template Result<Vec<M,E,S> >::DvdOp::perform(l,r); }
+    // The operation a/v where a is an adouble and v is a Vec is not supported.
 #endif
 
 // v = v/int, int/v -- just convert int to v's precision float
@@ -1331,10 +1328,7 @@ operator-(const double& l, const Vec<M,E,S>& r)
     typename Vec<M,E,S>::template Result<adouble>::Sub
     operator-(const Vec<M,E,S>& l, const adouble& r)
     { return Vec<M,E,S>::template Result<adouble>::SubOp::perform(l,r); }
-    template <int M, class E, int S> inline
-    typename CNT<adouble>::template Result<Vec<M,E,S> >::Sub
-    operator-(const adouble& l, const Vec<M,E,S>& r)
-    { return CNT<adouble>::template Result<Vec<M,E,S> >::SubOp::perform(l,r); }
+    // The operation a-v where a is an adouble and v is a Vec is not supported.
 #endif
 
 // v = v-int, int-v // just convert int to v's precision float

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -202,7 +202,7 @@ void testVec() {
     SimTK_TEST(vresdr[0] == b/a);
     SimTK_TEST(vresdr[1] == c/a);
     SimTK_TEST(vresdr[2] == d/a);
-    //Vec<3,adouble,1> vresdl = a/v;
+    //auto vresdl = a/v;
     // addition
     Vec<3,adouble,1> vresar = v+a;
     SimTK_TEST(vresar[0] == b+a);

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -202,7 +202,6 @@ void testVec() {
     SimTK_TEST(vresdr[0] == b/a);
     SimTK_TEST(vresdr[1] == c/a);
     SimTK_TEST(vresdr[2] == d/a);
-    //auto vresdl = a/v;
     // addition
     Vec<3,adouble,1> vresar = v+a;
     SimTK_TEST(vresar[0] == b+a);
@@ -217,7 +216,6 @@ void testVec() {
     SimTK_TEST(vressr[0] == b-a);
     SimTK_TEST(vressr[1] == c-a);
     SimTK_TEST(vressr[2] == d-a);
-    //Vec<3,adouble,1> vressl = a-v;
 }
 
 // Various unit tests verifying that operators involving a matrix and an
@@ -273,7 +271,6 @@ void testMat() {
     SimTK_TEST(mressr[1][0] == m[1][0]);
     SimTK_TEST(mressr[0][1] == m[0][1]);
     SimTK_TEST(mressr[1][1] == e-a);
-    //Mat<2,2,adouble,2,1> mressl = a-m;
 }
 
 

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -177,11 +177,113 @@ void testNegator() {
     SimTK_TEST(!isInf((negator<adouble>&)xad));
 }
 
+// Various unit tests verifying that operators involving a vector and an
+// adouble work properly
+void testVec() {
+    adouble a = -2;
+    adouble b = 2;
+    adouble c = -1.5;
+    adouble d = -2.8;
+    Vec<3,adouble,1> v;
+    v[0] = b;
+    v[1] = c;
+    v[2] = d;
+    // multiplication
+    Vec<3,adouble,1> vresmr = v*a;
+    SimTK_TEST(vresmr[0] == b*a);
+    SimTK_TEST(vresmr[1] == c*a);
+    SimTK_TEST(vresmr[2] == d*a);
+    Vec<3,adouble,1> vresml = a*v;
+    SimTK_TEST(vresml[0] == a*b);
+    SimTK_TEST(vresml[1] == a*c);
+    SimTK_TEST(vresml[2] == a*d);
+    // division
+    Vec<3,adouble,1> vresdr = v/a;
+    SimTK_TEST(vresdr[0] == b/a);
+    SimTK_TEST(vresdr[1] == c/a);
+    SimTK_TEST(vresdr[2] == d/a);
+    //Vec<3,adouble,1> vresdl = a/v;
+    // addition
+    Vec<3,adouble,1> vresar = v+a;
+    SimTK_TEST(vresar[0] == b+a);
+    SimTK_TEST(vresar[1] == c+a);
+    SimTK_TEST(vresar[2] == d+a);
+    Vec<3,adouble,1> vresal = a+v;
+    SimTK_TEST(vresal[0] == a+b);
+    SimTK_TEST(vresal[1] == a+c);
+    SimTK_TEST(vresal[2] == a+d);
+    // substraction
+    Vec<3,adouble,1> vressr = v-a;
+    SimTK_TEST(vressr[0] == b-a);
+    SimTK_TEST(vressr[1] == c-a);
+    SimTK_TEST(vressr[2] == d-a);
+    //Vec<3,adouble,1> vressl = a-v;
+}
+
+// Various unit tests verifying that operators involving a matrix and an
+// adouble work properly
+void testMat() {
+    adouble a = -2;
+    adouble b = 2;
+    adouble c = -1.5;
+    adouble d = -2.8;
+    adouble e = 1.87;
+    Mat<2,2,adouble,2,1> m;
+    m[0][0] = b;
+    m[1][0] = c;
+    m[0][1] = d;
+    m[1][1] = e;
+    // multiplication
+    Mat<2,2,adouble,2,1> mresmr = m*a;
+    SimTK_TEST(mresmr[0][0] == b*a);
+    SimTK_TEST(mresmr[1][0] == c*a);
+    SimTK_TEST(mresmr[0][1] == d*a);
+    SimTK_TEST(mresmr[1][1] == e*a);
+    Mat<2,2,adouble,2,1> mresml = a*m;
+    SimTK_TEST(mresml[0][0] == a*b);
+    SimTK_TEST(mresml[1][0] == a*c);
+    SimTK_TEST(mresml[0][1] == a*d);
+    SimTK_TEST(mresml[1][1] == a*e);
+    // division
+    Mat<2,2,adouble,2,1> mresdr = m/a;
+    SimTK_TEST(mresdr[0][0] == b/a);
+    SimTK_TEST(mresdr[1][0] == c/a);
+    SimTK_TEST(mresdr[0][1] == d/a);
+    SimTK_TEST(mresdr[1][1] == e/a);
+    Mat<2,2,adouble,2,1> mresdl = a/m;
+    Mat<2,2,adouble,2,1> minv = a*m.invert();
+    SimTK_TEST(mresdl[0][0] == minv[0][0]);
+    SimTK_TEST(mresdl[1][0] == minv[1][0]);
+    SimTK_TEST(mresdl[0][1] == minv[0][1]);
+    SimTK_TEST(mresdl[1][1] == minv[1][1]);
+    // addition
+    Mat<2,2,adouble,2,1> mresar = m+a;
+    SimTK_TEST(mresar[0][0] == b+a);
+    SimTK_TEST(mresar[1][0] == m[1][0]);
+    SimTK_TEST(mresar[0][1] == m[0][1]);
+    SimTK_TEST(mresar[1][1] == e+a);
+    Mat<2,2,adouble,2,1> mresal = a+m;
+    SimTK_TEST(mresal[0][0] == a+b);
+    SimTK_TEST(mresal[1][0] == m[1][0]);
+    SimTK_TEST(mresal[0][1] == m[0][1]);
+    SimTK_TEST(mresal[1][1] == a+e);
+    // substraction
+    Mat<2,2,adouble,2,1> mressr = m-a;
+    SimTK_TEST(mressr[0][0] == b-a);
+    SimTK_TEST(mressr[1][0] == m[1][0]);
+    SimTK_TEST(mressr[0][1] == m[0][1]);
+    SimTK_TEST(mressr[1][1] == e-a);
+    //Mat<2,2,adouble,2,1> mressl = a-m;
+}
+
+
 int main() {
     SimTK_START_TEST("TestADOLCCommon");
         SimTK_SUBTEST(testDerivativeADOLC);
         SimTK_SUBTEST(testNTraitsADOLC);
         SimTK_SUBTEST(testExceptionTaping);
         SimTK_SUBTEST(testNegator);
+        SimTK_SUBTEST(testVec);
+        SimTK_SUBTEST(testMat);
     SimTK_END_TEST();
 }

--- a/SimTKcommon/tests/TestADOLCCommon.cpp
+++ b/SimTKcommon/tests/TestADOLCCommon.cpp
@@ -251,7 +251,7 @@ void testVec() {
     SimTK_TEST(vresal[0] == a+b);
     SimTK_TEST(vresal[1] == a+c);
     SimTK_TEST(vresal[2] == a+d);
-    // substraction
+    // subtraction
     Vec<3,adouble,1> vressr = v-a;
     SimTK_TEST(vressr[0] == b-a);
     SimTK_TEST(vressr[1] == c-a);
@@ -289,11 +289,17 @@ void testMat() {
     SimTK_TEST(mresdr[0][1] == d/a);
     SimTK_TEST(mresdr[1][1] == e/a);
     Mat<2,2,adouble,2,1> mresdl = a/m;
+    // When the scalar is on the left, this operation means
+    // scalar * pseudoInverse(mat), which is a matrix whose type is like the
+    // matrix's Hermitian transpose.
     Mat<2,2,adouble,2,1> minv = a*m.invert();
     SimTK_TEST(mresdl[0][0] == minv[0][0]);
     SimTK_TEST(mresdl[1][0] == minv[1][0]);
     SimTK_TEST(mresdl[0][1] == minv[0][1]);
     SimTK_TEST(mresdl[1][1] == minv[1][1]);
+    // Addition and subtraction behave as though the scalar stands for a
+    // conforming matrix whose diagonal elements are that scalar and then a
+    // normal matrix addition or subtraction is done.
     // addition
     Mat<2,2,adouble,2,1> mresar = m+a;
     SimTK_TEST(mresar[0][0] == b+a);
@@ -305,7 +311,7 @@ void testMat() {
     SimTK_TEST(mresal[1][0] == m[1][0]);
     SimTK_TEST(mresal[0][1] == m[0][1]);
     SimTK_TEST(mresal[1][1] == a+e);
-    // substraction
+    // subtraction
     Mat<2,2,adouble,2,1> mressr = m-a;
     SimTK_TEST(mressr[0][0] == b-a);
     SimTK_TEST(mressr[1][0] == m[1][0]);


### PR DESCRIPTION
@sherm1, @chrisdembia, this PR contains the changes in `Mat.h `and `Vec.h` necessary to build Simbody with ADOL-C. This PR also contains various tests in `TestADOLCCommon.cpp` verifying that it works properly. EDIT: parent branches have been merged. This PR is thus the next one in the ADOL-C queue.

One question about the tests, should the following operations be supported:

- `a/v` where a is an `adouble `and v a `Vec`
- `a-v` where a is an `adouble `and v a `Vec`
- `a-m` where a is an `adouble `and m a `Mat`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/614)
<!-- Reviewable:end -->
