### PR TITLE
Fix custom acceleration-only constraint to call calcAccelerationErrors().

### DIFF
--- a/Simbody/src/ConstraintImpl.h
+++ b/Simbody/src/ConstraintImpl.h
@@ -3034,7 +3034,7 @@ void calcAccelerationErrorsVirtual
     const Array_<SpatialVec,ConstrainedBodyIndex>&  A_AB, 
     const Array_<Real,      ConstrainedUIndex>&     constrainedUDot,
     Array_<Real>&                                   aerr) const override
-{   getImplementation().calcVelocityDotErrors
+{   getImplementation().calcAccelerationErrors
                                         (state,A_AB,constrainedUDot,aerr); }
 
 void addInAccelerationConstraintForcesVirtual


### PR DESCRIPTION
Per issue #669, a custom acceleration-only constraint invoked the wrong virtual method. Should call calcAccelerationErrors() rather than calcVelocityDotErrors().

Fixes #669.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/670)
<!-- Reviewable:end -->
