### PR TITLE
Fix PlatformFiles_subdir creating a dependency on a not-copied lib file

### DIFF
--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -118,14 +118,19 @@ endif()
 # message(STATUS "List of dependencies : ${LIB_FILES}" )
 
 # This is where we're going to put these binaries.
-set(COPIED_LIB_FILES)
+set(PLATFORM_LIB_FILES)
 foreach(LIBF ${LIB_FILES})
     get_filename_component(LIBF_ROOT ${LIBF} NAME)
-    set(COPIED_LIB_FILES ${COPIED_LIB_FILES}
-    "${BUILD_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${LIBF_ROOT}")
+
+    string(REGEX MATCH "[.][dD][lL][lL]$" isFileADll ${LIBF})
+    if(isFileADll)
+        set(PLATFORM_LIB_FILES ${PLATFORM_LIB_FILES} "${BUILD_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${LIBF_ROOT}")
+    else()
+        set(PLATFORM_LIB_FILES ${PLATFORM_LIB_FILES} "${LIBF}")
+    endif()
 endforeach()
 
-add_custom_target(PlatformFiles_subdir DEPENDS ${COPIED_LIB_FILES})
+add_custom_target(PlatformFiles_subdir DEPENDS ${PLATFORM_LIB_FILES})
 add_dependencies(PlatformFiles PlatformFiles_subdir)
 set_target_properties(PlatformFiles
     PROPERTIES PROJECT_LABEL "Code - Platform Files")

--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -124,9 +124,14 @@ foreach(LIBF ${LIB_FILES})
 
     string(REGEX MATCH "[.][dD][lL][lL]$" isFileADll ${LIBF})
     if(isFileADll)
-        set(PLATFORM_LIB_FILES ${PLATFORM_LIB_FILES} "${BUILD_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${LIBF_ROOT}")
+        set(
+            PLATFORM_LIB_FILES
+            ${PLATFORM_LIB_FILES}
+            "${BUILD_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${LIBF_ROOT}")
     else()
-        set(PLATFORM_LIB_FILES ${PLATFORM_LIB_FILES} "${LIBF}")
+        set(PLATFORM_LIB_FILES
+            ${PLATFORM_LIB_FILES}
+            "${LIBF}")
     endif()
 endforeach()
 


### PR DESCRIPTION
This PR fixes a build bug that surfaces when trying to build simbody using Visual Studio's integrated CMake support.

The bug is that:

- Newer versions of Visual Studio come with in-built support for CMake. In principle, this means that simbody can be built by just opening the directory in VS
- But, by default, VS will use `ninja` as the build system for CMake projects (previously: it would've used `.vxproj` with MSVC)
- `ninja` has much stricter dependency rules than the previous build system. All dependencies' links must be listed correctly or `ninja` is likely to complain (`vxproj` tends to be more permissive and might build things in a different order or ignore things)
- `simbody`'s `Platform/` directory lists all lib dependencies--including `.dll`s and `.lib`s--as `"${BUILD_BINARY_DIR}/${CMAKE_CFG_INTDIR}/${LIBF_ROOT}"`
- However, that path only applies to the `.dll` files, which are copied to that location - the `.lib` files remain in their original location and are only ever either statically linked (i.e. adsorbed into the binary, so we don't care about runtime location) or installed (not applicable when debugging)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/757)
<!-- Reviewable:end -->
