### PR TITLE
Updated vendored c-maes code from upstream

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
   # that match the specified pattern. GREP does not pick up explicit tabs
   # (e.g., literally a \t in a source file).
   # This grep command is invalid on osx.
-  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then if grep --recursive --include={*.cpp,*.c,*.h,*.md,*.yml,*.cmake.*.xml,*.html,*.in,*.txt} -P "\t" . ; then echo "Tabs found in the lines shown above. See CONTRIBUTING.md about tabs."; false; else echo "Repo passed no-tabs check."; fi; else echo "No-tabs check not performed."; fi
+  - if [ "$TRAVIS_OS_NAME" = "linux" ]; then if grep --recursive --include={*.cpp,*.c,*.h,*.md,*.yml,*.cmake.*.xml,*.html,*.in,*.txt} --exclude-dir=c-cmaes -P "\t" . ; then echo "Tabs found in the lines shown above. See CONTRIBUTING.md about tabs."; false; else echo "Repo passed no-tabs check."; fi; else echo "No-tabs check not performed."; fi
   
   ## Dependencies for Simbody.
   - if [ "$TRAVIS_OS_NAME" = "linux" ]; then sudo apt-get --yes update; fi

--- a/SimTKmath/Optimizers/src/c-cmaes/README.md
+++ b/SimTKmath/Optimizers/src/c-cmaes/README.md
@@ -78,7 +78,7 @@ HOW TO START
   B1) Compile and run the example program. Compilation e.g. with 
      the GNU c-compiler in the `src` folder:
 
-        gcc -Wall -o evo cmaes.c example_short.c -lm
+	gcc -Wall -o evo cmaes.c example_short.c -lm
      
   and run with `evo` or `./evo`. Take a look at the output. 
 

--- a/SimTKmath/Optimizers/src/c-cmaes/cmaes.c
+++ b/SimTKmath/Optimizers/src/c-cmaes/cmaes.c
@@ -99,9 +99,13 @@
   14/10/18: splitted cmaes_init() into cmaes_init_para() and cmaes_init_final(),
             such that parameters can be set also comparatively safely within the
             code, namely after calling cmaes_init_para(). The order of parameters
+<<<<<<< HEAD
             of readpara_init() has changed to be the same as for cmaes_init().
   14/11/25  fix warnings from Microsoft C compiler (sherm)
+=======
+            of readpara_init() has changed to be the same as for cmaes_init(). 
   14/11/26: renamed exported symbols so they begin with a cmaes_prefix.
+>>>>>>> bd5aeb2a21fbc437f1b322610022f7cb1ba6a9db
   
   Wish List
     o make signals_filename part of cmaes_t using assign_string()
@@ -217,7 +221,6 @@ static double rgdouMax( const double *rgd, int len);
 static double rgdouMin( const double *rgd, int len);
 static double douMax( double d1, double d2);
 static double douMin( double d1, double d2);
-static int    intMin( int i, int j);
 static int    MaxIdx( const double *rgd, int len);
 static int    MinIdx( const double *rgd, int len);
 static double myhypot(double a, double b);
@@ -282,18 +285,18 @@ cmaes_init_final(cmaes_t *t /* "this" */)
   if (t->version == NULL) {
         ERRORMESSAGE("cmaes_init_final called (probably) without calling cmaes_init_para first",
                      ", which will likely lead to unexpected results",0,0);
-        printf("Warning: cmaes_init_final called (probably) without calling cmaes_init_para first\n");
+        printf("Error: cmaes_init_final called (probably) without calling cmaes_init_para first\n");
   }
   if (strcmp(c_cmaes_version, t->version) != 0) {
         ERRORMESSAGE("cmaes_init_final called twice, which will lead to a memory leak",
                      "; use cmaes_exit() first",0,0);
-        printf("Warning: cmaes_init_final called twice, which will lead to a memory leak; use cmaes_exit first\n");
+        printf("Error: cmaes_init_final called twice, which will lead to a memory leak; use cmaes_exit first\n");
   }
   /* assign_string(&t->signalsFilename, "cmaes_signals.par"); */
 
   if (!t->sp.flgsupplemented) {
     cmaes_readpara_SupplementDefaults(&t->sp);
-    if (!isNoneStr(t->sp.filename))
+    if (!isNoneStr(t->sp.filename)) /* TODO: should this be done in readpara_SupplementDefaults? */
       cmaes_readpara_WriteToFile(&t->sp, "actparcmaes.par");
   }
      
