### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Simbody works on Windows, Mac, and Linux. For each operating system, you can use
 5. [**FreeBSD**](#freebsd): install pre-built binaries with pkg.
 6. [**Windows using MinGW**](#windows-using-mingw): build from source using MinGW.
 7. [**Windows/Mac/Linux**](#windows-mac-and-linux-using-conda): install pre-built binaries with the Conda package manager.
+8. [**Install using vcpkg**](#installing-simbody(vcpkg)): download and install simbody using the vcpkg dependency manager
 
 If you use Linux, check [Repology](https://repology.org/project/simbody/versions) to see if your distribution provides a package for Simbody.
 
@@ -718,6 +719,19 @@ the Miniconda or Anaconda installation directory as per the standard layout for
 each of the operating systems described above. The Conda Forge Simbody recipe
 can be found in Conda Forge's [feedstock
 repository](https://github.com/conda-forge/simbody-feedstock).
+
+Installing simbody(vcpkg)
+-------------------------
+
+You can download and install simbody using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install simbody
+
+The simbody port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 Acknowledgments
 ---------------


### PR DESCRIPTION
`simbody `available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for `simbody `and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build simbody, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/simbody/portfile.cmake). We try to keep the library maintained as close as possible to the original library.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/741)
<!-- Reviewable:end -->
