### PR TITLE
Make sure CPodeFree() does not call cpFreeVectors() unless initialization occurred.

### DIFF
--- a/SimTKmath/Integrators/src/CPodes/sundials/src/cpodes/cpodes.c
+++ b/SimTKmath/Integrators/src/CPodes/sundials/src/cpodes/cpodes.c
@@ -1615,7 +1615,7 @@ void CPodeFree(void **cpode_mem)
 
   cp_mem = (CPodeMem) (*cpode_mem);
   
-  cpFreeVectors(cp_mem);
+  if (cp_mem->cp_MallocDone) cpFreeVectors(cp_mem);
 
   CPodeQuadFree(cp_mem);
 


### PR DESCRIPTION
This was the smallest change I could see to address #641. Although the flag (`cp_MallocDone`) is not specifically set to `true` right when the vectors are allocated, I think this still follows the intention/flow of the code.

@chrisdembia @sherm1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/642)
<!-- Reviewable:end -->
