### PR TITLE
Improved Sliding algorithm for ExponentialSpringForce

### DIFF
--- a/Simbody/include/simbody/internal/ExponentialSpringForce.h
+++ b/Simbody/include/simbody/internal/ExponentialSpringForce.h
@@ -346,21 +346,24 @@ public:
     @param forces The general force subsystem that encapsulates many (and
     possibly all) of the body forces, torques, and generalized forces applied
     to the system during a simulation.
-    @param contactPlaneTransform Transform specifying the location and
-    orientation of the contact plane with respect to the Ground frame. The
-    positive z-axis of the contact plane defines the normal direction; the
-    x-axis and y-axis define the tangent (or friction) plane.
-    @param body MobilizedBody that will interact / collide with the contact
-    plane.
-    @param station Point on the specified body at which the contact force
-    will be applied. The position and velocity of this point relative to
-    the contact plane determine the magnitude and direction of the contact
-    force.
+    @param X_GP Transform specifying the location and orientation of the
+    contact plane frame (P) with respect to the Ground frame (G). The positive
+    z-axis of P defines the normal direction; the x-axis and y-axis of P
+    together define the tangent (or friction) plane. Note that X_GP is the
+    operator that transforms a point of P (point_P) to that same point in
+    space but measured from the Ground origin (G₀) and expressed in G
+    (i.e., point_G = X_GP * point_P).
+    @param body_B MobilizedBody that will interact / collide with the contact
+    plane. body_B defines frame B.
+    @param station_B Point on the specified body at which the contact force
+    will be applied. station_B is expressed in the local frame of body_B.
+    The position and velocity of this point relative to the contact plane
+    determine the magnitude and direction of the contact force.
     @param params Customized Topology-stage parameters. If params is omitted
     from the argument list, the default set of parameters is used. */
     ExponentialSpringForce(GeneralForceSubsystem& forces,
-        const Transform& contactPlaneTransform,
-        const MobilizedBody& body, const Vec3& station,
+        const Transform& X_GP,
+        const MobilizedBody& body_B, const Vec3& station_B,
         ExponentialSpringParameters params = ExponentialSpringParameters());
 
     /** Get the Transform specifying the location and orientation of the

--- a/Simbody/include/simbody/internal/ExponentialSpringForce.h
+++ b/Simbody/include/simbody/internal/ExponentialSpringForce.h
@@ -46,7 +46,7 @@ limited to this use case. The contact plane can be rotated and displaced
 relative to the Ground frame and so can be used to model a wall, ramp, or
 some other planar structure.
 
-A distinguishing feature of the exponential spring, relative to other
+A distinguishing feature of the exponential spring, relative to traditional
 contact models, is that it ALWAYS applies a force to the body; there is
 never a time in a simulation when the spring force is not applied. This
 seemingly non-physical feature works because (assuming default parameters are
@@ -98,12 +98,14 @@ includes a velocity-dependent (damping) term AND a position-dependent
 (elastic) term. By including the elastic term, drift is entirely eliminated
 and relatively large integration step sizes are maintained.
 
-In initial comparisons, using class ExponentialSpringForce to model
-contact resulted in simulation cpu times that were typically 4 times faster
-(and sometimes 100+ times faster) than when using class
-CompliantContactSubsystem, and yet the simulated motions were similar.
-These comparisons can be reproduced by building and running the Test_Adhoc -
-ExponentialSpringsComparison project that is included with Simbody.
+Computationally, using class ExponentialSpringForce to model contact is
+usually faster than using class CompliantContactSubsystem, and yet simulated
+motions are typically quite similar. For default parameters choices,
+ExponentialSpringForce is about 2x faster. However, if the drift velocity of
+CompliantContactSubsystem is brought down to 0.001 m/s, ExponentialSpringForce
+can be 100x faster. Computational comparisons can be performed by building and
+running the Test_Adhoc - ExponentialSpringsComparison project that is included
+with Simbody.
 
 Aspects of the exponential spring contact model are described in the following
 publication:
@@ -167,17 +169,16 @@ which has the form of the Hunt & Crossley damping model:
 
 The friction force is computed by blending two different friction models.
 The blending is performed based on the 'Sliding' State of the
-ExponentialSpringForce class. 'Sliding' is a continuous state variable (a Z in
-Simbody vocabulary) that characterizes the extent to which either static or
-kinetic conditions are present.
+ExponentialSpringForce class. 'Sliding' characterizes the extent to which
+either static or kinetic conditions are present.
 
         Sliding = 0.0     static- fully fixed in place (lower bound)
         Sliding = 1.0     kinetic- fully sliding (upper bound)
 
-More details about the Sliding State are given in sections below.
+Details about the Sliding %State are given in sections below.
 
 #### Friction Model 1 - Pure Damping (Sliding = 1.0)
-When the body station is moving with respect to the contact plane, the
+When the body station is sliding with respect to the contact plane, the
 friction force is computed using a simple damping term:
 
         fricDamp = −cxy vxy
@@ -237,19 +238,12 @@ Sliding State:
         fricDampBlend = fricDampSpr + (fricDamp − fricDampSpr)*Sliding
         fricBlend = fricElasBlend + fricDampBlend
 
-Regarding the elastic term, when Sliding = 0.0, fricElasBlend is given
-entirely by fricElasSpr, and, as Sliding → 1.0, fricElasBlend → 0.0.
-Regarding the damping term, when Sliding = 0.0, fricDampBlend is
-given entirely by fricDampSpr, and, as Sliding → 1.0, fricDampBlend →
-fricDamp. Any difference between fricDampSpr and fricDamp is due to the
-difference in the ways the friction limit is enforced.
+Model 1 (Pure Damping) dominates as Sliding → 1.0, and Model 2 (Damped Linear
+Spring) dominates as Sliding → 0.0. The blending is well behaved and smooth
+for all values of Sliding between 0.0 and 1.0.
 
-Thus, Model 1 (Pure Damping) dominates as Sliding → 1.0, and
-Model 2 (Damped Linear Spring) dominates as Sliding → 0.0. The blending is
-well behaved and smooth for all values of Sliding between 0.0 and 1.0.
-
-#### Moving the Friction Spring Zero
-The friction spring zero (p₀) (the elastic anchor point) is always made
+#### Moving the Elastic Anchor Point
+The elastic anchor point (p₀) (i.e., the friction spring zero) is always made
 to be consistent with the final value of the blended elastic force
 (fricElasBlend):
 
@@ -266,7 +260,7 @@ change to p₀ is made to the Update Cache (not to the State directly), and the
 integrator moves this cache value to the actual p₀ State after a successful
 integration step is obtained.
 
-#### Coefficients of Friction and SlidingDot
+#### Coefficients of Friction and the Sliding State
 Coefficients of kinetic (sliding) and static (fixed) friction can be specified
 separately for the spring, subject to the following constraints:
 
@@ -277,36 +271,25 @@ friction (μ) is calculated based on the value of the Sliding State:
 
         μ = μₛ − Sliding*(μₛ − μₖ)
 
-The time derivative of Sliding, SlidingDot, is used to drive Sliding toward
-the extremes of 0.0 or 1.0, depending on the following criteria:
+Like the elastic anchor point (p₀), Sliding is handled as an Auto Update
+Discrete State. Again, see State::allocateAutoUpdateDiscreteVariable() for a
+detailed description. Any change to Sliding is made to the Update Cache
+(not to the State directly), and the integrator moves the cache value to the
+actual Sliding State after a successful integration step is obtained.
 
-- If the frictional spring force (fricSpr) exceeded the frictional limit at
-any point during its calculation, Sliding is driven toward 1.0 (rise):
+The value of Sliding is calculated using a continuous function of the
+ratio of the speed of the elastic anchor point (ṗ₀) to the settle velocity
+(vSettle). vSettle is a customizable topology-stage parameter that represents
+the speed at which a body station settles into a static state. See
+ExponentialSpringParameters::setSettleVelocity() for details. Specifically,
+Sliding is calculated as follows:
 
-        SlidingDot = (1.0 − Sliding)/tau
+        ṗ₀ = |Δp₀| / Δt
+        Sliding = SimTK::stepUp( SimTK::clamp(0.0, ṗ₀/vSettle, 1.0) )
 
-- If the frictional spring force (fricSpr) does not exceed the frictional
-limit at any point during its calculation and if the kinematics of the body
-station are near static equilibrium, Sliding is driven toward 0.0 (decay):
-
-        SlidingDot = −Sliding/tau
-
-The threshold for being "near" static equilibrium is established by two
-parameters, vSettle and aSettle. When the velocity and acceleration of the
-body station relative to the contact plane are below vSettle and aSettle,
-respectively, static equilibrium is considered effectively reached.
-
-During a simulation, once a rise or decay is triggered, the rise or decay
-continues uninterrupted until Sliding crosses 0.95 or 0.05, respectively. Once
-these thresholds have been crossed, the criteria for rise and decay are again
-monitored.
-
-In the above equations for SlidingDot, tau is the characteristic time it takes
-for the Sliding State to rise or decay. The default value of tau is 0.01 sec.
-The motivation for using a continuous state variable is that, although the
-transition between static and kinetic may happen quickly, it does not happen
-instantaneously. Evolving Sliding based on a differential equation ensures
-that μ is continuous and that the blending of friction models is well behaved.
+where Δp₀ is the change in p₀ and Δt is the change in time since the last
+successful integration step. When ṗ₀ ≥ vSettle, Sliding = 1.0, and as
+ṗ₀ → 0.0, Sliding → 0.0.
 
 ### Future Enhancements
 
@@ -321,10 +304,10 @@ table.
 ------
 STATES
 ------
-Each instance of ExponentialSpringForce possesses 5 states, which are listed
+Each instance of ExponentialSpringForce possesses 4 states, which are listed
 below in the appropriate category:
 
-### DISCRETE STATES (parameters)
+### DISCRETE STATES
 - μₛ (Real) = Static coefficient of friction.  0.0 ≤ μₛ
 - μₖ (Real) = Kinetic coefficient of friction.  0.0 ≤ μₖ ≤ μₛ
 
@@ -334,21 +317,15 @@ altered during a simulation to model, for example, a slippery spot on the
 floor.
 
 ### AUTO UPDATE DISCRETE STATES
-- p₀ (Vec3) = Zero point  of the frictional spring. p₀ always lies in the
-contact plane.
-- SlidingAction (int) = Action to take when setting SlidingDot. Possible
-actions are Check, Rise, or Decay.
-
-### CONTINUOUS STATE
-- Sliding (Real) = Indicator of whether the spring zero (p₀) is moving or
-fixed in the contact plane.  0.0 ≤ Sliding ≤ 1.0.
-The "Sliding" state is used to transition the instantaneous coefficient of
-friction (μ) between μₖ and μₛ. A value of 0.0 indicates that p₀ is fixed in
-place, in which case μ = μₛ. A value of 1.0 indicates that p₀ is sliding, in
-which case μ = μₖ. A value between 0.0 and 1.0 indicates that a transition
-from sliding to fixed or from fixed to sliding is underway, in which case
-μₖ ≤ μ ≤ μₛ. Sliding is also used to blend between friction Model 1 and Model 2
-(see above for details).
+- p₀ (Vec3) = Elastic anchor point of the frictional spring. p₀ always lies in
+the contact plane.
+- Sliding (Real) = Sliding state of the body station. 0.0 ≤ Sliding ≤ 1.0.
+A value of 0.0 indicates that p₀ is "static" or fixed in place, in which case
+μ = μₛ. A value of 1.0 indicates that p₀ is "kinetic" or sliding, in which case
+μ = μₖ. A value between 0.0 and 1.0 indicates that a transition from fixed to
+sliding or from sliding to fixed is underway, in which case μₖ ≤ μ ≤ μₛ.
+Sliding is also used to blend between friction Model 1 and Model 2 (see
+above).
 
 ----------
 PARAMETERS
@@ -359,9 +336,9 @@ exponential spring are managed using ExponentialSpringParameters.
 ----
 DATA
 ----
-Calculated quantities are cached when the System is realized through
-Stage::Dynamics. The cached data is made accessible via conventional "get"
-methods (see below). */
+Calculated quantities are cached during the appropriate realization stages
+(i.e., Stage::Position, Stage::Velocity, and Stage::Dynamics). Cached data is
+accessible via conventional "get" methods (see below). */
 class SimTK_SIMBODY_EXPORT ExponentialSpringForce : public Force {
 public:
     /** Construct an exponential spring force object with customized
@@ -369,10 +346,10 @@ public:
     @param forces The general force subsystem that encapsulates many (and
     possibly all) of the body forces, torques, and generalized forces applied
     to the system during a simulation.
-    @param contactPlane Transform specifying the location and orientation of
-    the contact plane with respect to the Ground frame. The positive z-axis
-    of the contact plane defines the normal direction; the x- and y-axes
-    define the tangent (or friction) plane.
+    @param contactPlaneTransform Transform specifying the location and
+    orientation of the contact plane with respect to the Ground frame. The
+    positive z-axis of the contact plane defines the normal direction; the
+    x-axis and y-axis define the tangent (or friction) plane.
     @param body MobilizedBody that will interact / collide with the contact
     plane.
     @param station Point on the specified body at which the contact force
@@ -382,7 +359,7 @@ public:
     @param params Customized Topology-stage parameters. If params is omitted
     from the argument list, the default set of parameters is used. */
     ExponentialSpringForce(GeneralForceSubsystem& forces,
-        const Transform& contactPlane,
+        const Transform& contactPlaneTransform,
         const MobilizedBody& body, const Vec3& station,
         ExponentialSpringParameters params = ExponentialSpringParameters());
 
@@ -455,24 +432,18 @@ public:
     @param state State object from which to retrieve μₖ. */
     Real getMuKinetic(const State& state) const;
 
-    /** Set the Sliding state of the spring.
-    @param state State object on which the new value will be set.
-    @param sliding New value of Sliding.  0.0 ≤ sliding ≤ 1.0 */
-    void setSliding(State& state, Real sliding);
-
     /** Get the Sliding state of the spring.
     @param state State object from which to retrieve Sliding. */
     Real getSliding(const State& state) const;
 
-    /** Reset the friction spring zero (elastic anchor point) so that it
-    coincides with the projection of the spring station onto the contact
-    plane. This step is often needed at the beginning of a simulation to
-    ensure that a simulation does not begin with large friction forces.
-    After this call, the elastic portion of the friction force (fxyElas)
-    should be 0.0. Calling this method will invalidate the System at
-    Stage::Dynamics.
-    @param state State object on which to base the reset. */
-    void resetSpringZero(State& state) const;
+    /** Reset the elastic anchor point (friction spring zero) so that it
+     coincides with the projection of the body station onto the contact
+     plane. This step is often needed at the beginning of a simulation to
+     ensure that a simulation does not begin with large friction forces.
+     After this call, the elastic portion of the friction force should be 0.0
+     Calling this method will invalidate the System at Stage::Dynamics.
+     @param state State object on which to base the reset. */
+    void resetAnchorPoint(State& state) const;
 
     /** Get the elastic part of the normal force. The system must be realized
     to Stage::Dynamics to access this data.
@@ -587,16 +558,16 @@ public:
     of the contact plane. */
     Vec3 getStationVelocity(const State& state, bool inGround = true) const;
 
-    /** Get the position of the friction spring zero (p₀), which will always
-    lie in the Contact Plane. p₀ is the elastic anchor point of the damped
-    linear spring used in Friction Model 2. The system must be realized
-    to Stage::Dynamics to access this data.
+    /** Get the position of the elastic anchor point (p₀), which will always
+    lie in the Contact Plane. p₀ is the spring zero of the damped linear
+    spring used in Friction Model 2. The system must be realized to
+    Stage::Dynamics to access this data.
     @param state State object on which to base the calculations.
     @param inGround Flag for choosing the frame in which the returned quantity
     will be expressed. If true (the default), the quantity will be expressed
     in the Ground frame. If false, the quantity will be expressed in the frame
     of the contact plane. */
-    Vec3 getFrictionSpringZeroPosition(const State& state,
+    Vec3 getAnchorPointPosition(const State& state,
         bool inGround=true) const;
 
 private:

--- a/Simbody/include/simbody/internal/ExponentialSpringForce.h
+++ b/Simbody/include/simbody/internal/ExponentialSpringForce.h
@@ -100,7 +100,7 @@ and relatively large integration step sizes are maintained.
 
 Computationally, using class ExponentialSpringForce to model contact is
 usually faster than using class CompliantContactSubsystem, and yet simulated
-motions are typically quite similar. For default parameters choices,
+motions are typically quite similar. For default parameter choices,
 ExponentialSpringForce is about 2x faster. However, if the drift velocity of
 CompliantContactSubsystem is brought down to 0.001 m/s, ExponentialSpringForce
 can be 100x faster. Computational comparisons can be performed by building and

--- a/Simbody/include/simbody/internal/ExponentialSpringParameters.h
+++ b/Simbody/include/simbody/internal/ExponentialSpringParameters.h
@@ -48,7 +48,7 @@ of that object. For example,
 
 4) Realize the system to Stage::Topology. When a new set of parameters is
 set on an ExponentialSpringForce instance, as above in step 3, the System will
-be invalidated at Stage::Topology.  The System must therefore be realized at
+be invalidated at Stage::Topology. The System must therefore be realized at
 Stage::Topology (and hence Stage::Model) before a simulation can proceed.
 
         system.realizeTopology();
@@ -239,7 +239,7 @@ public:
     of the body will still be dissipated because the frictional force is
     directed opposite the sliding velocity, and the elastic part of the
     friction spring will not store additional potential energy because the
-    friction spring zero (p₀) is continually released. The only way to
+    elastic anchor point (p₀) is continually released. The only way to
     eliminate energy dissipation entirely is to also set the coefficients of
     friction equal to 0.0.
     @param cxy Viscosity of the friction spring. Its default value is
@@ -254,19 +254,6 @@ public:
     @returns Viscosity of the friction spring. */
     Real getFrictionViscosity() const;
 
-    /** Set the time constant for transitioning back and forth between the
-    static (μₛ) and kinetic (μₖ) coefficients of friction. The transition is
-    mediated by a rising or decaying exponential that is asymptotic to μₛ or
-    μₖ, respectively.
-    @param tau Time constant (τ) for sliding transitions. The default value of
-    τ is 0.01 s. τ must be positive. */
-    void setSlidingTimeConstant(Real tau);
-
-    /** Get the time constant for transitioning back and forth between the
-    static (μₛ) and kinetic (μₖ) coefficients of friction.
-    @returns Time constant for sliding transitions. */
-    Real getSlidingTimeConstant() const;
-
     /** Set the velocity below which the coefficient of friction transitions
     to the static coefficient of friction (μₛ).
     @param vSettle Settle velocity. It's default value is 0.01 m/s. vSettle
@@ -277,17 +264,6 @@ public:
     transitions to the static coefficient of friction.
     @returns Settle velocity */
     Real getSettleVelocity() const;
-
-    /** Set the acceleration magnitude below which the coefficient of friction
-    transitions to the static coefficient of friction (μₛ).
-    @param aSettle Settle acceleration. It's default value is 1.0 m/s².
-    aSettle must be positive.*/
-    void setSettleAcceleration(Real aSettle);
-
-    /** Get the acceleration magnitude below which the coefficient of friction
-    transitions to the static coefficient of friction.
-    @returns Settle acceleration. */
-    Real getSettleAcceleration() const;
 
     /** Set the initial value of the static coefficient of friction (μₛ).
     Note- use ExponentialSpringForce::setMuStatic(), not this method, to set
@@ -319,9 +295,7 @@ private:
     Real maxFz;
     Real kxy;
     Real cxy;
-    Real tau;
     Real vSettle;
-    Real aSettle;
     Real initMus;
     Real initMuk;
 };

--- a/Simbody/src/ExponentialSpringForce.cpp
+++ b/Simbody/src/ExponentialSpringForce.cpp
@@ -121,22 +121,12 @@ struct ExponentialSpringData {
 class ExponentialSpringForceImpl : public ForceImpl {
 public:
 
-    // Flag for managing the Sliding state and SlidingDot.
-    // An auto update discrete state is used to store the sliding action
-    // for successive integration steps.
-    enum SlidingAction {
-        Decay = 0,  // Decay all the way to fully fixed (Sliding = 0).
-        Rise = 1,   // Rise all the way to fully slipping (Sliding = 1).
-        Check = 2   // Check if a transition condition is met.
-    };
-
     // Constructor
     ExponentialSpringForceImpl(const Transform& XContactPlane,
         const MobilizedBody& body, const Vec3& station,
         const ExponentialSpringParameters& params) :
         X_GP(XContactPlane), body(body), station(station),
-        defaultSprZero(Vec3(0., 0., 0.)),
-        defaultSlidingAction(SlidingAction::Check), defaultSliding(1.0)
+        defaultAnchorPoint(Vec3(0., 0., 0.)), defaultSliding(1.0)
     {
         this->params = params;
     }
@@ -185,60 +175,44 @@ public:
             getCacheEntry(state, indexDataDyn));
     }
 
-    // SLIDING STATE
-    void setSliding(State& state, Real sliding) {
-        updZ(state)[indexZ] = clampInPlace(0.0, sliding, 1.0);
-    }
-    Real getSliding(const State& state) const {
-        return getZ(state)[indexZ];
-    }
-    Real getSlidingDotInCache(const State& state) const {
-        return getZDot(state)[indexZ];
-    }
-    void updSlidingDotInCache(const State& state, Real slidingDot) const {
-        // Doesn't invalidate the State.
-        updZDot(state)[indexZ] = slidingDot;
-    }
-
-    // SLIDING ACTION
-    SlidingAction getSlidingAction(const State& state) const {
-        return Value<SlidingAction>::downcast(
-            getDiscreteVariable(state, indexSlidingAction));
-    }
-    SlidingAction& updSlidingAction(State& state) const {
-        return Value<SlidingAction>::updDowncast(
-            updDiscreteVariable(state, indexSlidingAction));
-    }
-    SlidingAction getSlidingActionInCache(const State& state) const {
-        return Value<SlidingAction>::downcast(
-            getDiscreteVarUpdateValue(state, indexSlidingAction));
-    }
-    void updSlidingActionInCache(
-        const State& state, SlidingAction action) const {
-        // Will not invalidate the State.
-        Value<SlidingAction>::updDowncast(
-            updDiscreteVarUpdateValue(state, indexSlidingAction)) = action;
-        markDiscreteVarUpdateValueRealized(state, indexSlidingAction);
-    }
-
-    // SPRING ZERO
-    const Vec3& getSprZero(const State& state) const {
+    // ELASTIC ANCHOR POINT
+    const Vec3& getAnchorPoint(const State& state) const {
         return Value<Vec3>::downcast(
-            getDiscreteVariable(state, indexSprZero));
+            getDiscreteVariable(state, indexAnchorPoint));
     }
-    Vec3& updSprZero(State& state) const {
+    Vec3& updAnchorPoint(State& state) const {
         return Value<Vec3>::updDowncast(
-            updDiscreteVariable(state, indexSprZero));
+            updDiscreteVariable(state, indexAnchorPoint));
     }
-    Vec3 getSprZeroInCache(const State& state) const {
+    Vec3 getAnchorPointInCache(const State& state) const {
         return Value<Vec3>::downcast(
-            getDiscreteVarUpdateValue(state, indexSprZero));
+            getDiscreteVarUpdateValue(state, indexAnchorPoint));
     }
-    void updSprZeroInCache(const State& state, const Vec3& p0) const {
+    void updAnchorPointInCache(const State& state, const Vec3& p0) const {
         // Will not invalidate the State.
         Value<Vec3>::updDowncast(
-            updDiscreteVarUpdateValue(state, indexSprZero)) = p0;
-        markDiscreteVarUpdateValueRealized(state, indexSprZero);
+            updDiscreteVarUpdateValue(state, indexAnchorPoint)) = p0;
+        markDiscreteVarUpdateValueRealized(state, indexAnchorPoint);
+    }
+
+    // SLIDING
+    const Real& getSliding(const State& state) const {
+        return Value<Real>::downcast(
+            getDiscreteVariable(state, indexSliding));
+    }
+    Real& updSliding(State& state) const {
+        return Value<Real>::updDowncast(
+            updDiscreteVariable(state, indexSliding));
+    }
+    Real getSlidingInCache(const State& state) const {
+        return Value<Real>::downcast(
+            getDiscreteVarUpdateValue(state, indexSliding));
+    }
+    void updSlidingInCache(const State& state, const Real& p0Speed) const {
+        // Will not invalidate the State.
+        Value<Real>::updDowncast(
+            updDiscreteVarUpdateValue(state, indexSliding)) = p0Speed;
+        markDiscreteVarUpdateValueRealized(state, indexSliding);
     }
 
     // STATIC COEFFICENT OF FRICTION
@@ -302,25 +276,19 @@ public:
         mutableThis->indexMuk = fsub.allocateDiscreteVariable(state,
             Stage::Dynamics, new Value<Real>(params.getInitialMuKinetic()));
 
-        // SprZero
-        mutableThis->indexSprZero =
+        // AnchorPoint (p0) (aka: friction spring zero)
+        mutableThis->indexAnchorPoint =
             fsub.allocateAutoUpdateDiscreteVariable(state, Stage::Dynamics,
-                new Value<Vec3>(defaultSprZero), Stage::Dynamics);
-        mutableThis->indexSprZeroInCache =
-            fsub.getDiscreteVarUpdateIndex(state, indexSprZero);
+                new Value<Vec3>(defaultAnchorPoint), Stage::Dynamics);
+        mutableThis->indexAnchorPointInCache =
+            fsub.getDiscreteVarUpdateIndex(state, indexAnchorPoint);
 
-        // SlidingAction
-        mutableThis->indexSlidingAction =
-            fsub.allocateAutoUpdateDiscreteVariable(state,
-                Stage::Acceleration,
-                new Value<SlidingAction>(defaultSlidingAction),
-                Stage::Dynamics);
-        mutableThis->indexSlidingActionInCache =
-            fsub.getDiscreteVarUpdateIndex(state, indexSlidingAction);
-
-        // Sliding
-        const Vector zInit(1, defaultSliding);
-        mutableThis->indexZ = fsub.allocateZ(state, zInit);
+        // Sliding (K --> for "Kinetic")
+        mutableThis->indexSliding = 
+            fsub.allocateAutoUpdateDiscreteVariable(state, Stage::Dynamics,
+                new Value<Real>(defaultSliding), Stage::Dynamics);
+        mutableThis->indexSlidingInCache =
+            fsub.getDiscreteVarUpdateIndex(state, indexSliding);
 
         // Data
         mutableThis->indexDataPos = fsub.allocateCacheEntry(state,
@@ -373,98 +341,6 @@ public:
         dataVel.vxy = dataVel.v_P;    dataVel.vxy[2] = 0.0;
     }
     //_________________________________________________________________________
-    // Stage::Acceleration - compute and update the derivatives of continuous,
-    // acceleration-dependent states.
-    //
-    // Two states are managed at this Stage: Sliding amd SlidingAction.
-    //
-    // Sliding is a continuous state (a "Z" in Simbody vocabulary), and its
-    // time derivative (SlidingDot) is set here. Sliding is bound between
-    // 0.0 (indicating that the body station is fixed in place or static) and
-    // 1.0 (indicating that the body station is moving or kinetic).
-    //
-    // SlidingAction is a discrete state used to trigger when Sliding should
-    // rise to 1.0 (kinetic - fully sliding) or decay to 0.0 (static - fully
-    // fixed in place). Some conditions for triggering a rise or decay depend
-    // on the acceleration of the body station. Thus, the need to manage these
-    // states at the Acceleration Stage.
-    void
-    realizeAcceleration(const State& state) const override {
-        // Parameters
-        Real kTau = 1.0 / params.getSlidingTimeConstant();
-        Real vSettle = params.getSettleVelocity();
-        Real aSettle = params.getSettleAcceleration();
-
-        // Current Sliding State
-        Real sliding = getZ(state)[indexZ];
-        SlidingAction action = getSlidingAction(state);
-
-        // Get const references to the data caches
-        // Values were updated during previous realization stages (see above).
-        const ExponentialSpringData::Pos& dataPos = getDataPos(state);
-        const ExponentialSpringData::Vel& dataVel = getDataVel(state);
-        const ExponentialSpringData::Dyn& dataDyn = getDataDyn(state);
-
-        // Decision tree for managing SlidingDot. Two things happen:
-        // 1) Assign target to 0.0 or 1.0.
-        // 2) Assign next action to Check, Rise, or Decay.
-        // Note that the reason for the 0.05 and 0.95 thresholds are because
-        // it takes a LONG time for Sliding to decay all the way to 0.0 or
-        // rise all the way to 1.0 (i.e., much longer than tau). Checking can
-        // resume when Sliding gets reasonably close to its target.
-        Real target = 1.0;
-        if (action == SlidingAction::Check) {
-
-            // Conditions for Rise (Sliding --> 1.0)
-            // 1. limitReached = true, OR
-            // 2. fz < SimTK::SignificantReal (not "touching" contact plane)
-            if ((dataDyn.limitReached) && (sliding < 0.95)) {
-                action = SlidingAction::Rise;
-
-            // Conditions for Decay (Sliding --> 0.0)
-            // The requirement is basically static equilibrium.
-            // 1. Friction limit not reached, AND
-            // 2. |v| < vSettle (Note: v must be small in ALL directions), AND
-            // 3. |a| < aSettle (Note: a must be small in ALL directions)
-            } else {
-                if (!dataDyn.limitReached && (dataVel.v_G.normSqr()
-                    < vSettle * vSettle) && (sliding > 0.05)) {
-                    // Using another tier of the conditional to avoid
-                    // computing the acceleration if possible.
-                    // Acceleration takes 48 flops.
-                    // norm() takes 15 to 20 flops, but we'll use normSqr()
-                    // which only takes a 5-flop dot product.
-                    Vec3 a =
-                        body.findStationAccelerationInGround(state, station);
-                    if (a.normSqr() < aSettle * aSettle) {
-                        target = 0.0;
-                        action = SlidingAction::Decay;
-                    }
-                }
-            }
-
-            // If the action is still StateAction::Check, finish transitioning
-            // to the current target.
-            if ((action == SlidingAction::Check) && (sliding < 0.06))
-                target = 0.0;
-
-        // Rise
-        } else if (action == SlidingAction::Rise) {
-            if (sliding >= 0.95) action = SlidingAction::Check;
-
-        // Decay
-        } else if (action == SlidingAction::Decay) {
-            target = 0.0;
-            if (sliding <= 0.05) action = SlidingAction::Check;
-        }
-
-        // Update
-        updSlidingActionInCache(state, action);
-        Real slidingDot = kTau * (target - sliding);
-        updSlidingDotInCache(state, slidingDot);
-    }
-
-    //_________________________________________________________________________
     // Calculate the normal force.
     // The normal is defined by the z axis of the contact plane.
     // Key quantities are saved in the data cache.
@@ -502,11 +378,11 @@ public:
         }
     }
     //_________________________________________________________________________
-    // Calculate the friction force using the Blended Option.
+    // Calculate the friction force.
     // The friction plane is defined by the x and y axes of the contact plane.
     // Key quantities are saved in the data cache.
     void
-    calcFrictionForceBlended(const State& state) const {
+    calcFrictionForce(const State& state) const {
         // Retrieve references to data cache entries.
         const ExponentialSpringData::Pos& dataPos = getDataPos(state);
         const ExponentialSpringData::Vel& dataVel = getDataVel(state);
@@ -515,20 +391,26 @@ public:
         Real kpFric = params.getFrictionElasticity();
         Real kvFric = params.getFrictionViscosity();
         // Other initializations
-        Vec3 p0 = getSprZero(state);
+        Vec3 p0 = getAnchorPoint(state);
+        Vec3 p0Last = p0;
         Real mus = getMuStatic(state);
         Real muk = getMuKinetic(state);
-        Real sliding = getZ(state)[indexZ];
-        if (sliding < 0.0) sliding = 0.0;
-        else if (sliding > 1.0) sliding = 1.0;
         dataDyn.limitReached = false;
 
+        // Get the Sliding state (K). ("K" stands for "kinetic")
+        // K is handled as an auto update discrete state. It is set at the end
+        // of this method for the next time step based on the velocity of p0.
+        // The value of K obtained on the line just below is the value set at
+        // the end of the previous successful time step.
+        Real K = getSliding(state);
+
         // Compute max friction force based on the instantaneous mu.
-        dataDyn.mu = mus - sliding * (mus - muk);
+        dataDyn.mu = mus - K * (mus - muk);
         dataDyn.fxyLimit = dataDyn.mu * dataDyn.fz;
 
         // Friction limit is too small.
         // Set all forces to 0.0.
+        // Set p0 = pxy.
         // Set limitReached to true.
         if (dataDyn.fxyLimit < SignificantReal) {
             Vec3 zero(0.0);
@@ -545,9 +427,10 @@ public:
             // Friction is the result purely of damping (no elastic term).
             // If damping force is greater than data.fxyLimit, the damping
             // force is capped at data.fxyLimit.
-            dataDyn.fricDampMod1_P = dataDyn.fricDampMod2_P =
-                -kvFric * dataVel.vxy;
-            if (dataDyn.fricDampMod1_P.normSqr() > square(dataDyn.fxyLimit)) {
+            Real fxyLimitSqr = square(dataDyn.fxyLimit);
+            dataDyn.fricDampMod1_P =
+                dataDyn.fricDampMod2_P = -kvFric*dataVel.vxy;
+            if (dataDyn.fricDampMod1_P.normSqr() > fxyLimitSqr) {
                 dataDyn.fricDampMod1_P =
                     dataDyn.fxyLimit * dataDyn.fricDampMod1_P.normalize();
                 dataDyn.limitReached = true;
@@ -559,27 +442,45 @@ public:
             dataDyn.fricElasMod2_P = -kpFric * (dataPos.pxy - p0);
             dataDyn.fricMod2_P = dataDyn.fricElasMod2_P +
                 dataDyn.fricDampMod2_P;
-            Real fxyMod2 = dataDyn.fricMod2_P.norm();
-            if (fxyMod2 > dataDyn.fxyLimit) {
-                Real scale = dataDyn.fxyLimit / fxyMod2;
+            Real fxyMod2Sqr = dataDyn.fricMod2_P.normSqr();
+            if (fxyMod2Sqr > fxyLimitSqr) {
+                Real scale = dataDyn.fxyLimit / std::sqrt(fxyMod2Sqr);
                 dataDyn.fricElasMod2_P *= scale;
                 dataDyn.fricDampMod2_P *= scale;
                 dataDyn.fricMod2_P =
                     dataDyn.fricElasMod2_P + dataDyn.fricDampMod2_P;
                 dataDyn.limitReached = true;
             }
-            // Blend Model 1 and Model 2 according to the Sliding state
-            // As Sliding --> 1.0, Model 1 dominates
-            // As Sliding --> 0.0, Model 2 dominates
-            dataDyn.fricElas_P = dataDyn.fricElasMod2_P * (1.0 - sliding);
+            // Blend Model 1 and Model 2 according to K
+            // As K --> 1.0, Model 1 dominates
+            // As K --> 0.0, Model 2 dominates
+            dataDyn.fricElas_P = dataDyn.fricElasMod2_P * (1.0 - K);
             dataDyn.fricDamp_P = dataDyn.fricDampMod2_P +
-                (dataDyn.fricDampMod1_P - dataDyn.fricDampMod2_P) * sliding;
+                (dataDyn.fricDampMod1_P - dataDyn.fricDampMod2_P) * K;
             dataDyn.fric_P = dataDyn.fricElas_P + dataDyn.fricDamp_P;
+
+            // Ensure p0 is consistent with the elastic component
             p0 = dataPos.pxy + dataDyn.fricElas_P / kpFric;  p0[2] = 0.0;
         }
 
-        // Update the spring zero in the data cache
-        updSprZeroInCache(state, p0);
+        // Update the elastic anchor point in the data cache
+        updAnchorPointInCache(state, p0);
+
+        // Determine the next sliding state (K) of p0.
+        K = 1.0;
+        Real tDelta = state.getTime() -
+            getDiscreteVarLastUpdateTime(state, indexAnchorPoint);
+        if (tDelta > SignificantReal && dataDyn.fxyLimit > SignificantReal) {
+            // Compute the average speed of the elastic anchor point.
+            Vec3 p0Delta(0.0);
+            p0Delta = p0 - p0Last;
+            Real speed = p0Delta.norm() / tDelta;
+            // Normalize speed by the settle velocity
+            Real speedFrac = speed / params.getSettleVelocity();
+            // Use a step up function to determine K
+            K = stepUp(clamp(0.0, speedFrac, 1.0));
+        }
+        updSlidingInCache(state, K);
     }
     //_________________________________________________________________________
     // Force - calculate the forces and add them to the GeneralForceSubsystem.
@@ -594,7 +495,7 @@ public:
         // Calculate the normal and friction forces.
         // Results are stored in the Dyn data cache.
         calcNormalForce(state);
-        calcFrictionForceBlended(state);
+        calcFrictionForce(state);
 
         // Totals and a transform need to be done for the force.
         ExponentialSpringData::Dyn& dataDyn = updDataDyn(state);
@@ -635,12 +536,12 @@ public:
         params.getShapeParameters(d0, d1, d2);
         double energy = dataDyn.fzElas / d2;
         // Strain energy in the tangent plane (friction spring)
-        // Note that the updated spring zero (the one held in cache) needs to be
-        // used, not the one in the state.
-        // In the process of realizing to Stage::Dynamics, the spring zero is
-        // changed when fxzElas > fxzLimit. This change is not reflected in the
-        // state, just in the cache.
-        Vec3 p0Cache = getSprZeroInCache(state);
+        // Note that the updated anchor point (the one held in cache) needs
+        // to be used, not the one in the state.
+        // In the process of realizing to Stage::Dynamics, the anchor point is
+        // changed when fxzElas > fxzLimit. This change is not reflected in
+        // the state, just in the cache.
+        Vec3 p0Cache = getAnchorPointInCache(state);
         Vec3 r = dataPos.pxy - p0Cache;
         energy += 0.5 * params.getFrictionElasticity() * r.normSqr();
         return energy;
@@ -652,7 +553,7 @@ public:
     //_________________________________________________________________________
     // Project the body spring station onto the contact plane.
     void
-    resetSprZero(State& state) const {
+    resetAnchorPoint(State& state) const {
         // Realize through to the Position Stage
         const MultibodySystem& system = MultibodySystem::downcast(
             getForceSubsystem().getSystem());
@@ -663,8 +564,8 @@ public:
         Vec3 p_P = ~X_GP * p_G;
         // Project onto the contact plane.
         p_P[2] = 0.0;
-        // Update the spring zero
-        updSprZero(state) = p_P;
+        // Update the elastic anchor point
+        updAnchorPoint(state) = p_P;
     }
 private:
     //-------------------------------------------------------------------------
@@ -674,16 +575,14 @@ private:
     Transform X_GP;
     const MobilizedBody& body;
     Vec3 station;
-    Vec3 defaultSprZero;
-    SlidingAction defaultSlidingAction;
+    Vec3 defaultAnchorPoint;
     Real defaultSliding;
     DiscreteVariableIndex indexMus;
     DiscreteVariableIndex indexMuk;
-    DiscreteVariableIndex indexSprZero;
-    CacheEntryIndex indexSprZeroInCache;
-    DiscreteVariableIndex indexSlidingAction;
-    CacheEntryIndex indexSlidingActionInCache;
-    ZIndex indexZ;
+    DiscreteVariableIndex indexAnchorPoint;
+    CacheEntryIndex indexAnchorPointInCache;
+    DiscreteVariableIndex indexSliding;
+    CacheEntryIndex indexSlidingInCache;
     CacheEntryIndex indexDataPos;
     CacheEntryIndex indexDataVel;
     CacheEntryIndex indexDataDyn;
@@ -691,22 +590,6 @@ private:
     //-------------------------------------------------------------------------
     // pass-through methods to reduce calls to getForceSubsystem().
     //-------------------------------------------------------------------------
-    // Z
-    const Vector& getZ(const State& s) const {
-        return getForceSubsystem().getZ(s);
-    }
-    Vector& updZ(State& s) const {
-        return getForceSubsystem().updZ(s);
-    }
-
-    // ZDot
-    const Vector& getZDot(const State& s) const {
-        return getForceSubsystem().getZDot(s);
-    }
-    Vector& updZDot(const State& s) const {
-        return getForceSubsystem().updZDot(s);
-    }
-
     // DiscreteVariable
     const AbstractValue& getDiscreteVariable(
         const State& s, DiscreteVariableIndex i) const {
@@ -721,6 +604,10 @@ private:
     const AbstractValue& getDiscreteVarUpdateValue(
         const State& s, DiscreteVariableIndex i) const {
         return getForceSubsystem().getDiscreteVarUpdateValue(s, i);
+    }
+    Real getDiscreteVarLastUpdateTime(
+        const State& s, DiscreteVariableIndex i) const {
+        return getForceSubsystem().getDiscreteVarLastUpdateTime(s, i);
     }
     AbstractValue& updDiscreteVarUpdateValue(
         const State& s, DiscreteVariableIndex i) const {
@@ -828,25 +715,11 @@ ExponentialSpringForce::
 getMuKinetic(const State& state) const {
     return getImpl().getMuKinetic(state);
 }
-
 //_____________________________________________________________________________
 void
 ExponentialSpringForce::
-setSliding(State& state, Real sliding) {
-    updImpl().setSliding(state, sliding);
-}
-//_____________________________________________________________________________
-Real
-ExponentialSpringForce::
-getSliding(const State& state) const {
-    return getImpl().getSliding(state);
-}
-
-//_____________________________________________________________________________
-void
-ExponentialSpringForce::
-resetSpringZero(State& state) const {
-    getImpl().resetSprZero(state);
+resetAnchorPoint(State& state) const {
+    getImpl().resetAnchorPoint(state);
 }
 
 //-----------------------------------------------------------------------------
@@ -969,20 +842,35 @@ getStationVelocity(const State& state, bool inGround) const {
     if(inGround) return dataVel.v_G;
     return dataVel.v_P;
 }
+
+//-----------------------------------------------------------------------------
+// Auto Update Discrete States
+//-----------------------------------------------------------------------------
 //_____________________________________________________________________________
-// Only the updated value stored in the data cache for the friction spring
-// zero (i.e., the elastic anchor point) is guaranteed to be consistent
-// with the state. Therefore, in order for this method to give a correct
-// value, the System must be realized through Stage::Dynamics prior to a
-// call to this method.
+// Only the updated value stored in the data cache for the elastic anchor
+// point is guaranteed to be consistent with the state. Therefore, in order
+// for this method to give a correct value, the System must be realized
+// through Stage::Dynamics prior to a call to this method.
 Vec3
 ExponentialSpringForce::
-getFrictionSpringZeroPosition(const State& state, bool inGround) const {
+getAnchorPointPosition(const State& state, bool inGround) const {
     SimTK_STAGECHECK_GE_ALWAYS(getStage(state), Stage::Dynamics,
-        "ExponentialSpringForce::getFrictionSpringZeroPosition");
-    Vec3 p0 = getImpl().getSprZeroInCache(state);
+        "ExponentialSpringForce::getAnchorPointPosition");
+    Vec3 p0 = getImpl().getAnchorPointInCache(state);
     if(inGround) {
         p0 = getContactPlaneTransform().shiftFrameStationToBase(p0);
     }
     return p0;
+}
+//_____________________________________________________________________________
+// Only the updated value stored in the data cache for the sliding state is
+// guaranteed to be consistent with the state. Therefore, in order for this
+// method to give a correct value, the System must be realized through
+// Stage::Dynamics prior to a call to this method.
+Real
+ExponentialSpringForce::
+getSliding(const State& state) const {
+    SimTK_STAGECHECK_GE_ALWAYS(getStage(state), Stage::Dynamics,
+        "ExponentialSpringForce::getSliding");
+    return getImpl().getSlidingInCache(state);
 }

--- a/Simbody/src/ExponentialSpringParameters.cpp
+++ b/Simbody/src/ExponentialSpringParameters.cpp
@@ -34,10 +34,8 @@ using std::endl;
 ExponentialSpringParameters::
 ExponentialSpringParameters() :
     d0(0.0065905), d1(0.5336), d2(1150.0), cz(0.5), maxFz(100000.0),
-    kxy(20000.0), cxy(0.0),
-    tau(0.01), vSettle(0.01), aSettle(1.0),
-    initMus(0.7), initMuk(0.5) {
-
+    kxy(20000.0), cxy(0.0), vSettle(0.01), initMus(0.7), initMuk(0.5)
+{
     setElasticityAndViscosityForCriticalDamping(kxy);
 }
 //_____________________________________________________________________________
@@ -48,8 +46,7 @@ operator==(const ExponentialSpringParameters& other) const {
     return ((d0 == other.d0) && (d1 == other.d1) && (d2 == other.d2) &&
         (cz == other.cz) && (maxFz == other.maxFz) &&
         (kxy == other.kxy) && (cxy == other.cxy) &&
-        (tau == other.tau) &&
-        (vSettle == other.vSettle) && (aSettle == other.aSettle) &&
+        (vSettle == other.vSettle) &&
         (initMus == other.initMus) && (initMuk == other.initMuk));
 }
 //_____________________________________________________________________________
@@ -165,22 +162,6 @@ getFrictionViscosity() const {
 //_____________________________________________________________________________
 void
 ExponentialSpringParameters::
-setSlidingTimeConstant(Real tau) {
-    SimTK_APIARGCHECK1_ALWAYS(tau > 0.0,
-        "ExponentialSpringParameters",
-        "setSlidingTimeConstant",
-        "expected tau > 0.0, but tau = %lf", tau);
-    this->tau = tau;
-}
-//_____________________________________________________________________________
-Real
-ExponentialSpringParameters::
-getSlidingTimeConstant() const {
-    return tau;
-}
-//_____________________________________________________________________________
-void
-ExponentialSpringParameters::
 setSettleVelocity(Real vSettle) {
     SimTK_APIARGCHECK1_ALWAYS(vSettle > 0.0,
         "ExponentialSpringParameters",
@@ -193,22 +174,6 @@ Real
 ExponentialSpringParameters::
 getSettleVelocity() const {
     return vSettle;
-}
-//_____________________________________________________________________________
-void
-ExponentialSpringParameters::
-setSettleAcceleration(Real aSettle) {
-    SimTK_APIARGCHECK1_ALWAYS(aSettle > 0.0,
-        "ExponentialSpringParameters",
-        "setSettleAcceleration",
-        "expected aSettle > 0.0, but aSettle = %lf", aSettle);
-    this->aSettle = aSettle;
-}
-//_____________________________________________________________________________
-Real
-ExponentialSpringParameters::
-getSettleAcceleration() const {
-    return aSettle;
 }
 //_____________________________________________________________________________
 void


### PR DESCRIPTION
@sherm1 

This PR includes:
1. A new algorithm for handling the Sliding State.
2. A modification to the API that I believe will be more intuitive for the user. Specifically, the Friction Spring Zero is now consistently referred to as the Elastic Anchor Point (a term first suggested by @sherm1).
3. Improved initial conditions and comments in the ```Test_Adhoc - ExponentialSpringsComparison``` program.

The chief improvement in this PR is a new algorithm for handling the ```Sliding``` State of the ```ExponentialSpringForce``` contact model ( 1.  in the list above).  The ```Sliding``` State (now ```K```) ```(0.0 ≤ K ≤ 1.0)``` characterizes the extent to which either static or kinetic conditions are present for a contact point. The contact point is referred to in the code as the Elastic Anchor Point (or Friction Spring Zero).  ```K = 0.0``` indicates static conditions (i.e., the anchor point is fixed in place).  ```K = 1.0``` indicates kinetic conditions (i.e., the anchor point is sliding). A value between 0.0 and 1.0 indicates a transition between the two extremes.

The new algorithm has allowed a fair amount of code to be removed, is about 10% faster, and I believe is more accurate.

In the previous version of ```ExponentialSpringForce```, ```Sliding``` was handled as a continuous state (a "Z").  It was modeled using a simple differential equation for a rising/decaying exponential.  Notably, the transition between a value of 0.0 and 1.0, once triggered, was entirely decoupled from the dynamics of the body.

In the new algorithm, Sliding is handled as an auto update discrete variable (```K```).  It is calculated using a continuous function of the ratio of the speed of the elastic anchor point (```ṗ₀```) to the settle velocity (```vSettle```). [```vSettle``` is a parameter that represents the speed at which a body station settles into a static state.] Specifically,

```
        ṗ₀ = |Δp₀| / Δt
        K = SimTK::stepUp( SimTK::clamp(0.0, ṗ₀/vSettle, 1.0) )
```

where ```Δp₀``` is the change in ```p₀``` and ```Δt``` is the change in time since the last successful integration step. When ```ṗ₀ ≥ vSettle```, ```K = 1.0```, and as ```ṗ₀ → 0.0```, ```K → 0.0```.

Presented below is a file-by-file description of the changes that were made.

**ExponentialSpringParameters.h**
- Parameters for the Sliding Time Constant (```tau```) and Settle Acceleration (```aSettle```), as well as their related get and set methods were removed. These parameters are not used by the new sliding algorithm.
- In user documentation, the "friction spring zero" is now referred to as the "elastic anchor point".

**ExponentialSpringParameters.cpp**
- Accessor implementations for tau and ```aSettle``` have been removed.
- ```tau``` and ```aSettle``` member variables are no longer referenced in the constructor and the ```opperator==``` method.

**ExponentialSpringForce.h**
- Doxygen comments for class ```ExponentialSpringForce``` have been updated to explain the new algorithm for the ```Sliding``` State and now use the phrase "elastic anchor point" in preference to "friction spring zero".  In addition, a few tweaks were made to generally improve the clarity of the comments.
- ```setSliding()``` was removed.
- ```resetFrictionSpringZero()``` was changed to ```resetAnchorPoint()```.
- ```getFrictionSpringZeroPosition()``` was changed to ```getAnchorPointPosition()```.

**ExponentialSpringForce.cpp**
- Anything related to the ```SlidingAction``` state was removed.
- The ```Sliding``` State, formerly ```Sliding``` and now ```K```, was changed from a continuous state to an auto update discrete state.
- ```ExponentialSpringForceImpl::realizeAcceleration()``` was removed.
- ```SprZero``` and ```FrictionSpringZero``` were changed to ```AnchorPoint``` in method and variable names.
- The new algorithm for computing the ```Sliding``` State (```K```) can be found near the end of ```ExponentialSpringForceImpl::realizeDynamics()```.
- ```ExponentialSpringForce::setSliding()``` was removed.
- ```ExponentialSpringForce::getSliding()``` was moved to the end of the file next to ```ExponentialSpringForce::getAnchorPointPosition()``` so that accessors for the auto update discrete states would be next to each other.
- A number of comments were tweaked to improve clarity.

**ExponentialSpringsComparison.cpp**
- Initial conditions for the simulations were altered to produce simulations that give more informative comparisons between ```ExponentialSpringForce``` and ```CompliantContactSubsystem```.
- A variable, ```vTransition```, was added to ```main()``` to make this variable's value more conspicuous to a potential user. Comments emphasizing and explaining the importance of the variable were also added.
- ```resetSpringZero()``` was changed to ```resetAnchorPoint()```.
- Maximum integration step size was changed from 0.05 to 0.03 sec.
- The final time of the simulation was changed from 10.0 to 12.0 sec.

**TestExponentialSpring.cpp**
- ```resetSpringZero()``` was changed to ```resetAnchorPoint()```
- ```getFrictionSpringZeroPosition()``` was changed to ```getAnchorPointPosition()```
- The value of ```Sliding``` now reliably stays between 0.0 and 1.0 and so the ```SimTK_TEST``` does not need to allow for overshoot.
- ```SimTK_TEST``` calls relating to the Sliding Time Constant and Settle Acceleration were removed because those parameters no longer exist.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/746)
<!-- Reviewable:end -->
