### PR TITLE
Fix issue #639: integration step size precision

### DIFF
--- a/SimTKmath/Geometry/include/simmath/internal/GeodesicIntegrator.h
+++ b/SimTKmath/Geometry/include/simmath/internal/GeodesicIntegrator.h
@@ -320,7 +320,9 @@ GeodesicIntegrator<Eqn>::takeOneStep(Real tStop) {
             SimTK_ERRCHK4_ALWAYS(h > hMin,
                 "GeodesicIntegrator::takeOneStep()", 
                 "Accuracy %g worse than required %g at t=%g with step size"
-                " h=%g; can't go any smaller.", errNorm, m_accuracy, m_t, h);
+                " h=%g; can't go any smaller.  Sometimes, this is caused by " 
+                "requesting a very tight accuracy.  If so, you can try a "
+                "looser one.", errNorm, m_accuracy, m_t, h);
 
             // Shrink step by (acc/err)^(1/4) for 4th order.
             Real hNew = Safety * h * std::sqrt(std::sqrt(m_accuracy/errNorm));
@@ -339,8 +341,9 @@ GeodesicIntegrator<Eqn>::takeOneStep(Real tStop) {
         SimTK_ERRCHK3_ALWAYS(h > hMin,
             "GeodesicIntegrator::takeOneStep()", 
             "Projection failed to reach constraint tolerance %g at t=%g "
-            "with step size h=%g; can't shrink step further.", 
-            m_consTol, m_t, h);
+            "with step size h=%g; can't shrink step further.  Sometimes, this "
+            "is caused by requesting a very tight tolerance.  If so, you can "
+            "try a looser one.", m_consTol, m_t, h);
 
         const Real hNew = MinShrink*h;
         t1 = m_t + hNew;

--- a/SimTKmath/Integrators/src/AbstractIntegratorRep.cpp
+++ b/SimTKmath/Integrators/src/AbstractIntegratorRep.cpp
@@ -494,16 +494,10 @@ bool AbstractIntegratorRep::adjustStepSize
     if (userMaxStepSize != -1)
         newStepSize = std::min(newStepSize, userMaxStepSize);
 
-    Real factor;
-    if (methodName == "RungeKutta3")
-        factor = 0.5;        // for h/2
-    else if (methodName == "RungeKuttaMerson")
-        factor = 0.166;      // for h*(1/2-1/3)
-    else if (methodName == "RungeKuttaFeldberg")
-        factor = 0.0769;     // for h*(1-12/13)
-    else                     // all other integrators
-        factor = 0.95;       // for 0.95*currentStepSize in takeOneStep() 
-    checkStepSizePrecision(getPreviousTime(), newStepSize, factor, __FILE__, 
+    // 1-12/13 = 0.0769 is the factor used by RungeKuttaFeldbergIntegrator.cpp.
+    // This is the smallest factor used by integrators calling adjustStepSize(),
+    // making it the strictest check.  
+    checkStepSizePrecision(getPreviousTime(), newStepSize, 0.0769, __FILE__, 
         __LINE__);
 
     //TODO: this is an odd definition of success. It only works because we're

--- a/SimTKmath/Integrators/src/CPodes/sundials/src/cpodes/cpodes_private.h
+++ b/SimTKmath/Integrators/src/CPodes/sundials/src/cpodes/cpodes_private.h
@@ -310,7 +310,9 @@ void cpRootFree(CPodeMem cp_mem);
 #define MSGCP_TOO_CLOSE "tout too close to t0 to start integration."
 #define MSGCP_MAX_STEPS "At " MSG_TIME ", mxstep steps taken before reaching tout."
 #define MSGCP_TOO_MUCH_ACC "At " MSG_TIME ", too much accuracy requested."
-#define MSGCP_HNIL "Internal " MSG_TIME_H " are such that t + h = t on the next step. The solver will continue anyway."
+#define MSGCP_HNIL "Internal " MSG_TIME_H " are such that t + h = t on the \
+next step. The solver will continue anyway.  Sometimes, this is caused by \
+requesting a very tight accuracy.  If so, you can try a looser one."
 #define MSGCP_ERR_FAILS "At " MSG_TIME_H ", the error test failed repeatedly or with |h| = hmin."
 #define MSGCP_CONV_FAILS "At " MSG_TIME_H ", the corrector convergence test failed repeatedly or with |h| = hmin."
 #define MSGCP_SETUP_FAILED "At " MSG_TIME ", the setup routine failed in an unrecoverable manner."

--- a/SimTKmath/Integrators/src/IntegratorRep.h
+++ b/SimTKmath/Integrators/src/IntegratorRep.h
@@ -60,11 +60,10 @@ public:
         setMessage("At time=" + String(t) + " the integrator failed to take a "
             + "step with step size " + String(h) + " which was already at or "
             + "below the minimum allowed size " + String(hmin) + ".  "
-            + "Sometimes, this is caused by requesting very loose "
-            + "(e.g., > 0.1) or very tight (e.g., < 1e-15) accuracies.  "
-            + "If so, you can try a tighter or looser accuracy, respectively.  "
-            + "Alternatively, you can try setting a max/min step size, or "
-            + "using another integrator.");
+            + "Sometimes, this is caused by requesting very loose or very "
+            + "tight accuracies.  If so, you can try a tighter or looser "
+            + "accuracy, respectively.  Alternatively, you can try setting "
+            + "a max/min step size, or using another integrator.");
     }
 };
 