@@ -414,7 +417,6 @@ cmaes_init(cmaes_t *t, /* "this" */
 /* --------------------------------------------------------- */
 
 #ifdef __GNUC__
-    // These macros generate warnings in Visual Studio.
     #pragma GCC diagnostic push
     #pragma GCC diagnostic ignored "-Wunused-result"
 #endif
@@ -532,6 +534,8 @@ cmaes_resume_distribution(cmaes_t *t, char *filename)
   if (res != (t->sp.N*t->sp.N+t->sp.N)/2)
     FATAL("cmaes_resume_distribution(): C: dimensions differ",0,0,0); 
    
+  fclose(fp);
+  
   t->flgIniphase = 0;
   t->flgEigensysIsUptodate = 0;
   t->flgresumedone = 1;
@@ -590,7 +594,7 @@ cmaes_SetMean(cmaes_t *t, const double *xmean)
   int i, N=t->sp.N;
 
   if (t->state >= 1 && t->state < 3)
-    FATAL("cmaes_SetMean: mean cannot be set between the calls of ",
+    FATAL("cmaes_SetMean: mean cannot be set inbetween the calls of ",
           "SamplePopulation and UpdateDistribution",0,0);
 
   if (xmean != NULL && xmean != t->rgxmean)
@@ -758,10 +762,10 @@ cmaes_Optimize( cmaes_t *evo, double(*pFun)(double const *, int dim), long itera
     double *const*pop; /* sampled population */
     const char *stop;
     int i;
-    long startiter = (long)evo->gen; 
+    double startiter = evo->gen; 
     
     while(!(stop=cmaes_TestForTermination(evo)) && 
-        ((long)evo->gen < startiter + iterations || !iterations))
+        (evo->gen < startiter + iterations || !iterations))
     { 
         /* Generate population of new candidate solutions */
         pop = cmaes_SamplePopulation(evo); /* do not change content of pop */
@@ -2401,7 +2405,7 @@ cmaes_random_init( cmaes_random_t *t, long unsigned inseed)
   if (inseed < 1) {
     while ((long) (cloc - clock()) == 0)
       ; /* TODO: remove this for time critical applications? */
-    inseed = (long unsigned)abs((long)(100*time(NULL)+clock()));
+    inseed = (long unsigned)labs((long)(100*time(NULL)+clock()));
   }
   return cmaes_random_Start(t, inseed);
 }
@@ -2476,9 +2480,20 @@ double cmaes_random_Uniform( cmaes_random_t *t)
   return (double)(t->aktrand)/(2.147483647e9);
 }
 
-static char *
-szCat(const char *sz1, const char*sz2, 
-      const char *sz3, const char *sz4);
+/* --------------------------------------------------------- */
+static void
+printErrorStrings(FILE *fd, char const *s1, char const *s2,
+                  char const *s3, char const *s4)
+{
+  if (s1 != NULL)
+    fprintf(fd, "%s", s1);
+  if (s2 != NULL)
+    fprintf(fd, " %s", s2);
+  if (s3 != NULL)
+    fprintf(fd, " %s", s3);
+  if (s4 != NULL)
+    fprintf(fd, " %s", s4);
+}
 
 /* --------------------------------------------------------- */
 /* -------------- Functions: cmaes_readpara_t -------------- */
@@ -2581,16 +2596,16 @@ cmaes_readpara_init (cmaes_readpara_t *t,
 
   N = t->N; 
   if (N == 0)
-    FATAL("cmaes_readpara_cmaes_readpara_t(): problem dimension N undefined.\n",
+    FATAL("cmaes_readpara_t(): problem dimension N undefined.\n",
           "  (no default value available).",0,0); 
   if (t->xstart == NULL && inxstart == NULL && t->typicalX == NULL) {
-    ERRORMESSAGE("Warning: initialX undefined. typicalX = 0.5...0.5 used.","","","");
-    printf("\nWarning: initialX undefined. typicalX = 0.5...0.5 used.\n");
+    ERRORMESSAGE("Error: initialX undefined. typicalX = 0.5...0.5 used.","","","");
+    printf("\nError: initialX undefined. typicalX = 0.5...0.5 used.\n");
   }
   if (t->rgInitialStds == NULL && inrgsigma == NULL) {
     /* FATAL("initialStandardDeviations undefined","","",""); */
-    ERRORMESSAGE("Warning: initialStandardDeviations undefined. 0.3...0.3 used.","","","");
-    printf("\nWarning: initialStandardDeviations. 0.3...0.3 used.\n");
+    ERRORMESSAGE("Error: initialStandardDeviations undefined. 0.3...0.3 used.","","","");
+    printf("\nError: initialStandardDeviations undefined. 0.3...0.3 used.\n");
   }
 
   if (t->xstart == NULL) {
@@ -2781,7 +2796,7 @@ cmaes_readpara_SupplementDefaults(cmaes_readpara_t *t)
   if (t->seed < 1) {
     while ((int) (cloc - clock()) == 0)
       ; /* TODO: remove this for time critical applications!? */
-    t->seed = (unsigned int)abs((long)(100*time(NULL)+clock()));
+    t->seed = (unsigned int)labs((long)(100*time(NULL)+clock()));
   }
 
   if (t->stStopFitness.flg == -1)
@@ -2904,11 +2919,6 @@ static double
 douSquare(double d)
 {
   return d*d;
-}
-static int 
-intMin( int i, int j)
-{
-  return i < j ? i : j;
 }
 static double
 douMax( double i, double j)
@@ -3067,8 +3077,9 @@ cmaes_FATAL(char const *s1, char const *s2, char const *s3,
   time_t t = time(NULL);
   ERRORMESSAGE( s1, s2, s3, s4);
   ERRORMESSAGE("*** Exiting cmaes_t ***",0,0,0);
-  printf("\n -- %s %s\n", asctime(localtime(&t)), 
-           s2 ? szCat(s1, s2, s3, s4) : s1);
+  printf("\n -- %s ", asctime(localtime(&t)));
+  printErrorStrings(stdout, s1, s2, s3, s4);
+  printf("\n");
   printf(" *** CMA-ES ABORTED, see errcmaes.err *** \n");
   fflush(stdout);
   exit(1);
@@ -3090,43 +3101,21 @@ static void ERRORMESSAGE( char const *s1, char const *s2,
   /*  static char szBuf[700];  desirable but needs additional input argument 
       sprintf(szBuf, "%f:%f", gen, gen*lambda);
   */
-  time_t t = time(NULL);
   FILE *fp = fopen( "errcmaes.err", "a");
-  if (!fp)
-    {
-      printf("\nFATAL ERROR: %s\n", s2 ? szCat(s1, s2, s3, s4) : s1);
-      printf("cmaes_t could not open file 'errcmaes.err'.");
-      printf("\n *** CMA-ES ABORTED *** ");
-      fflush(stdout);
-      exit(1);
-    }
-  fprintf( fp, "\n -- %s %s\n", asctime(localtime(&t)), 
-           s2 ? szCat(s1, s2, s3, s4) : s1);
-  fclose (fp);
+  if (fp == NULL) {
+    printf("\nFATAL ERROR: ");
+    printErrorStrings(stdout, s1, s2, s3, s4);
+    printf("\n");
+    printf("cmaes_t could not open file 'errcmaes.err'.");
+    printf("\n *** CMA-ES ABORTED *** ");
+    fflush(stdout);
+    exit(1);
+  } else {
+    time_t t = time(NULL);
+    fprintf(fp, "\n -- %s ", asctime(localtime(&t)));
+    printErrorStrings(fp, s1, s2, s3, s4);
+    fprintf(fp, "\n");
+    fclose (fp);
+  }
 #endif
 }
-
-/* ========================================================= */
-static char *szCat(const char *sz1, const char*sz2, 
-                   const char *sz3, const char *sz4)
-{
-  static char szBuf[700];
-
-  if (!sz1)
-    FATAL("szCat() : Invalid Arguments",0,0,0);
-
-  strncpy ((char *)szBuf, sz1, (unsigned)intMin( (int)strlen(sz1), 698));
-  szBuf[intMin( (int)strlen(sz1), 698)] = '\0';
-  if (sz2)
-    strncat ((char *)szBuf, sz2, 
-             (unsigned)intMin((int)strlen(sz2)+1, 698 - (int)strlen((char const *)szBuf)));
-  if (sz3)
-    strncat((char *)szBuf, sz3, 
-            (unsigned)intMin((int)strlen(sz3)+1, 698 - (int)strlen((char const *)szBuf)));
-  if (sz4)
-    strncat((char *)szBuf, sz4, 
-            (unsigned)intMin((int)strlen(sz4)+1, 698 - (int)strlen((char const *)szBuf)));
-  return (char *) szBuf;
-}
-
-

--- a/SimTKmath/Optimizers/src/c-cmaes/cmaes.c
+++ b/SimTKmath/Optimizers/src/c-cmaes/cmaes.c
@@ -99,13 +99,9 @@
   14/10/18: splitted cmaes_init() into cmaes_init_para() and cmaes_init_final(),
             such that parameters can be set also comparatively safely within the
             code, namely after calling cmaes_init_para(). The order of parameters
-<<<<<<< HEAD
             of readpara_init() has changed to be the same as for cmaes_init().
-  14/11/25  fix warnings from Microsoft C compiler (sherm)
-=======
-            of readpara_init() has changed to be the same as for cmaes_init(). 
+  14/11/25:  fix warnings from Microsoft C compiler (sherm)
   14/11/26: renamed exported symbols so they begin with a cmaes_prefix.
->>>>>>> bd5aeb2a21fbc437f1b322610022f7cb1ba6a9db
   
   Wish List
     o make signals_filename part of cmaes_t using assign_string()

--- a/SimTKmath/Optimizers/src/c-cmaes/cmaes.h
+++ b/SimTKmath/Optimizers/src/c-cmaes/cmaes.h
@@ -160,7 +160,7 @@ typedef struct
   double genOfEigensysUpdate; 
   cmaes_timings_t eigenTimings;
  
-  double dMaxSignifKond;                      
+  double dMaxSignifKond; 				     
   double dLastMinEWgroesserNull;
 
   short flgresumedone; 

--- a/SimTKmath/Optimizers/src/c-cmaes/cmaes_interface.h
+++ b/SimTKmath/Optimizers/src/c-cmaes/cmaes_interface.h
@@ -25,11 +25,11 @@ extern "C" {
 
 /* --- initialization, constructors, destructors --- */
 double * cmaes_init(cmaes_t *, int dimension , double *xstart, 
-        double *stddev, long seed, int lambda, 
-        const char *input_parameter_filename);
+		double *stddev, long seed, int lambda, 
+		const char *input_parameter_filename);
 void cmaes_init_para(cmaes_t *, int dimension , double *xstart, 
-        double *stddev, long seed, int lambda, 
-        const char *input_parameter_filename);
+		double *stddev, long seed, int lambda, 
+		const char *input_parameter_filename);
 double * cmaes_init_final(cmaes_t *);
 void cmaes_resume_distribution(cmaes_t *evo_ptr, char *filename);
 void cmaes_exit(cmaes_t *);
@@ -37,7 +37,7 @@ void cmaes_exit(cmaes_t *);
 /* --- core functions --- */
 double * const * cmaes_SamplePopulation(cmaes_t *);
 double *         cmaes_UpdateDistribution(cmaes_t *, 
-                      const double *rgFitnessValues);
+					  const double *rgFitnessValues);
 const char *     cmaes_TestForTermination(cmaes_t *);
 
 /* --- additional functions --- */
@@ -60,7 +60,7 @@ char *         cmaes_SayHello(cmaes_t *);
 /* --- misc --- */
 double *       cmaes_NewDouble(int n); /* user is responsible to free */
 void           cmaes_FATAL(char const *s1, char const *s2, char const *s3, 
-               char const *s4);
+			   char const *s4);
 
 #ifdef __cplusplus
 } // end extern "C"

--- a/SimTKmath/Optimizers/src/c-cmaes/doc.txt
+++ b/SimTKmath/Optimizers/src/c-cmaes/doc.txt
@@ -34,7 +34,7 @@ LINKS
   http://www.lri.fr/~hansen/publications.html
 
 TUTORIAL:
-  http://www.lri.fr/~hansen/cmatutorial.pdf
+	http://www.lri.fr/~hansen/cmatutorial.pdf
 
 REFERENCES:
 

--- a/SimTKmath/Optimizers/src/c-cmaes/docfunctions.txt
+++ b/SimTKmath/Optimizers/src/c-cmaes/docfunctions.txt
@@ -39,11 +39,11 @@ cmaes_init_final(cmaes_t * evo_ptr);
 double * 
 cmaes_init(cmaes_t * evo_ptr, int dimension , 
            double *initialX, double *initialStdDev,
-           long seed, int lambda, const char *input_parameter_filename);
+	   long seed, int lambda, const char *input_parameter_filename);
 void
 cmaes_init_para(cmaes_t * evo_ptr, int dimension , 
            double *initialX, double *initialStdDev,
-           long seed, int lambda, const char *input_parameter_filename);
+	   long seed, int lambda, const char *input_parameter_filename);
 
     DEFAULTS of input parameters (invoked by 0 or NULL respectively):
         dimension                : 0 /* no default available */
