### PR TITLE
[appveyor] Build visualizer on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ build_script:
   - mkdir build
   - cd build
   # Treat all warnings as errors.
-  - cmake .. -G"%CMAKE_GENERATOR%" -T"%CMAKE_TOOLSET%" -DCMAKE_BUILD_TYPE=Release -DBUILD_VISUALIZER=OFF -DCMAKE_INSTALL_PREFIX=C:\simbody
+  - cmake .. -G"%CMAKE_GENERATOR%" -T"%CMAKE_TOOLSET%" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=C:\simbody
   # See http://msdn.microsoft.com/en-us/library/ms164311.aspx for
   # command-line options to MSBuild.
   - cmake --build . --target ALL_BUILD --config Release -- /maxcpucount:4 /verbosity:quiet /p:TreatWarningsAsErrors="true"


### PR DESCRIPTION
Previously, we did not build Simbody with the Visualizer on AppVeyor (the visualizer was built on Travis). This PR causes AppVeyor to build the Visualizer, which we can then use in OpenSim.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/632)
<!-- Reviewable:end -->