--- a/SimTKmath/tests/TestIntegrationStepSizePrecision.cpp
+++ b/SimTKmath/tests/TestIntegrationStepSizePrecision.cpp
@@ -1,0 +1,117 @@
+/* -------------------------------------------------------------------------- *
+ *                               Simbody(tm)                                  *
+ * -------------------------------------------------------------------------- *
+ * This is part of the SimTK biosimulation toolkit originating from           *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
+ *                                                                            *
+ * Portions copyright (c) 2007-15 Stanford University and the Authors.        *
+ * Authors: Artin Farahani                                                    *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+/* Some Simbody integrators use checkStepSizePrecision() to throw an exception 
+ * when their step size falls below the Real type's precision. The following 
+ * is a test case for this functionality.
+ */
+
+#include "SimTKcommon.h"
+#include "SimTKmath.h"
+#include "simmath/TimeStepper.h"
+#include "PendulumSystem.h"
+#include "simmath/RungeKuttaMersonIntegrator.h"
+#include "../Integrators/src/IntegratorRep.h"
+using namespace SimTK;
+
+
+void testIntegrator (Integrator& integ, PendulumSystem& sys, Real accuracy) {
+    const Real t0 = 0.0;
+    const Real qi[] = {1.0, 0.0};
+    const Real ui[] = {0.0, 0.0};
+    const Vector q0(2, qi);
+    const Vector u0(2, ui);
+
+    sys.setDefaultMass(10);
+    sys.setDefaultTimeAndState(t0, q0, u0);
+    integ.setAccuracy(accuracy);
+    // This loose accuracy is needed for step size to reach the precision limit.
+    integ.setConstraintTolerance(0.8);
+    
+    TimeStepper ts(sys);
+    ts.setIntegrator(integ);
+    ts.initialize(sys.getDefaultState());
+    ts.stepTo(2.0);
+}
+
+
+// In this subtest, a very tight accuracy is intentionally chosen to cause the
+// step size to reach its precision limit.  Therefore, we expect 
+// checkStepSizePrecision() to catch this and throw an exception.
+int testNoMinStepSize(PendulumSystem& sys, 
+                      RungeKuttaMersonIntegrator& integ) {
+    try {
+        testIntegrator(integ, sys, 1e-35);
+        return 1;
+    }
+    catch (Integrator::StepFailed& e) {
+        std::printf("Success: As expected: %s\n", e.what());
+        return 0;
+    }
+}
+
+
+// In this subtest, the user specifies a min step size that is _smaller_ than
+// the precision limit.  Therefore, the limit should still be reached and
+// caught by checkStepSizePrecision().
+int testSmallerMinStepSize(PendulumSystem& sys,
+                           RungeKuttaMersonIntegrator& integ) {
+    try {
+        integ.setMinimumStepSize(1e-16);
+        testIntegrator(integ, sys, 1e-35);
+        return 1;
+    }
+    catch (Integrator::StepFailed& e) {
+        std::printf("Success: As expected: %s\n", e.what());
+        return 0;
+    }
+}
+
+
+// In this subtest, the user specifies a min step size that is _larger_ than
+// the precision limit.  Therefore, the limit should not be reached and not
+// caught by checkStepSizePrecision().  We don't expect an exception to be 
+// thrown here.
+int testLargerMinStepSize(PendulumSystem& sys,
+                          RungeKuttaMersonIntegrator& integ) {
+    integ.setMinimumStepSize(1e-14);
+    testIntegrator(integ, sys, 1e-35);
+    return 0;
+}
+
+
+int main() {
+    SimTK_START_TEST("TestIntegrationStepSizePrecision");
+
+    PendulumSystem sys;
+    sys.realizeTopology();
+    RungeKuttaMersonIntegrator integ(sys);
+
+    SimTK_SUBTEST2(testNoMinStepSize, sys, integ);
+    SimTK_SUBTEST2(testSmallerMinStepSize, sys, integ);
+    SimTK_SUBTEST2(testLargerMinStepSize, sys, integ);
+
+    SimTK_END_TEST();
+    return 0;
+}
+


