### PR TITLE
Fix visualizer scaling on macOS Catalina

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This is not a comprehensive list of changes but rather a hand-curated collection
 
 3.7 (in development)
 --------------------
-
+* Fix scaling issue of simbody-visualizer on macOS Catalina. Now,
+  simbody-visualizer is an app bundle (simbody-visualizer.app) on Mac.
 
 3.6 (21 February 2018)
 ----------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,6 +149,10 @@ endif()
 # Ensure that debug libraries have "_d" appended to their names.
 set(CMAKE_DEBUG_POSTFIX "_d")
 
+# This variable gets used when configuring the Info.plist for
+# simbody-visualizer.app; see cmake/MacOSXBundleInfo.plist.in.
+set(MACOSX_BUNDLE_HIGH_RESOLUTION_CAPABLE "false")
+
 #
 # These are the names of all the libraries we may generate. These are
 # target names so can be used to specify dependencies of one library

--- a/Simbody/Visualizer/simbody-visualizer/CMakeLists.txt
+++ b/Simbody/Visualizer/simbody-visualizer/CMakeLists.txt
@@ -63,9 +63,15 @@ if(${SIMBODY_USE_INSTALL_RPATH})
     # Linux we'll have to revisit.
 
     # vis_dir_to_install_dir is most likely "../"
