### PR TITLE
Fix crash from ~VisualizerProtocol() throwing an exception.

### DIFF
--- a/Simbody/Visualizer/src/VisualizerProtocol.cpp
+++ b/Simbody/Visualizer/src/VisualizerProtocol.cpp
@@ -435,7 +435,7 @@ void VisualizerProtocol::stopListeningIfNecessary() {
         // finished (though is still joinable), so we can ignore the exception.
         try {
             WRITE(outPipe, &StopCommunication, 1);
-        } catch (const SimTK::Exception::ErrorCheck&) {}
+        } catch (...) {}
         eventListenerThread.join();
     }
 }

--- a/Simbody/Visualizer/src/VisualizerProtocol.cpp
+++ b/Simbody/Visualizer/src/VisualizerProtocol.cpp
@@ -429,8 +429,13 @@ void VisualizerProtocol::stopListeningIfNecessary() {
     if (eventListenerThread.joinable()) {
         // Shut down the listener thread cleanly. Tell the GUI to tell the
         // simulator's listener thread to stop listening, which will allow the
-        // the (simulator's) listener thread to die.
-        WRITE(outPipe, &StopCommunication, 1);
+        // the (simulator's) listener thread to die. WRITE throws an exception
+        // if it can't write to the pipe, which most likely means the GUI has
+        // been closed. If the GUI is closed, the listener thread has
+        // finished (though is still joinable), so we can ignore the exception.
+        try {
+            WRITE(outPipe, &StopCommunication, 1);
+        } catch (const SimTK::Exception::ErrorCheck&) {}
         eventListenerThread.join();
     }
 }


### PR DESCRIPTION
Previously, if the simbody-visualizer GUI was closed before
`VisualizerProtocol::stopListeningIfNecessary()` was called, the
simulator would crash because writing to the visualizer pipe caused an
exception to be thrown in `~VisualizerProtocol()`.

This PR traps that exception to prevent the simulator from crashing when the GUI is closed prematurely.

It would be great for this PR to get a quick review, as it is needed for a workshop at Dynamic Walking in a few weeks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/633)
<!-- Reviewable:end -->
