### PR TITLE
simbody.pc.in: add -std=c++11 to flags

### DIFF
--- a/cmake/pkgconfig/simbody.pc.in
+++ b/cmake/pkgconfig/simbody.pc.in
@@ -7,4 +7,4 @@ Description: Simbody Libraries
 Version: @SIMBODY_VERSION@
 Requires:
 Libs: -L${libdir} -lSimTKsimbody -lSimTKmath -lSimTKcommon @PKGCONFIG_PLATFORM_LIBS@
-CFlags: -I${includedir}
+CFlags: -I${includedir} -std=c++11


### PR DESCRIPTION
We now require c++11, so we should add that to the pkg-config flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/645)
<!-- Reviewable:end -->
