### PR TITLE
Solve compare operator ambiguity with c++20 for gcc/clang

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -456,7 +456,7 @@ public:                                     \
     void invalidate(){clear();}                     \
     void clear(){ix=SimTK::InvalidIndex;}           \
     \
-    bool operator==(const NAME& other) const { return other == ix; } \
+    bool operator==(const NAME& other) const {assert(isValidExtended() && isValidExtended(other)); return ix == other.ix; } \
     bool operator==(int  i) const {assert(isValidExtended() && isValidExtended(i)); return ix==i;}    \
     bool operator==(short s) const{assert(isValidExtended() && isValidExtended(s)); return ix==(int)s;}  \
     bool operator==(long l) const {assert(isValidExtended() && isValidExtended(l)); return ix==(int)l;}  \

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -456,6 +456,7 @@ public:                                     \
     void invalidate(){clear();}                     \
     void clear(){ix=SimTK::InvalidIndex;}           \
     \
+    bool operator==(const NAME& other) const { return other == ix; } \
     bool operator==(int  i) const {assert(isValidExtended() && isValidExtended(i)); return ix==i;}    \
     bool operator==(short s) const{assert(isValidExtended() && isValidExtended(s)); return ix==(int)s;}  \
     bool operator==(long l) const {assert(isValidExtended() && isValidExtended(l)); return ix==(int)l;}  \
@@ -637,6 +638,7 @@ struct Segment {
 // operators in the std::rel_ops namespace, except that those require both
 // types to be the same.
 
+#if !defined(__cpp_lib_three_way_comparison)
 template<class L, class R> inline
 bool operator!=(const L& left, const R& right)
 {   // test for inequality, in terms of equality
@@ -660,7 +662,7 @@ bool operator>=(const L& left, const R& right)
 {   // test if left >= right, in terms of operator<
     return !(left < right);
 }
-
+#endif
 
 /** This is a special type used for causing invocation of a particular
 constructor or method overload that will avoid making a copy of the source

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -633,12 +633,13 @@ struct Segment {
     int offset;
 };  
 
+// With compiler support for <=> operator these four methods below don't
+// need to be manually defined. (from gcc 10, clang 10 & msvc 19.22)
+#if !defined(__cpp_lib_three_way_comparison)
 // These next four methods supply the missing relational operators for any
 // types L and R where L==R and L<R have been defined. This is like the
 // operators in the std::rel_ops namespace, except that those require both
 // types to be the same.
-
-#if !defined(__cpp_lib_three_way_comparison)
 template<class L, class R> inline
 bool operator!=(const L& left, const R& right)
 {   // test for inequality, in terms of equality


### PR DESCRIPTION
### Solve compare operator ambiguity with c++20 for gcc/clang
As mentioned in #710  
>When compiling under C++20, it breaks with
/home/adam/Desktop/osc/master-RelWithDebInfo-install/include/simbody/simmath/internal/ContactGeometry.h:840:27: error: use of overloaded operator '==' is ambiguous (with operand types 'SimTK::ContactGeometryTypeId' and 'SimTK::ContactGeometryTypeId')
{   return geo.getTypeId()==classTypeId(); }

This pull requests attempts to solve this by
1. Defining equal operator for same type.
2. Only define templated compare operators when `__cpp_lib_three_way_comparison (spaceship operator)`  is not available 

Note: I have not tested if any change of behavior occurs (as I'm not familiar with simbody), and have only check for successful compile on gcc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/748)
<!-- Reviewable:end -->
