### PR TITLE
Eliminate two warnings

### DIFF
--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Row.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Row.h
@@ -468,7 +468,7 @@ public:
     // conjugates if there are any.
     TNormalize normalize() const {
         if (CNT<E>::IsScalar) {
-            return castAwayNegatorIfAny() / (SignInterpretation*norm());
+            return castAwayNegatorIfAny() / (int(SignInterpretation)*norm());
         } else {
             TNormalize elementwiseNormalized;
             for (int j=0; j<N; ++j) 

--- a/SimTKcommon/tests/adhoc/BigMatrixTest.cpp
+++ b/SimTKcommon/tests/adhoc/BigMatrixTest.cpp
@@ -684,7 +684,7 @@ int main()
     Matrix_<P> big(N,N);
     for (int j=0; j<N; ++j)
         for (int i=0; i<N; ++i)
-            big(i,j) = 1+(float)std::rand()/RAND_MAX;
+            big(i,j) = 1+(double)std::rand()/RAND_MAX;
     cout << "big.norm()=" << big.norm() << endl;
 
 


### PR DESCRIPTION
Fixes one more enum/double deprecated operation and an int->float warning in a test case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/750)
<!-- Reviewable:end -->
