### PR TITLE
[travis] Comment out osx_image line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,11 @@ sudo: required
 dist: trusty
 language: cpp
 
-# For thread_local support on macOS.
-osx_image: xcode8
+# For thread_local support on macOS, we require xcode8 or greater.
+# Before 2018, xcode7 was the default. Now that xcode8.3 is the default,
+# we no longer need to specify an osx_image.
+# https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
+# osx_image: xcode8
     
 matrix:
   include:


### PR DESCRIPTION
In the Travis YML file, we no longer need to provide `osx_image: xcode8` for `thread_local` support, because Travis CI updated the default OSX image to contain Xcode 8.3.

The real impetus for this change, though, is that moving to Travis CI's new default image fixes an issue for opensim-core, and it would be good to use the same compiler for both simbody and opensim-core.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/615)
<!-- Reviewable:end -->
