### PR TITLE
[travis] Set CMAKE_OSX_DEPLOYMENT_TARGET to 10.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ matrix:
       env: BTYPE=Debug   COV=ON  DEPLOY=yes
     - os: osx
       compiler: clang
-      env: BTYPE=Release COV=OFF DEPLOY=yes
+      env: BTYPE=Release COV=OFF DEPLOY=yes OSX_TARGET=10.10
 
 addons:
   # To avoid an interactive prompt when uploading binaries to sourceforge.
@@ -67,7 +67,12 @@ before_install:
 install:
   - mkdir -p $TRAVIS_BUILD_DIR/simbody-build && cd $TRAVIS_BUILD_DIR/simbody-build
   # Configure.
-  - cmake $TRAVIS_BUILD_DIR -DCMAKE_BUILD_TYPE=$BTYPE -DCMAKE_CXX_FLAGS=-Werror -DSIMBODY_COVERAGE:BOOL=$COV -DCMAKE_INSTALL_PREFIX=~/simbody
+  - CMAKE_ARGS=($TRAVIS_BUILD_DIR -DCMAKE_BUILD_TYPE=$BTYPE -DCMAKE_CXX_FLAGS=-Werror -DSIMBODY_COVERAGE:BOOL=$COV -DCMAKE_INSTALL_PREFIX=~/simbody)
+  # The minimum supported OSX version is 10.10.
+  - if [[ "$TRAVIS_OS_NAME" = "osx" ]]; then CMAKE_ARGS+=(-DCMAKE_OSX_DEPLOYMENT_TARGET=$OSX_TARGET); fi
+  
+  - printf '%s\n' "${CMAKE_ARGS[@]}"
+  - cmake "${CMAKE_ARGS[@]}" 
   # Build.
   - make -j8
 


### PR DESCRIPTION
In preparing for an OpenSim workshop, we discovered that the `simbody-visualizer` crashes on versions of macOS that are older than the version used to compile `simbody-visualizer` (that is, distributing binaries to other machines). We can fix this by setting `CMAKE_OSX_DEPLOYMENT_TARGET` to the minimum macOS version we want to support. This PR sets `CMAKE_OSX_DEPLOYMENT_TARGET` so that distributions of OpenSim will support macOS 10.10 and later.

Related: https://github.com/opensim-org/opensim-core/issues/1835

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/629)
<!-- Reviewable:end -->
