### PR TITLE
Removed NDEBUG-dependent SimTK::StateImpl members

### DIFF
--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/StateImpl.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/StateImpl.h
@@ -389,10 +389,8 @@ public:
                != m_cacheEntryPrerequisites.cend();
     }
 
-    #ifndef NDEBUG
     void recordPrerequisiteVersions(const StateImpl&);
     void validatePrerequisiteVersions(const StateImpl&) const;
-    #endif
 
     const ListOfDependents& getDependents() const {return m_dependents;}
     ListOfDependents& updDependents() {return m_dependents;}
@@ -434,11 +432,9 @@ private:
     // numbers are recorded for every prerequisite. Then the "is valid" code
     // can double check that the "is up to date with prerequisites" flag is
     // set correctly.
-    #ifndef NDEBUG
     ValueVersion                m_qVersion{0}, m_uVersion{0}, m_zVersion{0};
     Array_<ValueVersion>        m_discreteVarVersions;
     Array_<ValueVersion>        m_cacheEntryVersions;
-    #endif
 
     bool isReasonable() const {
         return (   m_allocationStage==Stage::Topology

--- a/SimTKcommon/Simulation/src/State.cpp
+++ b/SimTKcommon/Simulation/src/State.cpp
@@ -1041,10 +1041,7 @@ unregisterWithPrerequisites(StateImpl& stateImpl) const {
     }
 }
 
-
-
-#ifndef NDEBUG
-//--------------------------------- Debug only ---------------------------------
+// ------------------- Only Executed in Debug Builds -------------------
 void CacheEntryInfo::
 recordPrerequisiteVersions(const StateImpl& stateImpl) {
     if (isQPrerequisite())
@@ -1097,7 +1094,6 @@ validatePrerequisiteVersions(const StateImpl& stateImpl) const {
             info.getValueVersion(), m_cacheEntryVersions[i]);
     }
 }
-//--------------------------------- Debug only ---------------------------------
-#endif
+// ------------------- Only Executed in Debug Builds -------------------
 
 


### PR DESCRIPTION
Although the members that are affected by this diff (`m_qVersion`, `m_discreteVarVersions`, etc.) are unused in release builds, it is dangerous to conditionally expose them.

The reason why is because of ABI breakages. `StateImpl.h` is a header that can, in principle, be included by downstream code (I know it's `internal/`, but that won't stop it from being transitively included by, e.g. OpenSim) there is a chance that different compilation units will compile different downstream code based on what *their* `NDEBUG` is set to (might be different from simbody's build).

> **Example**:  In Linux, I was getting a segfault on a cache variable read from a not-debug part of `StateImpl`, probably because my downstream code--compiled in Debug mode--compiled assembly code that computes an incorrect offset into the `StateImpl` struct, because it inlined a function via OpenSim.
>
> That segfault disappears if I apply this patch, and I can then build [opensim-creator](https://github.com/computationalbiomechanicslab/opensim-creator) in Debug mode against Release-mode binaries in Linux. The utility of this is that I'm using debug mode /w `libasan` to kick out harder-to-detect faults.

I have read in other PRs, issues, etc. on both `simbody` and `opensim-core` that downstream projects *must* be compiled with the same optimization+debug levels. This should not be the case. It is perfectly normal to use a downstream debug binary with an upstream release library (think about graphics bindings, OS APIs, game engines, etc.).

The only exception is *maybe* MSVC, which has some kind of iterator debug level macro in its standard library, which causes is to cry quite a bit if you mix up flags. I have only seen this in MSVC--specifically for iterators--and both OSX and Linux are *usually* ok with mixing debug levels.

This patch makes `StateImpl` slightly bigger but, assuming empty containers cause no allocations, the overhead should be small compared to the rest of the datastructure. If there is genuinely a performance concern then I would recommend heap-allocating a `DebugData` struct behind a `unique_ptr` to put a cap (pointer size) on the overhead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/738)
<!-- Reviewable:end -->
