### PR TITLE
Make compile definition for static targets transitive

### DIFF
--- a/SimTKcommon/staticTarget/CMakeLists.txt
+++ b/SimTKcommon/staticTarget/CMakeLists.txt
@@ -1,8 +1,7 @@
 ## This whole directory exists just so I could define this extra 
 ## preprocessor values.
 
-add_definitions(-DSimTK_SimTKCOMMON_BUILDING_STATIC_LIBRARY 
-                -DSimTK_USE_STATIC_LIBRARIES)
+add_definitions(-DSimTK_SimTKCOMMON_BUILDING_STATIC_LIBRARY)
 
 if(BUILD_UNVERSIONED_LIBRARIES)
     add_library(${STATIC_TARGET} STATIC 
@@ -15,6 +14,8 @@ if(BUILD_UNVERSIONED_LIBRARIES)
 
     set_target_properties(${STATIC_TARGET} PROPERTIES
         PROJECT_LABEL "Code - ${STATIC_TARGET}")
+
+    target_compile_definitions(${STATIC_TARGET} PUBLIC SimTK_USE_STATIC_LIBRARIES)
         
     # Warning 4996 is not propagated to downstream targets
     if(WIN32 AND NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2) 
@@ -50,6 +51,8 @@ if(BUILD_VERSIONED_LIBRARIES)
     set_target_properties(${STATIC_TARGET_VN} PROPERTIES
         PROJECT_LABEL "Code - ${STATIC_TARGET_VN}")
     
+    target_compile_definitions(${STATIC_TARGET_VN} PUBLIC SimTK_USE_STATIC_LIBRARIES)
+
     # Warning 4996 is not propagated to downstream targets  
     if(WIN32 AND NOT ${CMAKE_VERSION} VERSION_LESS 3.0.2) 
         target_compile_options(${STATIC_TARGET_VN} INTERFACE 

--- a/SimTKmath/staticTarget/CMakeLists.txt
+++ b/SimTKmath/staticTarget/CMakeLists.txt
@@ -1,8 +1,7 @@
 ## This whole directory exists just so I could define these extra 
 ## preprocessor values.
 
-add_definitions(-DSimTK_SIMMATH_BUILDING_STATIC_LIBRARY 
-                -DSimTK_USE_STATIC_LIBRARIES)
+add_definitions(-DSimTK_SIMMATH_BUILDING_STATIC_LIBRARY)
 
 #
 # Set up file groups for better browsing in Visual Studio.
@@ -39,6 +38,8 @@ if(BUILD_UNVERSIONED_LIBRARIES)
     set_target_properties(${STATIC_TARGET} PROPERTIES
         PROJECT_LABEL "Code - ${STATIC_TARGET}")
     
+    target_compile_definitions(${STATIC_TARGET} PUBLIC SimTK_USE_STATIC_LIBRARIES)
+
     # install library; on Windows both .lib and .dll go in the lib directory.
     install(TARGETS ${STATIC_TARGET} EXPORT SimbodyTargets
                      PERMISSIONS OWNER_READ OWNER_WRITE 
@@ -72,7 +73,9 @@ if(BUILD_VERSIONED_LIBRARIES)
     
     set_target_properties(${STATIC_TARGET_VN} PROPERTIES
         PROJECT_LABEL "Code - ${STATIC_TARGET_VN}")
-    
+
+    target_compile_definitions(${STATIC_TARGET_VN} PUBLIC SimTK_USE_STATIC_LIBRARIES)
+
     # install library; on Windows both .lib and .dll go in the lib directory.
     install(TARGETS ${STATIC_TARGET_VN} EXPORT SimbodyTargets
                      PERMISSIONS OWNER_READ OWNER_WRITE 

--- a/Simbody/staticTarget/CMakeLists.txt
+++ b/Simbody/staticTarget/CMakeLists.txt
@@ -1,8 +1,7 @@
 ## This whole directory exists just so I could define these extra 
 ## preprocessor values.
 
-add_definitions(-DSimTK_SIMBODY_BUILDING_STATIC_LIBRARY 
-                -DSimTK_USE_STATIC_LIBRARIES)
+add_definitions(-DSimTK_SIMBODY_BUILDING_STATIC_LIBRARY)
 
 if(BUILD_UNVERSIONED_LIBRARIES)
 
@@ -17,6 +16,8 @@ if(BUILD_UNVERSIONED_LIBRARIES)
     
     set_target_properties(${STATIC_TARGET} PROPERTIES
         PROJECT_LABEL "Code - ${STATIC_TARGET}")
+
+    target_compile_definitions(${STATIC_TARGET} PUBLIC SimTK_USE_STATIC_LIBRARIES)
     
     # install library
     
@@ -54,6 +55,8 @@ if(BUILD_VERSIONED_LIBRARIES)
     
     set_target_properties(${STATIC_TARGET_VN} PROPERTIES
         PROJECT_LABEL "Code - ${STATIC_TARGET_VN}")
+
+    target_compile_definitions(${STATIC_TARGET_VN} PUBLIC SimTK_USE_STATIC_LIBRARIES)
     
     # install library
     


### PR DESCRIPTION
This change removes the need for the user to know about that compile definition, which was required to avoid link errors on Windows with static libraries. This problem occurred in my case using vcpkg with `x64-windows-static` triplet

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/752)
<!-- Reviewable:end -->