@@ -85,7 +85,7 @@ cmaes_init_para(cmaes_t * evo_ptr, int dimension ,
 
     Return, double *: array of size lambda==popsize that can be
              used to assign fitness values and pass them to
-             cmaes_UpdateDistribution(). 
+	     cmaes_UpdateDistribution(). 
 
     Details: The dimension has to be defined > 0 here or in the
         input parameter file ("cmaes_initials.par"). 
@@ -113,7 +113,7 @@ cmaes_resume_distribution(cmaes_t *evo_ptr, char *filename):
         subsequent values for xmean, evolution paths ps and pc, sigma
         and covariance matrix.  Note that cmaes_init() needs to be 
         called before calling cmaes_resume_distribution()
-        explicitly.  In the former all the remaining
+        explicitely.  In the former all the remaining
         (strategy-)parameters are set. It can be useful to edit the
         written parameters, in particular to increase sigma, before
         resume. 
@@ -126,7 +126,7 @@ cmaes_resume_distribution(cmaes_t *evo_ptr, char *filename):
 
 void 
 cmaes_exit(cmaes_t *) releases the dynamically allocated memory, 
-                   including that of the return value of cmaes_init(). 
+		   including that of the return value of cmaes_init(). 
 
 
 double *const*pop 
@@ -146,7 +146,7 @@ cmaes_ReSampleSingle(cmaes_t evo_ptr, int index)
       index, int: index to an element of the returned value 
          of cmaes_SamplePopulation, double **pop. pop[index] 
          will be resampled where 0<=index<cmaes_Get("lambda") 
-         must hold. 
+	 must hold. 
 
     Return, double *: A pointer to the resampled "population".  
 
@@ -288,7 +288,7 @@ cmaes_GetNew( cmaes_t * evo_prt, char const *keyword)
 
     Return, double *: pointer to the desired value array
          with unlimited reading and writing access to its
-         elements. 
+	 elements. 
 
     Details: The memory of the returned array must be 
          explicitly released using stdlib function free(). 
@@ -301,8 +301,8 @@ cmaes_GetInto( cmaes_t * evo_prt, char const *keyword, double *mem)
           mem, double*: memory of size N==dimension, where the 
                desired values are written into. For mem==NULL
                new memory is allocated as with calling
-               cmaes_GetNew() and must be released by the 
-               user at some point. 
+	       cmaes_GetNew() and must be released by the 
+	       user at some point. 
 
     Return, double *: pointer to input parameter mem, 
              or the new memory, with the desired values. 
@@ -350,21 +350,21 @@ cmaes_WriteToFile(cmaes_t *evo_ptr, const char *szKeyWord,
                minimum of diagonal of D. 
 
            "few(diag(D))": 4 to 6 sorted eigenvalue square roots, 
-                 including the smallest and largest. 
+		 including the smallest and largest. 
 
            "resume": Writes internal state parameters for reading with
                cmaes_resume_distribution. For reading back also the
-               keyword resume in cmaes_initials.par can be used.
+	       keyword resume in cmaes_initials.par can be used.
 
             further keywords: "dim", "funval", "N", "xbest",
                 "xmean",...  See also implementation in cmaes.c and
-                 the file cmaes_signals.par print and write keywords.
+		 the file cmaes_signals.par print and write keywords.
 
          szFileName, const char *: File name, default is "tmpcmaes.dat".
 
        Details: Useful combined keywords can be "eval+funval", "eval+few(diag(D))"
                 "few+few(diag(D))", "all+B". The file cmaes_signals.par provides more
-                examples as it uses the same syntax for writing and printing. 
+		examples as it uses the same syntax for writing and printing. 
 
 void 
 cmaes_UpdateEigensystem(cmaes_t *, int flgforce);
@@ -372,7 +372,7 @@ cmaes_UpdateEigensystem(cmaes_t *, int flgforce);
         evo_ptr, cmaes_t: Pointer to CMA-ES struct cmaes_t will be initialized 
                  within cmaes_init
 
-        flgforce, int: flag, for flgforce!=0 the eigendecomposion is conducted
+	flgforce, int: flag, for flgforce!=0 the eigendecomposion is conducted
                   even if eigenvector and values seem to be up to date. 
 
       Details: conducts the eigendecomposition of C into B and D
@@ -392,7 +392,7 @@ cmaes_NewDouble(int n);
 
 void
 cmaes_FATAL(char const *s1, char const *s2, char const *s3, 
-            char const *s4)
+	    char const *s4)
      Input parameters: error messages, can be NULL. 
 
      Details: cmaes_FATAL writes error messages and terminates


### PR DESCRIPTION
- Upstream commit 0bd2e9e8ec69e9dcedc2b78716a5db5c2edf4e13
- Should remove compiler warning:
    "‘strncpy’ specified bound depends on the length of the source argument"

This PR aims to update the vendored c-maes code in the repo to the latest upstream version.

The significance of this work is that the current (older) c-maes code currently produces these kinds of warnings when compiled in later (>v8) gcc version:

```
simbody/SimTKmath/Optimizers/src/c-cmaes/cmaes.c: In function ‘szCat’:
simbody/SimTKmath/Optimizers/src/c-cmaes/cmaes.c:3118:3: warning: ‘strncpy’ specified bound depends on the length of the source argument [-Wstringop-overflow=]
   strncpy ((char *)szBuf, sz1, (unsigned)intMin( (int)strlen(sz1), 698));
   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Previous discussions about this fix are in [a previous PR](https://github.com/simbody/simbody/pull/689). Ultimately, the resolution was to [upstream a patch to c-maes](https://github.com/CMA-ES/c-cmaes/pull/25), which was merged in [this](https://github.com/CMA-ES/c-cmaes/commit/0bd2e9e8ec69e9dcedc2b78716a5db5c2edf4e13) upstream commit. This PR essentially tracks the work necessary to put the updated source files into Simbody, which should eliminate the warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/690)
<!-- Reviewable:end -->
