### PR TITLE
Remove Unnecessary CMake Policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,11 +18,6 @@ else()
 endif()
 cmake_minimum_required(VERSION ${SIMBODY_REQUIRED_CMAKE_VERSION})
 
-if(COMMAND cmake_policy)
-    cmake_policy(SET CMP0003 NEW)
-    cmake_policy(SET CMP0005 NEW)
-endif()
-
 project(Simbody)
 
 # At this point CMake will have set CMAKE_INSTALL_PREFIX to /usr/local on Linux


### PR DESCRIPTION
This PR addresses issue #662.  It removes the explicit setting of CMake policies CMP0003 and CMP0005.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/663)
<!-- Reviewable:end -->
