### PR TITLE
Replace loop with explicit formula

### DIFF
--- a/SimTKcommon/src/Parallel2DExecutor.cpp
+++ b/SimTKcommon/src/Parallel2DExecutor.cpp
@@ -24,6 +24,7 @@
 #include "Parallel2DExecutorImpl.h"
 #include "SimTKcommon/internal/ParallelExecutor.h"
 #include <utility>
+#include <cmath>
 
 using std::pair;
 
@@ -46,13 +47,10 @@ void Parallel2DExecutorImpl::init(int numProcessors) {
         bins = 1;
     }
     else {
-        
+
         // Determine how many levels of subdivision to use.
-        
-        int levels = 1;
-        while (1<<levels < numProcessors)
-            levels++;
-        levels++;
+
+        int levels = (int)std::ceil(std::log2(numProcessors)) + 1;
         bins = 1<<levels;
         
         // Build the set of squares.


### PR DESCRIPTION
Iterative calculation of the number of bins in `Parallel2DExecutor` can be replaced by an explicit formula.

Test code:
```c++
#include <cmath>
#include <iostream>

int main()
{
        for (int nCpus = 2; nCpus < 513; nCpus++) {
                int levels = 1;
                while (1 << levels < nCpus)
                        levels++;
                levels++;
                int bins = 1 << levels;

                int levelsNew = std::ceil(std::log2(nCpus)) + 1;
                int binsNew = 1 << levelsNew;
                if (bins != binsNew)
                        throw std::runtime_error(std::string("MISMATCH ") + std::to_string(bins) + " " + std::to_string(binsNew));
                std::cout << nCpus << "(" << levels << ", " << bins << ") - " << "(" << levelsNew << ", " << binsNew << ")" << std::endl;
        }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/705)
<!-- Reviewable:end -->
