### PR TITLE
Eliminate some c++20 warnings

### DIFF
--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
@@ -706,7 +706,7 @@ public:
     // conjugates if there are any.
     TNormalize normalize() const {
         if (CNT<E>::IsScalar) {
-            return castAwayNegatorIfAny() / (SignInterpretation*norm());
+            return castAwayNegatorIfAny() / (int(SignInterpretation)*norm());
         } else {
             TNormalize elementwiseNormalized;
             // punt to the column Vec to deal with the elements
@@ -1120,7 +1120,7 @@ public:
 
     /// For approximate comparisons, the default tolerance to use for a matrix is
     /// its shortest dimension times its elements' default tolerance.
-    static double getDefaultTolerance() {return MinDim*CNT<ELT>::getDefaultTolerance();}
+    static double getDefaultTolerance() {return int(MinDim)*CNT<ELT>::getDefaultTolerance();}
 
     /// %Test whether this matrix is numerically equal to some other matrix with
     /// the same shape, using a specified tolerance.

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/SymMat.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/SymMat.h
@@ -582,7 +582,7 @@ public:
     /// conjugates if there are any.
     TNormalize normalize() const {
         if (CNT<E>::IsScalar) {
-            return castAwayNegatorIfAny() / (SignInterpretation*norm());
+            return castAwayNegatorIfAny() / (int(SignInterpretation)*norm());
         } else {
             TNormalize elementwiseNormalized;
             // punt to the equivalent Vec to get the elements normalized

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
@@ -622,7 +622,7 @@ public:
     conjugates if there are any. **/
     TNormalize normalize() const {
         if (CNT<E>::IsScalar) {
-            return castAwayNegatorIfAny() / (SignInterpretation*norm());
+            return castAwayNegatorIfAny() / (int(SignInterpretation)*norm());
         } else {
             TNormalize elementwiseNormalized;
             for (int i=0; i<M; ++i) 


### PR DESCRIPTION
Clang c++20 says that arithmetic between an enum and a double is deprecated. The changes here explicitly cast the enums to int rather than leaving the conversion implicit. That gets rid of the deprecation warnings.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/749)
<!-- Reviewable:end -->
