### PR TITLE
Fix GCC-8 warning about incomplete type.

### DIFF
--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/Measure.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/Measure.h
@@ -228,6 +228,8 @@ public:
     /// throw an exception if the Measure is not currently owned by any
     /// Subsystem.
     const Subsystem& getSubsystem()  const;
+    /// Is getSubsystem() the same as the passed-in Subsystem?
+    bool isSameSubsystem(const Subsystem&) const;
     /// Return the MeasureIndex by which this Measure is known to the Subsystem 
     /// that owns it. Will throw an exception if the Measure is not currently 
     /// owned by any Subsystem.
@@ -600,8 +602,8 @@ public:
     :   Measure_<T>(sub, new Implementation(left, right), 
                     AbstractMeasure::SetHandle())
     {   SimTK_ERRCHK_ALWAYS
-           (   this->getSubsystem().isSameSubsystem(left.getSubsystem())
-            && this->getSubsystem().isSameSubsystem(right.getSubsystem()),
+           (   this->isSameSubsystem(left.getSubsystem())
+            && this->isSameSubsystem(right.getSubsystem()),
             "Measure_<T>::Plus::ctor()",
             "Arguments must be in the same Subsystem as this Measure.");
     }
@@ -625,8 +627,8 @@ public:
     :   Measure_<T>(sub, new Implementation(left, right), 
                     AbstractMeasure::SetHandle())
     {   SimTK_ERRCHK_ALWAYS
-           (   this->getSubsystem().isSameSubsystem(left.getSubsystem())
-            && this->getSubsystem().isSameSubsystem(right.getSubsystem()),
+           (   this->isSameSubsystem(left.getSubsystem())
+            && this->isSameSubsystem(right.getSubsystem()),
             "Measure_<T>::Minus::ctor()",
             "Arguments must be in the same Subsystem as this Measure.");
     }
@@ -650,7 +652,7 @@ public:
     :   Measure_<T>(sub, new Implementation(factor, operand), 
                     AbstractMeasure::SetHandle())
     {   SimTK_ERRCHK_ALWAYS
-           (this->getSubsystem().isSameSubsystem(operand.getSubsystem()),
+           (this->isSameSubsystem(operand.getSubsystem()),
             "Measure_<T>::Scale::ctor()",
             "Argument must be in the same Subsystem as this Measure.");
     }

--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/MeasureImplementation.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/MeasureImplementation.h
@@ -229,6 +229,10 @@ inline const Subsystem& AbstractMeasure::
 getSubsystem() const
 {   return getImpl().getSubsystem(); }
 
+inline bool AbstractMeasure::
+isSameSubsystem(const Subsystem& other) const
+{   return getSubsystem().isSameSubsystem(other); }
+
 inline MeasureIndex AbstractMeasure::
 getSubsystemMeasureIndex() const
 {   return getImpl().getSubsystemMeasureIndex();}


### PR DESCRIPTION
This PR fixes a warning generated by GCC-8.

```
In file included from /Users/chris/repos/simbody/6/simbody/SimTKcommon/./include/SimTKcommon/basics.h:43,
                 from /Users/chris/repos/simbody/6/simbody/SimTKcommon/Simulation/include/SimTKcommon/internal/EventHandler.h:27,
                 from /Users/chris/repos/simbody/6/simbody/SimTKcommon/Simulation/src/EventHandler.cpp:24:
/Users/chris/repos/simbody/6/simbody/SimTKcommon/Simulation/include/SimTKcommon/internal/Measure.h: In constructor 'SimTK::Measure_<T>::Plus::Plus(SimTK::Subsystem&, const SimTK::Measure_<T>&, const SimTK::Measure_<T>&)':
/Users/chris/repos/simbody/6/simbody/SimTKcommon/Simulation/include/SimTKcommon/internal/Measure.h:603:34: warning: invalid use of incomplete type 'const class SimTK::Subsystem'
            (   this->getSubsystem().isSameSubsystem(left.getSubsystem())
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/656)
<!-- Reviewable:end -->
