### PR TITLE
Add getPreviousStepUnweightedYErrorEstimates to Integrator

### DIFF
--- a/SimTKmath/Integrators/include/simmath/Integrator.h
+++ b/SimTKmath/Integrators/include/simmath/Integrator.h
@@ -278,6 +278,19 @@ public:
     /// Get the size of the most recent successful step.
     Real getPreviousStepSizeTaken() const;
 
+    /// Get a vector containing the unweighted errors that the integrator estimated
+    /// for each state variable in Y during the previous step.
+    ///
+    /// - The ordering of entries in the returned vector matches the ordering of
+    ///   entries in Y. That is, yerrors[i] shall return the yerror of the `i`th
+    ///   state variable in Y.
+    ///
+    /// - The returned sequence contains unweighted ("raw") error estimates. The
+    ///   integrator's implementation may (internally) rescale each of these
+    ///   coefficients when using them. Therefore, you shouldn't use the returned
+    ///   sequence to reason about the behavior of the integrator.
+    const Vector& getPreviousStepUnweightedYErrorEstimates() const;
+
     /// Get the step size that will be attempted first on the next call to stepTo() or stepBy().
     Real getPredictedNextStepSize() const;
 

--- a/SimTKmath/Integrators/src/AbstractIntegratorRep.cpp
+++ b/SimTKmath/Integrators/src/AbstractIntegratorRep.cpp
@@ -527,8 +527,8 @@ bool AbstractIntegratorRep::takeOneStep(Real tMax, Real tReport)
               nu = advanced.getNU(), 
               nz = advanced.getNZ(), 
               ny = nq+nu+nz;
-    
-    Vector yErrEst(ny);
+
+    yErrEst.resize(ny);
     bool stepSucceeded = false;
     do {
         // If we lose more than a small fraction of the step size we wanted
@@ -767,6 +767,10 @@ Real AbstractIntegratorRep::getActualInitialStepSizeTaken() const {
 
 Real AbstractIntegratorRep::getPreviousStepSizeTaken() const {
     return lastStepSize;
+}
+
+const Vector& AbstractIntegratorRep::getPreviousStepUnweightedYErrorEstimates() const {
+    return yErrEst;
 }
 
 Real AbstractIntegratorRep::getPredictedNextStepSize() const {

--- a/SimTKmath/Integrators/src/AbstractIntegratorRep.h
+++ b/SimTKmath/Integrators/src/AbstractIntegratorRep.h
@@ -55,6 +55,7 @@ public:
 
     Real getActualInitialStepSizeTaken() const override;
     Real getPreviousStepSizeTaken() const override;
+    const Vector& getPreviousStepUnweightedYErrorEstimates() const override;
     Real getPredictedNextStepSize() const override;
     int getNumStepsAttempted() const override;
     int getNumStepsTaken() const override;
@@ -162,6 +163,7 @@ private:
     bool takeOneStep(Real tMax, Real tReport);
     bool initialized, hasErrorControl;
     Real currentStepSize, lastStepSize, actualInitialStepSizeTaken;
+    Vector yErrEst;
     int minOrder, maxOrder;
     std::string methodName;
 };

--- a/SimTKmath/Integrators/src/CPodesIntegrator.cpp
+++ b/SimTKmath/Integrators/src/CPodesIntegrator.cpp
@@ -577,6 +577,11 @@ Real CPodesIntegratorRep::getPreviousStepSizeTaken() const {
     return size;
 }
 
+const Vector& CPodesIntegratorRep::getPreviousStepUnweightedYErrorEstimates() const {
+    assert(initialized);
+    throw std::runtime_error{__FILE__ ": CPodesIntegratorRep::getPreviousStepUnweightedYErrorEstimates is not implemented"};
+}
+
 Real CPodesIntegratorRep::getPredictedNextStepSize() const {
     assert(initialized);
     Real size;

--- a/SimTKmath/Integrators/src/CPodesIntegratorRep.h
+++ b/SimTKmath/Integrators/src/CPodesIntegratorRep.h
@@ -44,6 +44,7 @@ public:
     Integrator::SuccessfulStepStatus stepTo(Real reportTime, Real scheduledEventTime) override;
     Real getActualInitialStepSizeTaken() const override;
     Real getPreviousStepSizeTaken() const override;
+    const Vector& getPreviousStepUnweightedYErrorEstimates() const override;
     Real getPredictedNextStepSize() const override;
     int getNumStepsAttempted() const override;
     int getNumStepsTaken() const override;

--- a/SimTKmath/Integrators/src/Integrator.cpp
+++ b/SimTKmath/Integrators/src/Integrator.cpp
@@ -182,6 +182,9 @@ Real Integrator::getActualInitialStepSizeTaken() const {
 Real Integrator::getPreviousStepSizeTaken() const {
     return getRep().getPreviousStepSizeTaken();
 }
+const Vector& Integrator::getPreviousStepUnweightedYErrorEstimates() const {
+    return getRep().getPreviousStepUnweightedYErrorEstimates();
+}
 Real Integrator::getPredictedNextStepSize() const {
     return getRep().getPredictedNextStepSize();
 }

--- a/SimTKmath/Integrators/src/IntegratorRep.h
+++ b/SimTKmath/Integrators/src/IntegratorRep.h
@@ -264,6 +264,9 @@ public:
     // What was the size of the most recent successful step?
     virtual Real getPreviousStepSizeTaken() const = 0;
 
+    // What were the errors of all state variables (Y) in the previous step?
+    virtual const Vector& getPreviousStepUnweightedYErrorEstimates() const = 0;
+
     // What step size will be attempted first on the next step() call?
     virtual Real getPredictedNextStepSize() const = 0;
 


### PR DESCRIPTION
Hi,

This PR adds `getPreviousStepUnweightedYErrorEstimates` into simbody's `Integrator` interface. 

## Motivation

We would like to improve the performance of OpenSim model simulations. One important factor in a simulation's performance may be integrator behaviour. An OpenSim model can contain many components, such as bodies, joints, muscles, etc. - each of those components may map to state variables in the integrator. We suspect that, in complex OpenSim models using error-corrected integrators, integrator performance may be dictated by a small number of components that have high errors in their state variables. 

This PR enables downstream implementations to ask the integrator what its estimates of error were for all state variables during the last integration step. Downstream, we want to join this information (raw state variable values) with OpenSim-level information (components) so that we can ask questions like "which muscle in the model has high-error state variables associated with it". The ambition being that we can eventually say "these muscles might be misconfigured (e.g. too stiff) - we should investigate why".

## Discussion

My initial commit here is a general suggestion for how this could be achieved, rather than being authoritative. I'm not ultra-familiar with the integrator implementation, so I may have missed some things. Likely discussion points are:

- The name is fairly verbose, but I wanted to make it clear that the error estimates returned by this are unweighted, and that they can't, alone, be used to infer an integrator's behavior (they are still, nevertheless, fairly useful to have access to). Maybe a better name could be used
- The error estimates are populated on each step, successful or not. The wording deliberately says "previous step", but the other "previous step" method (`getPreviousStepSize`) is for the previous *successful* step.
- I'm guessing `AbstractIntegratorRep` is the best place to hold the `yErrEst` `Vector`, because other representations may want to store it differently (so it shouldn't force a storage model by putting it on `IntegratorRep`)
- `CPodesIntegratorRep::getPreviousStepUnweightedYErrorEstimates` is currently just `throw`ing as a placeholder. I noticed the implementation does access (in `constraint`) but doesn't store it. Downstream (OpenSim) doesn't typically use this integrator, but throwing does technically violate Liskov (and his substitution principle).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/713)
<!-- Reviewable:end -->