+    if (APPLE)
+        set(vis_install_dir
+                "${SIMBODY_VISUALIZER_INSTALL_DIR}/simbody-visualizer.app/Contents/MacOS")
+    else()
+        set(vis_install_dir "${SIMBODY_VISUALIZER_INSTALL_DIR}")
+    endif()
     file(RELATIVE_PATH vis_dir_to_install_dir
-        "${SIMBODY_VISUALIZER_INSTALL_DIR}"
-        "${CMAKE_INSTALL_PREFIX}")
+            "${vis_install_dir}"
+            "${CMAKE_INSTALL_PREFIX}")
     set(vis_dir_to_lib_dir "${vis_dir_to_install_dir}${CMAKE_INSTALL_LIBDIR}")
     set_target_properties(${GUI_NAME} PROPERTIES
         INSTALL_RPATH "\@executable_path/${vis_dir_to_lib_dir}"

--- a/Simbody/Visualizer/simbody-visualizer/CMakeLists.txt
+++ b/Simbody/Visualizer/simbody-visualizer/CMakeLists.txt
@@ -38,7 +38,7 @@ endif()
 
 if(OPENGL_FOUND AND SIMBODY_HAS_GLUT)
 
-add_executable(${GUI_NAME} 
+add_executable(${GUI_NAME} MACOSX_BUNDLE
     simbody-visualizer.cpp lodepng.cpp lodepng.h
     ${GLUT32_HEADERS}) # only on Windows
 
@@ -49,9 +49,11 @@ endif()
 # If building as debug, append the debug postfix to the name of the executable.
 # CMAKE_DEBUG_POSTFIX only affects non-executable targets, but we use its value
 # to set the postfix for this executable.
+# Setting the target property DEBUG_POSTFIX does not work for MACOSX bundles,
+# so we use DEBUG_OUTPUT_NAME instead.
 set_target_properties(${GUI_NAME} PROPERTIES
         PROJECT_LABEL "Code - ${GUI_NAME}"
-        DEBUG_POSTFIX ${CMAKE_DEBUG_POSTFIX})
+        DEBUG_OUTPUT_NAME ${GUI_NAME}${CMAKE_DEBUG_POSTFIX})
 
 # On OSX, bake the relative path to the Simbody libraries into the visualizer
 # executable. Then there's no need to set `DYLD_LIBRARY_PATH` to find the

--- a/Simbody/Visualizer/simbody-visualizer/simbody-visualizer.cpp
+++ b/Simbody/Visualizer/simbody-visualizer/simbody-visualizer.cpp
@@ -2647,7 +2647,7 @@ static const int DefaultWindowWidth  = 800;
 static const int DefaultWindowHeight = 600;
 
 
-// The glut callback for chaning window size.
+// The glut callback for changing window size.
 static void changeSize(int width, int height) {
     if (height == 0)
         height = 1;

--- a/Simbody/Visualizer/src/VisualizerProtocol.cpp
+++ b/Simbody/Visualizer/src/VisualizerProtocol.cpp
@@ -321,6 +321,16 @@ VisualizerProtocol::VisualizerProtocol
         Pathname::addDirectoryOffset(def,
             Pathname::addDirectoryOffset("SimTK", SIMBODY_VISUALIZER_REL_INSTALL_DIR)));
 
+    #if defined(__APPLE__)
+        for (auto& path : actualSearchPath) {
+            #ifndef NDEBUG
+                path += "/simbody-visualizer_d.app/Contents/MacOS/";
+            #else
+                path += "/simbody-visualizer.app/Contents/MacOS/";
+            #endif
+        }
+    #endif
+
     // Pipe[0] is the read end, Pipe[1] is the write end.
     int sim2vizPipe[2], viz2simPipe[2], status;
 

--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -2,35 +2,35 @@
 <!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>English</string>
-	<key>CFBundleExecutable</key>
-	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
-	<key>CFBundleGetInfoString</key>
-	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
-	<key>CFBundleIconFile</key>
-	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
-	<key>CFBundleIdentifier</key>
-	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleLongVersionString</key>
-	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
-	<key>CFBundleName</key>
-	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
-	<key>CFBundlePackageType</key>
-	<string>APPL</string>
-	<key>CFBundleShortVersionString</key>
-	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>CFBundleVersion</key>
-	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
-	<key>CSResourcesFileMapped</key>
-	<true/>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>English</string>
+    <key>CFBundleExecutable</key>
+    <string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+    <key>CFBundleGetInfoString</key>
+    <string>${MACOSX_BUNDLE_INFO_STRING}</string>
+    <key>CFBundleIconFile</key>
+    <string>${MACOSX_BUNDLE_ICON_FILE}</string>
+    <key>CFBundleIdentifier</key>
+    <string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleLongVersionString</key>
+    <string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
+    <key>CFBundleName</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+    <key>CFBundleSignature</key>
+    <string>????</string>
+    <key>CFBundleVersion</key>
+    <string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+    <key>CSResourcesFileMapped</key>
+    <true/>
     <key>NSHighResolutionCapable</key>
     <${MACOSX_BUNDLE_HIGH_RESOLUTION_CAPABLE}/>
-	<key>NSHumanReadableCopyright</key>
-	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+    <key>NSHumanReadableCopyright</key>
+    <string>${MACOSX_BUNDLE_COPYRIGHT}</string>
 </dict>
 </plist>

--- a/cmake/MacOSXBundleInfo.plist.in
+++ b/cmake/MacOSXBundleInfo.plist.in
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>${MACOSX_BUNDLE_EXECUTABLE_NAME}</string>
+	<key>CFBundleGetInfoString</key>
+	<string>${MACOSX_BUNDLE_INFO_STRING}</string>
+	<key>CFBundleIconFile</key>
+	<string>${MACOSX_BUNDLE_ICON_FILE}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${MACOSX_BUNDLE_GUI_IDENTIFIER}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLongVersionString</key>
+	<string>${MACOSX_BUNDLE_LONG_VERSION_STRING}</string>
+	<key>CFBundleName</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${MACOSX_BUNDLE_SHORT_VERSION_STRING}</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>${MACOSX_BUNDLE_BUNDLE_VERSION}</string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+    <key>NSHighResolutionCapable</key>
+    <${MACOSX_BUNDLE_HIGH_RESOLUTION_CAPABLE}/>
+	<key>NSHumanReadableCopyright</key>
+	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+</dict>
+</plist>


### PR DESCRIPTION
This PR fixes #674  by converting simbody-visualizer into an "app bundle". Now, the visualizer is installed as `simbody-visualizer.app/Contents/MacOS`, which allows us to set the setting `NSHighResolutionCapable` to false.

I also added a stub function to help us, in the future, to better support high-resolution displays.

I tested only on Mac. Might someone volunteer to test on Windows and Linux?

@mitkof6 , would you be willing to test on Linux?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/676)
<!-- Reviewable:end -->
