### PR TITLE
Fix TLS issues in ParallelExecutor

### DIFF
--- a/SimTKcommon/src/ParallelExecutor.cpp
+++ b/SimTKcommon/src/ParallelExecutor.cpp
@@ -70,7 +70,7 @@ ParallelExecutorImpl* ParallelExecutorImpl::clone() const {
     return new ParallelExecutorImpl(numMaxThreads);
 }
 void ParallelExecutorImpl::execute(ParallelExecutor::Task& task, int times) {
-  if (min(times, numMaxThreads) == 1) {
+  if (numMaxThreads < 2) {
       //(1) NON-PARALLEL CASE:
       // Nothing is actually going to get done in parallel, so we might as well
       // just execute the task directly and save the threading overhead.

--- a/SimTKcommon/tests/TestNoMovingTasks.cpp
+++ b/SimTKcommon/tests/TestNoMovingTasks.cpp
@@ -1,0 +1,99 @@
+/* -------------------------------------------------------------------------- *
+ *                       Simbody(tm): SimTKcommon                             *
+ * -------------------------------------------------------------------------- *
+ * This is part of the SimTK biosimulation toolkit originating from           *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
+ *                                                                            *
+ * Portions copyright (c) 2008-20 Stanford University and the Authors.        *
+ * Authors: Michal Malý                                                       *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+
+/* -------------------------------------------------------------------------- *
+ * Current ParallelExecutor design relies on TLS to store task data. If       *
+ * an initialized task moves between threads, the TLS will point to invalid   *
+ * data. Test that the task division logic does not move ParallelTasks        *
+ * between threads.                                                           *
+ * -------------------------------------------------------------------------- */
+
+#include "SimTKcommon.h"
+
+#include <iostream>
+#include <thread>
+
+#define ASSERT(cond) {SimTK_ASSERT_ALWAYS(cond, "Assertion failed");}
+
+using namespace SimTK;
+
+static int num_cpus;
+
+class TestTask : public Parallel2DExecutor::Task {
+public:
+    TestTask() {}
+    void execute(int, int) override {
+        ASSERT(threadId == std::this_thread::get_id());
+    }
+    void initialize() override {
+        threadId = std::this_thread::get_id();
+    }
+    void finish() override {
+        ASSERT(threadId == std::this_thread::get_id());
+
+        threadId = std::thread::id{};
+    }
+
+private:
+    static thread_local std::thread::id threadId;
+    static thread_local int counter;
+};
+
+thread_local std::thread::id TestTask::threadId;
+
+void testDefault() {
+    for (int size = 1; size < num_cpus * 2 + 1; size++) {
+        Parallel2DExecutor executor(size);
+        TestTask task;
+        executor.execute(task, Parallel2DExecutor::FullMatrix);
+    }
+}
+
+void testFixedMultiple() {
+    for (int size = 1; size < num_cpus * 2 + 1; size++) {
+        ParallelExecutor e(num_cpus > 1 ? num_cpus : 1);
+        Parallel2DExecutor executor(size, e);
+        TestTask task;
+        executor.execute(task, Parallel2DExecutor::FullMatrix);
+    }
+}
+
+void testFixedSingle() {
+    for (int size = 1; size < num_cpus * 2 + 1; size++) {
+        ParallelExecutor e(1);
+        Parallel2DExecutor executor(size, e);
+        TestTask task;
+        executor.execute(task, Parallel2DExecutor::FullMatrix);
+    }
+}
+
+int main() {
+    SimTK_START_TEST("TestStableThreadId");
+        num_cpus = ParallelExecutor::getNumProcessors();
+        SimTK_SUBTEST(testDefault);
+        SimTK_SUBTEST(testFixedMultiple);
+        SimTK_SUBTEST(testFixedSingle);
+    SimTK_END_TEST();
+    return 0;
+}

--- a/Simbody/src/GeneralForceSubsystem.cpp
+++ b/Simbody/src/GeneralForceSubsystem.cpp
@@ -515,6 +515,7 @@ private:
     Vector_<Vec3> m_particleForceCacheLocal;
     Vector m_mobilityForceCacheLocal;
 };
+
 } //namespace
 
 namespace SimTK{
@@ -675,8 +676,12 @@ public:
         }
         if (hasParallelForces)
             calcForcesTask = new CalcForcesParallelTask();
-        else
+        else {
             calcForcesTask = new CalcForcesNonParallelTask();
+
+            // NonParallelTask is not thread-safe, force to single thread
+            calcForcesExecutor = new ParallelExecutor(1);
+        }
         
         // Note that we'll allocate these even if all the needs-caching
         // elements are presently disabled. That way they'll be around when


### PR DESCRIPTION
Current implementation of `ParallelExecutor` is allowed to switch between singlethreaded and multithreaded operation based on the size of the problem. This causes issues in `Parallel2DExecutor`. `Parallel2DExecutor` splits its calculation into multiple substeps which call `ParallelExecutor::execute()`. However, the associated task and its TLS is initialized only once at the beginning of the calculation. If `ParallelExecutor` decides to switch from ST to MT (or vice versa) mode in the middle `Parallel2DExecutor`'s calculation, the associated task may try to access invalid TLS.

First patch in the PR removes the problem-size-based logic and uses only the specified maximum number of threads to decide whether to run in ST or MT mode. This seems to have unmasked a potential race condition in `CalcForcesNonParallelTask`. This task does not use TLS and therefore is not thread-safe. `GeneralForcesSubsystem` does not limit the maximum number of threads to 1 when `CalcForcesNonParallelTask` is used, which leads to data races. This was not an issue before because `ParallelExecutor` ran in ST mode for `times` value of 1. With the size-based logic removed, we need to set the number of threads to 1 manually for thread-unsafe tasks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/704)
<!-- Reviewable:end -->
