### PR TITLE
Do not install dirent.h on Windows to avoid conflicts

### DIFF
--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -203,15 +203,3 @@ endif()
 # Copy to parent.
 set(PLATFORM_INCLUDE_DIRECTORIES "${PLATFORM_INCLUDE_DIRECTORIES}"
     PARENT_SCOPE)
-
-# This needs an outer loop if you add more include directories.
-file(GLOB INCL_FILES "${PLATFORM_INCLUDE_DIRECTORIES}/*.h")
-foreach(INCLF ${INCL_FILES})
-    get_filename_component(INCLF_ROOT ${INCLF} NAME)
-    install(FILES ${INCLF}
-    PERMISSIONS OWNER_READ OWNER_WRITE
-            GROUP_READ GROUP_WRITE
-                WORLD_READ
-        DESTINATION include )
-endforeach()
-


### PR DESCRIPTION
`dirent.h` is not used in public headers of Simbody, so we can avoid to install it as it can create conflicts with other installation of `dirent.h` from https://github.com/tronkko/dirent .

See for the downstream issue: https://github.com/conda-forge/simbody-feedstock/issues/39 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/716)
<!-- Reviewable:end -->