### PR DESCRIPTION
This PR addresses the root cause of issue #639.  It throws an exception when the integration step size becomes too small to correctly calculate time.

A new function, `checkStepSizePrecision()`, checks the rounding error in the expression `t + factor*h`.  It ensures that the size of `factor*h` relative to `t` is not below the `Real` type's precision.  If it is, the `StepSizeTooSmall` exception is thrown which prints some suggestions on how to avoid this error. 

### Runge-Kutta Type Integrators
A check on `t + h` is recommended for all variable-step-size integrators [[ref]](http://www.ams.org/journals/mcom/1974-28-125/S0025-5718-1974-0329308-8/S0025-5718-1974-0329308-8.pdf), so it is added to `adjustStepSize()`.

However, for RK type methods, a stricter check is needed because they evaluate the derivative `f` within a step.  For example, RK-Merson evaluates `f(t + h/3)` and `f(t + h/2)`.  Since these two values should be distinct, a check on `t + h/6` is needed.  That's why the factor used in the check depends on the RK method used, i.e., `RungeKutta3`, `RungeKuttaMerson`, or `RungeKuttaFeldberg`(This is a typo in Simbody.  The correct name is Fehlberg [[ref]](https://en.wikipedia.org/wiki/Runge%E2%80%93Kutta%E2%80%93Fehlberg_method)).

### Suggestions for User
1. Trying a tighter accuracy was proposed in issue #639.  On the other hand, very tight accuracies can also cause this issue, so trying looser accuracies is also suggested.
2. Setting a max step size can prevent the loose accuracy problem, while setting a min step size would prevent the tight accuracy problem.
3. Another integrator may be better suited to the problem or to loose accuracies.  So, trying another integrator is also suggested.

### Example
If we run `ExampleKneeJoint` with accuracy 0.5, we get:
#### Before this PR:
```
EXCEPTION THROWN: SimTK Exception thrown at AbstractIntegratorRep.cpp:428:
  Integrator step failed at time 2.7475657411302921 apparently because:
SimTK Exception thrown at AbstractIntegratorRep.cpp:551:
  Error detected by Simbody method AbstractIntegrator::takeOneStep(): Unable to advance 
time past 2.74757.
  (Required condition 't1 > t0' was not met.)
```
#### After this PR:
```
EXCEPTION THROWN: SimTK Exception thrown at AbstractIntegratorRep.cpp:428:
  Integrator step failed at time 2.7475657411071852 apparently because:
SimTK Exception thrown at AbstractIntegratorRep.cpp:507:
  At time=2.7475657411071852 the integrator failed to take a step with step size
 6.2135304281274001e-15 which was already at or below the minimum allowed size
 7.3503873432493461e-15.  Sometimes, this is caused by requesting very loose 
(e.g., > 0.1) or very tight (e.g., < 1e-15) accuracies.  If so, you can try a tighter 
or looser accuracy, respectively.  Alternatively, you can try setting a max/min 
step size, or using another integrator.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/661)
<!-- Reviewable:end -->
