### PR TITLE
Removed trailing whitespace in String.h and Xml.h. Changed sprintf() to snprintf().

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -118,22 +118,22 @@ Inf, -Inf). **/
 /*@{*/
 /** Format an int as a printable %String. **/
 explicit String(int i, const char* fmt="%d")
-{   const int n=32; char buf[n]; snprintf(buf, n, fmt,i); (*this)=buf; }
+{   const int n=32; char buf[n]; snprintf(buf,n,fmt,i); (*this)=buf; }
 /** Format a long as a printable %String. **/
 explicit String(long i, const char* fmt="%ld")
-{   const int n=64; char buf[n]; snprintf(buf, n, fmt,i); (*this)=buf; }
+{   const int n=64; char buf[n]; snprintf(buf,n,fmt,i); (*this)=buf; }
 /** Format a long long as a printable %String. **/
 explicit String(long long i, const char* fmt="%lld")
-{   const int n=64; char buf[n]; snprintf(buf, n, fmt,i); (*this)=buf; }
+{   const int n=64; char buf[n]; snprintf(buf,n,fmt,i); (*this)=buf; }
 /** Format an unsigned int as a printable %String. **/
 explicit String(unsigned int s, const char* fmt="%u")
-{   const int n=32; char buf[n]; snprintf(buf, n, fmt,s); (*this)=buf; }
+{   const int n=32; char buf[n]; snprintf(buf,n,fmt,s); (*this)=buf; }
 /** Format an unsigned long as a printable %String. **/
 explicit String(unsigned long s, const char* fmt="%lu")
-{   const int n=64; char buf[n]; snprintf(buf, n, fmt,s); (*this)=buf; }
+{   const int n=64; char buf[n]; snprintf(buf,n,fmt,s); (*this)=buf; }
 /** Format an unsigned long long as a printable %String. **/
 explicit String(unsigned long long s, const char* fmt="%llu")
-{   const int n=64; char buf[n]; snprintf(buf, n, fmt,s); (*this)=buf; }
+{   const int n=64; char buf[n]; snprintf(buf,n,fmt,s); (*this)=buf; }
 
 /** Format a float as a printable %String. Nonfinite values are formatted as
 NaN, Inf, or -Inf as appropriate (Matlab compatible). The default format

--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -43,19 +43,19 @@ namespace SimTK {
 
 template <class N> class negator;
 template <class R> class conjugate;
-    
+
 /** SimTK::String is a plug-compatible std::string replacement (plus some
-additional functionality) intended to be suitable for passing through the 
-SimTK API without introducing binary compatibility problems the way 
-std::string does, especially on Windows. You can work in your own code with 
-std::strings which will be quietly converted to and from SimTK::Strings when 
-invoking SimTK API methods. Or, you can use SimTK::Strings and still pass them 
-to standard library or other methods that are expecting std::strings, usually 
+additional functionality) intended to be suitable for passing through the
+SimTK API without introducing binary compatibility problems the way
+std::string does, especially on Windows. You can work in your own code with
+std::strings which will be quietly converted to and from SimTK::Strings when
+invoking SimTK API methods. Or, you can use SimTK::Strings and still pass them
+to standard library or other methods that are expecting std::strings, usually
 transparently. The SimTK::Array_<T> class is used similarly to avoid binary
 compatibility problems that arise with std::vector<T>.
 
 @todo Currently this is just derived from std::string and inherits all the
-binary compatibility issues. Use it now anyway and you'll pick up the 
+binary compatibility issues. Use it now anyway and you'll pick up the
 compatibility benefits later, when we get the time ...
 
 @see SimTK::Array_  **/
@@ -76,11 +76,11 @@ explicit String(char c) {push_back(c);}
 /** This is an implicit conversion from std::string to String **/
 String(const std::string& s) : std::string(s) { }
 
-/** Construct a String as a copy of a substring beginning at position \a start 
+/** Construct a String as a copy of a substring beginning at position \a start
 with length \a len. **/
 String(const String& s, int start, int len) : std::string(s,start,len) { }
 
-/** This is an implicit conversion from String to null-terminated C-style 
+/** This is an implicit conversion from String to null-terminated C-style
 string (array of chars). **/
 operator const char*() const { return c_str(); }
 
@@ -101,38 +101,38 @@ char& operator[](std::string::size_type i) {return std::string::operator[](i);}
 /** Pass through to string::operator[]. **/
 char operator[](std::string::size_type i) const {return std::string::operator[](i);}
 
-/** Override std::string size() method to return an int instead of the 
+/** Override std::string size() method to return an int instead of the
 inconvenient unsigned type size_type. **/
 int size() const {return (int)std::string::size();}
 
-/** Override std::string length() method to return an int instead of the 
+/** Override std::string length() method to return an int instead of the
 inconvenient unsigned type size_type. **/
 int length() const {return (int)std::string::length();}
 
 /** @name             Formatted output constructors
 These constructors format the supplied argument into a human-readable %String,
-using a default or caller-supplied printf-like format. By default, maximum 
-precision is used for floating point values, and user-friendly strings are 
-used for bool (true or false) and non-finite floating point values (NaN, 
+using a default or caller-supplied printf-like format. By default, maximum
+precision is used for floating point values, and user-friendly strings are
+used for bool (true or false) and non-finite floating point values (NaN,
 Inf, -Inf). **/
 /*@{*/
 /** Format an int as a printable %String. **/
-explicit String(int i, const char* fmt="%d") 
+explicit String(int i, const char* fmt="%d")
 {   char buf[32]; sprintf(buf,fmt,i); (*this)=buf; }
 /** Format a long as a printable %String. **/
-explicit String(long i, const char* fmt="%ld") 
+explicit String(long i, const char* fmt="%ld")
 {   char buf[64]; sprintf(buf,fmt,i); (*this)=buf; }
 /** Format a long long as a printable %String. **/
-explicit String(long long i, const char* fmt="%lld") 
+explicit String(long long i, const char* fmt="%lld")
 {   char buf[64]; sprintf(buf,fmt,i); (*this)=buf; }
 /** Format an unsigned int as a printable %String. **/
-explicit String(unsigned int s, const char* fmt="%u")  
+explicit String(unsigned int s, const char* fmt="%u")
 {   char buf[32]; sprintf(buf,fmt,s); (*this)=buf; }
 /** Format an unsigned long as a printable %String. **/
-explicit String(unsigned long s, const char* fmt="%lu") 
+explicit String(unsigned long s, const char* fmt="%lu")
 {   char buf[64]; sprintf(buf,fmt,s); (*this)=buf; }
 /** Format an unsigned long long as a printable %String. **/
-explicit String(unsigned long long s, const char* fmt="%llu") 
+explicit String(unsigned long long s, const char* fmt="%llu")
 {   char buf[64]; sprintf(buf,fmt,s); (*this)=buf; }
 
 /** Format a float as a printable %String. Nonfinite values are formatted as
@@ -148,14 +148,14 @@ recovered if the string is converted back to double. **/
 SimTK_SimTKCOMMON_EXPORT explicit String(double r, const char* fmt="%.17g");
 
 /** Format a complex\<float> as a printable %String (real,imag) with parentheses
-and a comma as shown. The format string should be for a single float and will 
+and a comma as shown. The format string should be for a single float and will
 be used twice; the default format is the same as for float. **/
 explicit String(std::complex<float> r, const char* fmt="%.9g")
 {   (*this)="(" + String(r.real(),fmt) + "," + String(r.imag(),fmt) + ")"; }
-/** Format a complex\<double> as a printable %String (real,imag) with 
-parentheses and a comma as shown. The format string should be for a single 
+/** Format a complex\<double> as a printable %String (real,imag) with
+parentheses and a comma as shown. The format string should be for a single
 double and will be used twice; the default format is the same as for double. **/
-explicit String(std::complex<double> r, const char* fmt="%.17g")    
+explicit String(std::complex<double> r, const char* fmt="%.17g")
 {   (*this)="(" + String(r.real(),fmt) + "," + String(r.imag(),fmt) + ")"; }
 
 /** Format a bool as a printable %String "true" or "false"; if you want "1"
@@ -169,7 +169,7 @@ operator<<() available for type T. **/
 template <class T> inline explicit String(const T& t); // see below
 
 /** Constructing a %String from a negated value converts to the underlying
-native type and then uses one of the native-type constructors. **/ 
+native type and then uses one of the native-type constructors. **/
 template <class T> explicit
 String(const negator<T>& nt) {
     new (this) String(T(nt));
@@ -181,7 +181,7 @@ String(const negator<T>& nt, const char* fmt) {
 }
 
 /** Constructing a %String from a conjugate value converts to the underlying
-complex type and then uses one of the native-type constructors. **/ 
+complex type and then uses one of the native-type constructors. **/
 template <class T> explicit
 String(const conjugate<T>& ct) {
     new (this) String(std::complex<T>(ct));
@@ -197,33 +197,33 @@ String(const conjugate<T>& ct, const char* fmt) {
 
 /** @name             Formatted input from String
 These templatized methods attempt to interpret the entire contents of
-this String as a single object of type T (although T may itself be a 
+this String as a single object of type T (although T may itself be a
 container like an Array or Vector). It is an error if the String has
 the wrong format for an object of this type, or if the entire String is
 not consumed. The acceptable formatting is defined by type T based on what
-it thinks is acceptable stream formatting. Leading and trailing white space 
-are ignored except when type T is itself a String or std::string in which case 
+it thinks is acceptable stream formatting. Leading and trailing white space
+are ignored except when type T is itself a String or std::string in which case
 the white space is included in the result. It is not acceptable for type T
 to be a pointer type. In particular if you want to convert a String to a null-
-terminated C-style char*, use the standard c_str() method rather than any of 
+terminated C-style char*, use the standard c_str() method rather than any of
 these.
 @see Related namespace-level static methods convertStringTo<T>().
 **/
 /*@{*/
 /** Attempt to convert this String to an object of type T, returning a status
-value to indicate success or failure. We require that the whole string is 
-consumed except possibly for some trailing white space. 
-@tparam         T   
-    A non-pointer type that supports extraction operator>>() from an istream. 
-    You will get a compilation failure if you try to use this method for a 
+value to indicate success or failure. We require that the whole string is
+consumed except possibly for some trailing white space.
+@tparam         T
+    A non-pointer type that supports extraction operator>>() from an istream.
+    You will get a compilation failure if you try to use this method for a
     type T for which no extraction operator is available and a runtime error
     if T is a pointer type.
 @param[out]     out
     The converted value if we were able to parse the string successfully
-    (i.e., function return is true), otherwise the output value is 
+    (i.e., function return is true), otherwise the output value is
     undefined.
 @return true if we got what we're looking for, false if anything went
-wrong including failure to consume the entire string. 
+wrong including failure to consume the entire string.
 @see convertTo<T>() **/
 template <class T> inline bool tryConvertTo(T& out) const; // see below
 
@@ -235,13 +235,13 @@ have to throw an error anyway.
 @see tryConvertTo<T>(out), SimTK::convertStringTo<T>() **/
 template <class T> inline void convertTo(T& out) const; // see below
 
-/** A more convenient form of convertTo<T>() that returns the result as its 
+/** A more convenient form of convertTo<T>() that returns the result as its
 function argument, although this may involve an extra copy operation. For very
 large objects you may want to use the other form where the output is written
-to an already-constructed object you provide. 
+to an already-constructed object you provide.
 @return The converted value as an object of type T.
 @see convertTo<T>(out), tryConvertTo<T>(out), SimTK::convertStringTo<T>() **/
-template <class T> T convertTo() const 
+template <class T> T convertTo() const
 {   T temp; convertTo<T>(temp); return temp; }
 
 /** Special-purpose method for interpreting this %String as a bool. Recognizes
@@ -265,20 +265,20 @@ SimTK_SimTKCOMMON_EXPORT bool tryConvertToDouble(double& out) const;
 
 /** @name In-place modifications
 These are member functions which add to the existing std::string functionality.
-These methods return a reference to "this" String, so may be chained like 
-assignment statements. If you would like to use these on an std::string, use 
-the String::updAs() method to recast the std::string to a String. Note that 
-there is also an equivalent set of static methods which return a new String 
+These methods return a reference to "this" String, so may be chained like
+assignment statements. If you would like to use these on an std::string, use
+the String::updAs() method to recast the std::string to a String. Note that
+there is also an equivalent set of static methods which return a new String
 rather than changing the original. **/
 /*@{*/
-/** Upshift the given String in place, so that lowercase letters are replaced 
+/** Upshift the given String in place, so that lowercase letters are replaced
 with their uppercase equivalents as defined by std::toupper(). **/
 SimTK_SimTKCOMMON_EXPORT String& toUpper();
 /** Downshift the given String in place, so that uppercase letters are replaced
 with their lowercase equivalents as defined by std::tolower(). **/
 SimTK_SimTKCOMMON_EXPORT String& toLower();
-/** Trim this String in place, removing all the initial leading and trailing 
-white space, as defined by std::isspace() which typically includes space, 
+/** Trim this String in place, removing all the initial leading and trailing
+white space, as defined by std::isspace() which typically includes space,
 tab (\\t), newline (\\n), return (\\r),  and form feed (\\f). **/
 SimTK_SimTKCOMMON_EXPORT String& trimWhiteSpace();
 /** Substitute in place \a newChar for \a oldChar wherever \a oldChar appears
@@ -301,7 +301,7 @@ static String toLower(const std::string& in)
 {   return String(in).toLower(); }
 /** Copy the input std::string to a new SimTK::String leaving off all the
 initial leading and trailing white space, as defined by isspace() which
-typically includes space, tab (\\t), newline (\\n), return (\\r), 
+typically includes space, tab (\\t), newline (\\n), return (\\r),
 and form feed (\\f). **/
 static SimTK_SimTKCOMMON_EXPORT String trimWhiteSpace(const std::string& in);
 /** Copy the input std::string to a new SimTK::String while substituting
@@ -310,10 +310,10 @@ String& replaceAllChar(const std::string& in, char oldChar, char newChar)
 {   return String(in).replaceAllChar(oldChar, newChar); }
 /*@}*/
 
-};    
+};
 
 // All std::stream activity should be dealt with inline so that we don't have
-// to worry about binary compatibility issues that can arise when passing 
+// to worry about binary compatibility issues that can arise when passing
 // streams through the API.
 
 /** @cond **/ // Hide from Doxygen
@@ -328,9 +328,9 @@ auto stringStreamInsertHelper(std::ostringstream& os, const T& t, bool)
 template <class T> inline
 auto stringStreamInsertHelper(std::ostringstream& os, const T& t, int)
                                                     -> std::ostringstream& {
-    SimTK_ERRCHK1_ALWAYS(!"no stream insertion operator", "String::String(T)", 
+    SimTK_ERRCHK1_ALWAYS(!"no stream insertion operator", "String::String(T)",
         "Type T=%s has no stream insertion operator<<(T) and there "
-        "is no specialized String(T) constructor.", 
+        "is no specialized String(T) constructor.",
         NiceTypeName<T>::namestr().c_str());
     return os;
 }
@@ -345,21 +345,21 @@ auto stringStreamExtractHelper(std::istringstream& is, T& t, bool)
 template <class T> inline
 auto stringStreamExtractHelper(std::istringstream& is, T& t, int)
                                                     -> std::istringstream& {
-    SimTK_ERRCHK1_ALWAYS(!"no stream extraction operator", 
-        "String::tryConvertTo<T>()", 
+    SimTK_ERRCHK1_ALWAYS(!"no stream extraction operator",
+        "String::tryConvertTo<T>()",
         "Type T=%s has no stream extraction operator>>(T) and there "
-        "is no specialized tryConvertTo<T>() constructor.", 
+        "is no specialized tryConvertTo<T>() constructor.",
         NiceTypeName<T>::namestr().c_str());
     return is;
 }
 
 /** @endcond **/
 
-/** Generic templatized %String constructor uses stream insertion 
+/** Generic templatized %String constructor uses stream insertion
 `operator<<(T)` to generate the %String when no specialization of this
 constructor is available. A *runtime* error is thrown if this method is
-invoked and neither a specialization nor stream insertion operator is 
-available. **/ 
+invoked and neither a specialization nor stream insertion operator is
+available. **/
 template <class T> inline
 String::String(const T& t) {
     std::ostringstream os;
@@ -369,7 +369,7 @@ String::String(const T& t) {
 
 // This namespace-level static method should not be necessary but gcc 4.1
 // still has trouble with template specialization for template member
-// functions. So rather than specializing the tryConvertTo() member, I'm 
+// functions. So rather than specializing the tryConvertTo() member, I'm
 // specializing this helper function instead.
 template <class T> inline static
 bool tryConvertStringTo(const String& value, T& out) {
@@ -383,25 +383,25 @@ bool tryConvertStringTo(const String& value, T& out) {
     return sstream.eof();   // We must have used up the whole string now.
 }
 
-// This specialization ensures that "true" and "false" are recognized as 
+// This specialization ensures that "true" and "false" are recognized as
 // values for bools (with any case).
-template <> inline 
+template <> inline
 bool tryConvertStringTo(const String& value, bool& out)
 {   return value.tryConvertToBool(out); }
 
 // Specialization to ensure recognition of non-finite values NaN, Inf, etc.
-template <> inline 
+template <> inline
 bool tryConvertStringTo(const String& value, float& out)
 {   return value.tryConvertToFloat(out); }
 
 // Specialization to ensure recognition of non-finite values NaN, Inf, etc.
-template <> inline 
+template <> inline
 bool tryConvertStringTo(const String& value, double& out)
 {   return value.tryConvertToDouble(out); }
 
 // This specialization ensures that we get the whole String including
-// leading and trailing white space. Of course this is not useful for 
-// anything but may occur as a result of some higher-level templatized 
+// leading and trailing white space. Of course this is not useful for
+// anything but may occur as a result of some higher-level templatized
 // method that doesn't know what type it is converting here.
 template<> inline
 bool tryConvertStringTo(const String& value, String& out)
@@ -415,7 +415,7 @@ bool tryConvertStringTo(const String& value, std::string& out)
 /** Partial specialization to read negator<T> as a T. **/
 template <class T> inline
 bool tryConvertStringTo(const String& value, negator<T>& out) {
-    T nonnegated; 
+    T nonnegated;
     if (!tryConvertStringTo(value, nonnegated)) return false;
     out = nonnegated;
     return true;
@@ -424,7 +424,7 @@ bool tryConvertStringTo(const String& value, negator<T>& out) {
 /** Partial specialization to read conjugate<T> as a std::complex<T>. **/
 template <class T> inline
 bool tryConvertStringTo(const String& value, conjugate<T>& out) {
-    std::complex<T> cmplx; 
+    std::complex<T> cmplx;
     if (!tryConvertStringTo(value, cmplx)) return false;
     out = cmplx;
     return true;
@@ -438,14 +438,14 @@ bool tryConvertStringTo(const String& value, T*& out) {
     SimTK_ERRCHK1_ALWAYS(false, "SimTK::convertStringTo(value,T*)",
         "Can't interpret a string as a pointer (%s*).",
         NiceTypeName<T>::namestr().c_str());
-    return false; 
+    return false;
 }
 
-template <class T> inline bool 
-String::tryConvertTo(T& out) const 
+template <class T> inline bool
+String::tryConvertTo(T& out) const
 {   return tryConvertStringTo(*this, out); }
 
-template <class T> inline void 
+template <class T> inline void
 String::convertTo(T& out) const {
     const int MaxStr = 50;
     const bool convertOK = tryConvertTo<T>(out);
@@ -462,7 +462,7 @@ String::convertTo(T& out) const {
 
 /** This method converts its String argument to type T and returns it into
 the variable supplied as its second argument; this is particularly convenient
-when you have a string literal or std::string since the conversion to String 
+when you have a string literal or std::string since the conversion to String
 happens automatically. For example the two lines shown are equivalent:
 @code
     Array_<float> array;

--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -118,22 +118,22 @@ Inf, -Inf). **/
 /*@{*/
 /** Format an int as a printable %String. **/
 explicit String(int i, const char* fmt="%d")
-{   char buf[32]; sprintf(buf,fmt,i); (*this)=buf; }
+{   const int n=32; char buf[n]; snprintf(buf, n, fmt,i); (*this)=buf; }
 /** Format a long as a printable %String. **/
 explicit String(long i, const char* fmt="%ld")
-{   char buf[64]; sprintf(buf,fmt,i); (*this)=buf; }
+{   const int n=64; char buf[n]; snprintf(buf, n, fmt,i); (*this)=buf; }
 /** Format a long long as a printable %String. **/
 explicit String(long long i, const char* fmt="%lld")
-{   char buf[64]; sprintf(buf,fmt,i); (*this)=buf; }
+{   const int n=64; char buf[n]; snprintf(buf, n, fmt,i); (*this)=buf; }
 /** Format an unsigned int as a printable %String. **/
 explicit String(unsigned int s, const char* fmt="%u")
-{   char buf[32]; sprintf(buf,fmt,s); (*this)=buf; }
+{   const int n=32; char buf[n]; snprintf(buf, n, fmt,s); (*this)=buf; }
 /** Format an unsigned long as a printable %String. **/
 explicit String(unsigned long s, const char* fmt="%lu")
-{   char buf[64]; sprintf(buf,fmt,s); (*this)=buf; }
+{   const int n=64; char buf[n]; snprintf(buf, n, fmt,s); (*this)=buf; }
 /** Format an unsigned long long as a printable %String. **/
 explicit String(unsigned long long s, const char* fmt="%llu")
-{   char buf[64]; sprintf(buf,fmt,s); (*this)=buf; }
+{   const int n=64; char buf[n]; snprintf(buf, n, fmt,s); (*this)=buf; }
 
 /** Format a float as a printable %String. Nonfinite values are formatted as
 NaN, Inf, or -Inf as appropriate (Matlab compatible). The default format

--- a/SimTKcommon/include/SimTKcommon/internal/Xml.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Xml.h
@@ -34,8 +34,8 @@
 namespace SimTK {
 
 // These are declared but never defined; all TinyXML code is hidden.
-class TiXmlNode; 
-class TiXmlElement; 
+class TiXmlNode;
+class TiXmlElement;
 class TiXmlAttribute;
 class TiXmlText;
 class TiXmlComment;
@@ -66,7 +66,7 @@ class element_iterator;
 
 /** The Xml::NodeType enum serves as the actual type of a node and as a filter
 for allowable node types during an iteration over nodes. We consider
-Element and Text nodes to be meaningful, while Comment and Unknown 
+Element and Text nodes to be meaningful, while Comment and Unknown
 nodes are meaningless junk. However, you are free to extract some meaning
 from them if you know how. In particular, DTD nodes end up as Unknown. **/
 enum NodeType {
@@ -83,20 +83,20 @@ enum NodeType {
 
 /** Translate a NodeType to a human-readable string. **/
 String getNodeTypeAsString(NodeType type);
-    
-/** This class provides a minimalist capability for reading and writing XML 
-documents, as files or strings. This is based with gratitude on the excellent 
-open source XML parser TinyXML (http://www.grinninglizard.com/tinyxml/). Note 
-that this is a <em>non-validating</em> parser, meaning it deals only with the 
-XML file itself and not with a Document Type Definition (DTD), XML Schema, or 
-any other description of the XML file's expected contents. Instead, the 
-structure of your code that uses this class encodes the expected structure 
+
+/** This class provides a minimalist capability for reading and writing XML
+documents, as files or strings. This is based with gratitude on the excellent
+open source XML parser TinyXML (http://www.grinninglizard.com/tinyxml/). Note
+that this is a <em>non-validating</em> parser, meaning it deals only with the
+XML file itself and not with a Document Type Definition (DTD), XML Schema, or
+any other description of the XML file's expected contents. Instead, the
+structure of your code that uses this class encodes the expected structure
 and contents of the XML document.
 
-Our in-memory model of an XML document is simplified even further than 
-TinyXML's. There a lot to know about XML; you could start here: 
+Our in-memory model of an XML document is simplified even further than
+TinyXML's. There a lot to know about XML; you could start here:
 http://en.wikipedia.org/wiki/XML. However, everything you need to know in
-order to read and write XML documents with the SimTK::Xml::Document class is 
+order to read and write XML documents with the SimTK::Xml::Document class is
 described below.
 
 Much of the detailed documentation is in the class Xml::Element; be sure to look
@@ -105,20 +105,20 @@ there as well as at this overview.
 <h2>Our in-memory model of an XML document</h2>
 
 We consider an XML document to be a tree of "Nodes". There are only four
-types of nodes: Comments, Unknowns, %Text, and Elements. Only Elements can 
-contain Text and other nodes, including recursively child Element nodes. 
+types of nodes: Comments, Unknowns, %Text, and Elements. Only Elements can
+contain Text and other nodes, including recursively child Element nodes.
 Elements can also have "Attributes" which are name:value pairs (not nodes).
 
 The XML document as a whole is represented by an object of class Xml::Document.
-The Xml::Document object directly contains a short list of nodes, consisting 
+The Xml::Document object directly contains a short list of nodes, consisting
 only of Comments, Unknowns, and a single %Element called the "root element". The
-tag word associated with the root element is called the "root tag" and 
+tag word associated with the root element is called the "root tag" and
 conventionally identifies the kind of document this is. For example, XML files
 produced by VTK begin with a root tag "<VTKFile>".
 
-We go to some pain to make sure every Xml::Document fits the above model so 
-that you don't have to think about anything else. For example, if the file as 
-read in has multiple root-level elements, or has document-level text, we will 
+We go to some pain to make sure every Xml::Document fits the above model so
+that you don't have to think about anything else. For example, if the file as
+read in has multiple root-level elements, or has document-level text, we will
 enclose all the element and text nodes within document start tag "<_Root>"
 and end tag "</_Root>" thus making it fit the description above. We call
 this "canonicalizing" the document.
@@ -126,7 +126,7 @@ this "canonicalizing" the document.
 <h3>%Value Elements</h3>
 
 Element nodes can be classified into "value elements" and "compound
-elements". A value element is a "leaf" element (no child elements) that 
+elements". A value element is a "leaf" element (no child elements) that
 contains at most one Text node. For example, a document might contain value
 elements like these:
 @code
@@ -137,29 +137,29 @@ elements like these:
     <vector>1.2 -4 2e-3</vector>
 @endcode
 All of these have a unique value so it makes sense to talk about "the" value
-of these elements (the empty "preferences" element has a null value). These 
-are very common in XML documents, and the Xml::Element class makes them very 
+of these elements (the empty "preferences" element has a null value). These
+are very common in XML documents, and the Xml::Element class makes them very
 easy to work with. For example, if Element elt is the "<vector>" element
 from the example, you could retrieve its value as a Vec3 like this:
 @code
-    Vec3 v = elt.getValueAs<Vec3>(); 
+    Vec3 v = elt.getValueAs<Vec3>();
 @endcode
-This would automatically throw an error if the element wasn't a value element 
+This would automatically throw an error if the element wasn't a value element
 or if its value didn't have the right format to convert to a Vec3.
 
 Note that it is okay for a value element to have attributes; those are ignored
-in determining the element's value. Any element that is not a value element is 
-a "compound element", meaning it has either child elements and/or more than 
+in determining the element's value. Any element that is not a value element is
+a "compound element", meaning it has either child elements and/or more than
 one %Text node.
 
 <h2>Reading an XML document</h2>
 
-To read an XML document, you create an Xml::Document object and tell it to 
+To read an XML document, you create an Xml::Document object and tell it to
 read in the document from a file or from a string. The document will be parsed
-and canonicalized into the in-memory model described above. Then to rummage 
+and canonicalized into the in-memory model described above. Then to rummage
 around in the document, you ask the Xml::Document object for its root element,
-and check the root tag to see that it is the type of document you are 
-expecting. You can check the root element's attributes, and then process its 
+and check the root tag to see that it is the type of document you are
+expecting. You can check the root element's attributes, and then process its
 contents (child nodes). Iterators are provided for running through all the
 attributes, all the child nodes contained in the element, or all the child
 nodes of a particular type. For a child node that is an element,
@@ -186,11 +186,11 @@ you could write:
 
 <h2>Writing an XML document</h2>
 
-You can insert, remove, and modify nodes and attributes in a document, or 
-create a document from scratch. Then you can write the results in a 
+You can insert, remove, and modify nodes and attributes in a document, or
+create a document from scratch. Then you can write the results in a
 "pretty-printed" or compact format to a file or a string; for pretty-printing
-you can override the default indentation string (four spaces). Whenever we 
-write an XML document, we write it in canoncial format, regardless of how it 
+you can override the default indentation string (four spaces). Whenever we
+write an XML document, we write it in canoncial format, regardless of how it
 looked when we found it.
 
 At the document level, you can only insert Comment and Unknown nodes. Text and
@@ -200,7 +200,7 @@ Element nodes can be inserted only at the root element level and below.
 
 This section provides detailed information about the syntax of XML files as
 we accept and produce them. You won't have to know these details to read and
-write XML files using the SimTK::Xml::Document class, but you may find this 
+write XML files using the SimTK::Xml::Document class, but you may find this
 helpful for when you have to look at an XML file in a text editor.
 
 <h3>Lexical elements</h3>
@@ -217,14 +217,14 @@ through Doxygen.)
     by \e name="value", and character escapes delimited by "&" and ";".
   - Tags come in three flavors: \e start tags like "<word>", \e end tags like
     "</word>" and <em>empty element</em> tags like "<word/>". Tag words must
-    begin with a letter or an underscore and are case sensitive; "xml" is 
+    begin with a letter or an underscore and are case sensitive; "xml" is
     reserved; don't use it.
   - Attributes are recognized only in start tags, empty element tags, and
-    declaration tags. In standard XML the value must be quoted with single or 
+    declaration tags. In standard XML the value must be quoted with single or
     double quotes, but we'll supply missing quotes if there are none.
     Attribute names are case sensitive and must be unique within a tag; but if
     we see duplicates we'll just ignore all but the last.
-  - There are five pre-defined escapes: "&lt;" and "&gt;" representing "<" 
+  - There are five pre-defined escapes: "&lt;" and "&gt;" representing "<"
     and ">", "&amp;" for ampersand, "&apos;" for apostrophe (single quote)
     and "&quot;" for double quote.
   - There are also "numeric character reference" escapes of the form "&#nnnnn;"
@@ -232,11 +232,11 @@ through Doxygen.)
   - %Text set off by "<![CDATA[" and "]]>" is interpreted as a raw byte stream.
   - Tags that begin "<x" where x is not a letter or underscore and isn't one
     of the above recognized patterns will be passed through uninterpreted.
-  - Anything else is Unicode text. 
+  - Anything else is Unicode text.
 
 <h3>File structure</h3>
 
-An XML file contains a single \e document which consists at the top level of 
+An XML file contains a single \e document which consists at the top level of
   - a declaration
   - comments and unknowns
   - a root element
@@ -250,13 +250,13 @@ structure of XML files. Elements can contain:
   - child elements, recursively
   - attributes
 
-A declaration (see below) also has attributes, but there are only three: 
-version, encoding, and standalone ('yes' or 'no'). Unknowns are constructs 
-found in the file that are not recognized; they might be errors but they are 
-likely to be more sophisticated uses of XML that our feeble parser doesn't 
+A declaration (see below) also has attributes, but there are only three:
+version, encoding, and standalone ('yes' or 'no'). Unknowns are constructs
+found in the file that are not recognized; they might be errors but they are
+likely to be more sophisticated uses of XML that our feeble parser doesn't
 understand. Unknowns are tags where the tag word doesn't begin with a letter or
 underscore and isn't one of the very few other tags we recognize, like
-comments. As an example, a DTD tag like this would come through as an Unknown 
+comments. As an example, a DTD tag like this would come through as an Unknown
 node here:
 @code
     <!DOCTYPE note SYSTEM "Note.dtd">
@@ -274,19 +274,19 @@ us to simplify the in-memory model as discussed above.
     <!-- maybe comments and unknowns -->
 @endcode
 That is, the first line should be a declaration, most commonly exactly the
-characters shown above, without the "standalone" attribute which will 
+characters shown above, without the "standalone" attribute which will
 default to "yes". If we don't see a declaration when reading an XML
-document, we'll assume we read the one above. Then the document should contain 
-exactly one root element representing the type of document and 
-document-level attributes. The tag for the root element is not literally 
-"roottag" but some name that makes sense for the given document. Note that the 
-root element is an ordinary element so "contents" can contain text and child 
+document, we'll assume we read the one above. Then the document should contain
+exactly one root element representing the type of document and
+document-level attributes. The tag for the root element is not literally
+"roottag" but some name that makes sense for the given document. Note that the
+root element is an ordinary element so "contents" can contain text and child
 elements (as well as comments and unknowns).
 
-When reading an XML document, if it has exactly one document-level element and 
-no document-level text, we'll take the document as-is. If there is 
-more than one document-level element, or we find some document-level text, 
-we'll assume that the root element is missing and act as though we had seen a 
+When reading an XML document, if it has exactly one document-level element and
+no document-level text, we'll take the document as-is. If there is
+more than one document-level element, or we find some document-level text,
+we'll assume that the root element is missing and act as though we had seen a
 root element "<_Root>" at the beginning and "</_Root>" at the end so
 the root tag will be "_Root". Note that this means that we will
 interpret even a plain text file as a well-formed XML document:
@@ -297,7 +297,7 @@ interpret even a plain text file as a well-formed XML document:
                                  </_Root>
 @endcode
 The above XML document has a single document-level element and that element
-contains one Text node whose value is the original text. 
+contains one Text node whose value is the original text.
 
 @see Xml::Element, Xml::Node **/
 
@@ -313,17 +313,17 @@ You can start with an empty Xml::Document or initialize it from a file. **/
 /** Create an empty XML Document with default declaration and default root
 element with tag "_Root".
 
-If you were to print out this document now you would see:                                          
+If you were to print out this document now you would see:
 @code
     <?xml version="1.0" encoding="UTF-8"?>
-    <_Root />                                      
+    <_Root />
 @endcode **/
 Document();
 
 /** Create a new XML document and initialize it from the contents of the given
-file name.  
+file name.
 
-An exception will be thrown if the file doesn't exist or can't be 
+An exception will be thrown if the file doesn't exist or can't be
 parsed. @see readFromFile(), readFromString() **/
 explicit Document(const String& pathname);
 
@@ -348,20 +348,20 @@ These methods deal with conversion to and from the in-memory representation
 of the XML document from and to files and strings. **/
 /*@{*/
 /** Read the contents of this Xml::Document from the file whose pathname
-is supplied. This first clears the current document so the new one 
+is supplied. This first clears the current document so the new one
 completely replaces the old one. @see readFromString() **/
 void readFromFile(const String& pathname);
 /** Write the contents of this in-memory Xml::Document to the file whose
-pathname is supplied. The file will be created if it doesn't exist, 
+pathname is supplied. The file will be created if it doesn't exist,
 overwritten if it does exist. The file will be "pretty-printed" using the
 current indent string. @see setIndentString(), writeToString() **/
 void writeToFile(const String& pathname) const;
 /** Read the contents of this Xml::Document from the supplied string. This
-first clears the current document so the new one completely replaces the 
+first clears the current document so the new one completely replaces the
 old one. @see readFromFile() **/
 void readFromString(const String& xmlDocument);
-/** Alternate form that reads from a null-terminated C string (char*) 
-rather than a C++ string object. This would otherwise be implicitly 
+/** Alternate form that reads from a null-terminated C string (char*)
+rather than a C++ string object. This would otherwise be implicitly
 converted to string first which would require copying. **/
 void readFromString(const char* xmlDocument);
 /** Write the contents of this in-memory Xml::Document to the supplied
@@ -372,18 +372,18 @@ a more compact representation. @see setIndentString(), writeToFile() **/
 void writeToString(String& xmlDocument, bool compact = false) const;
 /** Set the string to be used for indentation when we produce a
 "pretty-printed" serialized form of this document.\ The default is
-to use four spaces for each level of indentation. 
+to use four spaces for each level of indentation.
 @see writeToFile(), writeToString(), getIndentString() **/
 void setIndentString(const String& indent);
 /** Return the current value of the indent string.\ The default is
 four spaces. @see setIndentString() **/
 const String& getIndentString() const;
 
-/** Set global mode to control whether white space is preserved or condensed 
+/** Set global mode to control whether white space is preserved or condensed
 down to a single space (affects all subsequent document reads; not document
 specific). The default is to condense. **/
 static void setXmlCondenseWhiteSpace(bool shouldCondense);
-/** Return the current setting of the global "condense white space" option. 
+/** Return the current setting of the global "condense white space" option.
 Note that this option affects all Xml reads; it is not document specific. **/
 static bool isXmlWhiteSpaceCondensed();
 /*@}*/
@@ -391,18 +391,18 @@ static bool isXmlWhiteSpaceCondensed();
 
 /**@name                Top-level node manipulation
 These methods provide access to the top-level nodes, that is, those that are
-directly owned by the Xml::Document. Comment and Unknown nodes are allowed 
+directly owned by the Xml::Document. Comment and Unknown nodes are allowed
 anywhere at the top level, but Text nodes are not allowed and there is just
 one distinguished Element node, the root element. If you want to add Text
 or Element nodes, add them to the root element rather than at the document
 level. **/
 /*@{*/
 
-/** Return an Element handle referencing the top-level element in this 
-Xml::Document, known as the "root element". The tag word of this element is 
+/** Return an Element handle referencing the top-level element in this
+Xml::Document, known as the "root element". The tag word of this element is
 usually the type of document. This is the \e only top-level element; all others
-are its children and descendents. Once you have the root Element handle, you 
-can also use any of the Element methods to manipulate it. If you need a 
+are its children and descendents. Once you have the root Element handle, you
+can also use any of the Element methods to manipulate it. If you need a
 node_iterator that refers to the root element (perhaps to use one of the
 top-level insert methods), use node_begin() with a NodeType filter:
 @code
@@ -418,30 +418,30 @@ const String& getRootTag() const;
 the document type. This is the same as getRootElement().setElementTag(tag). **/
 void setRootTag(const String& tag);
 
-/** Insert a top-level Comment or Unknown node just \e after the location 
-indicated by the node_iterator, or at the end of the list if the iterator is 
-node_end(). The iterator must refer to a top-level node. The Xml::Document 
+/** Insert a top-level Comment or Unknown node just \e after the location
+indicated by the node_iterator, or at the end of the list if the iterator is
+node_end(). The iterator must refer to a top-level node. The Xml::Document
 takes over ownership of the Node which must be a Comment or Unknown node and
-must have been an orphan. The supplied Node handle will retain a reference 
+must have been an orphan. The supplied Node handle will retain a reference
 to the node within the document and can still be used to make changes, but
 will no longer by an orphan. **/
-void insertTopLevelNodeAfter (const node_iterator& afterThis, 
+void insertTopLevelNodeAfter (const node_iterator& afterThis,
                               Node                 insertThis);
-/** Insert a top-level Comment or Unknown node just \e before the location 
+/** Insert a top-level Comment or Unknown node just \e before the location
 indicated by the node_iterator. See insertTopLevelNodeAfter() for details. **/
-void insertTopLevelNodeBefore(const node_iterator& beforeThis, 
+void insertTopLevelNodeBefore(const node_iterator& beforeThis,
                               Node                 insertThis);
 /** Delete the indicated top-level node, which must not be the root element,
 and must not be node_end(). That is, it must be a top-level Comment or
 Unknown node which will be removed from the Xml::Document and deleted. The
-iterator is invalid after this call; be sure not to use it again. Also, there 
+iterator is invalid after this call; be sure not to use it again. Also, there
 must not be any handles referencing the now-deleted node. **/
 void eraseTopLevelNode(const node_iterator& deleteThis);
 /** Remove the indicated top-level node from the document, returning it as an
 orphan rather than erasing it. The node must not be the root element,
 and must not be node_end(). That is, it must be a top-level Comment or
 Unknown node which will be removed from the Xml::Document and returned as
-an orphan Node. The iterator is invalid after this call; be sure not to use it 
+an orphan Node. The iterator is invalid after this call; be sure not to use it
 again. **/
 Node removeTopLevelNode(const node_iterator& removeThis);
 /*@}*/
@@ -449,10 +449,10 @@ Node removeTopLevelNode(const node_iterator& removeThis);
 
 /**@name       Iteration through top-level nodes (rarely used)
 If you want to run through this document's top-level nodes (of which the
-"root element" is one), these methods provide begin and end 
-iterators. By default you'll see all the nodes (types Comment, Unknown, 
-and the lone top-level Element) but you can restrict the node types that 
-you'll see via the NodeType mask. Iteration is rarely used at this top level 
+"root element" is one), these methods provide begin and end
+iterators. By default you'll see all the nodes (types Comment, Unknown,
+and the lone top-level Element) but you can restrict the node types that
+you'll see via the NodeType mask. Iteration is rarely used at this top level
 since you almost never care about about the Comment and Unknown nodes here and
 you can get to the root element directly using getRootElement().
 @see getRootElement() **/
@@ -468,16 +468,16 @@ node_iterator       node_end() const;
 
 /**@name           XML Declaration attributes (rarely used)
 These methods deal with the mysterious XML "declaration" line that comes at the
-beginning of every XML document; that is the line that begins with "<?xml" 
+beginning of every XML document; that is the line that begins with "<?xml"
 and ends with "?>". There are at most three of these attributes and they have
 well-defined names that are always the same (default values shown):
-  - \e version = "1.0": to what version of the XML standard does this document 
+  - \e version = "1.0": to what version of the XML standard does this document
     adhere?
-  - \e encoding = "UTF-8": what Unicode encoding is used to represent the 
-    character in this document? Typically this is UTF-8, an 8-bit encoding in 
-    which the first 128 codes match standard ASCII but where other characters 
+  - \e encoding = "UTF-8": what Unicode encoding is used to represent the
+    character in this document? Typically this is UTF-8, an 8-bit encoding in
+    which the first 128 codes match standard ASCII but where other characters
     are represented in variable-length multibyte sequences.
-  - \e standalone = "yes": can this document be correctly parsed without 
+  - \e standalone = "yes": can this document be correctly parsed without
     consulting other documents?
 
 You can examine and change these attributes with the methods in this section,
@@ -491,21 +491,21 @@ String getXmlVersion() const;
 line at the beginning of the document). **/
 String getXmlEncoding() const;
 /** Returns the Xml "standalone" attribute as a bool (from the declaration
-line at the beginning of the document); default is true ("yes" in a file), 
-meaning that the document can be parsed correctly without any other documents. 
-We won't include "standalone" in the declaration line for any Xml documents 
+line at the beginning of the document); default is true ("yes" in a file),
+meaning that the document can be parsed correctly without any other documents.
+We won't include "standalone" in the declaration line for any Xml documents
 we generate unless the value is false ("no" in a file). **/
 bool getXmlIsStandalone() const;
 
-/** Set the Xml "version" attribute; this will be written to the 
+/** Set the Xml "version" attribute; this will be written to the
 "declaration" line which is first in any Xml document. **/
 void setXmlVersion(const String& version);
 /** Set the Xml "encoding" attribute; this doesn't affect the in-memory
 representation but can affect how the document gets written out. **/
 void setXmlEncoding(const String& encoding);
 /** Set the Xml "standalone" attribute; this is normally true (corresponding
-to standalone="yes") and won't appear in the declaration line in that 
-case when we write it out. If you set this to false then standalone="no" 
+to standalone="yes") and won't appear in the declaration line in that
+case when we write it out. If you set this to false then standalone="no"
 will appear in the declaration line when it is written. **/
 void setXmlIsStandalone(bool isStandalone);
 /*@}*/
@@ -525,7 +525,7 @@ Impl*       impl; // This is the lone data member.
 
 /** Output a "pretty printed" textual representation of the given Xml::Document
 to an std::ostream, using the document's current indent string for
-formatting. @see Xml::Document::setIndentString() 
+formatting. @see Xml::Document::setIndentString()
 @relates Xml::Document **/
 // Do this inline so we don't have to pass the ostream through the API.
 inline std::ostream& operator<<(std::ostream& o, const Document& doc) {
@@ -548,27 +548,27 @@ class SimTK_SimTKCOMMON_EXPORT Attribute {
 public:
 /** Default constructor creates a null Attribute handle. **/
 Attribute() : tiAttr(0) {}
-/** Create a new orphan Attribute, that is, an Attribute that is not 
+/** Create a new orphan Attribute, that is, an Attribute that is not
 owned by any Xml Element. **/
 Attribute(const String& name, const String& value);
 /** Copy constructor is shallow; that is, this handle will refer to the
 same attribute as the source. Note that this handle will provide write
 access to the underlying attribute, even if the source was const. **/
-Attribute(const Attribute& src) : tiAttr(src.tiAttr) {} 
-/** Copy assignment is shallow; the handle is first cleared and then will 
-refer to the same attribute as the source. Note that this handle will 
+Attribute(const Attribute& src) : tiAttr(src.tiAttr) {}
+/** Copy assignment is shallow; the handle is first cleared and then will
+refer to the same attribute as the source. Note that this handle will
 provide write access to the underlying attribute even if the source handle
 was const. @see clear() **/
-Attribute& operator=(const Attribute& src) 
+Attribute& operator=(const Attribute& src)
 {   if (&src!=this) {clear(); tiAttr=src.tiAttr;} return *this; }
 /** The Attribute handle destructor does not recover heap space so if you create
-orphan attributes and then don't put them in a document there will be a memory 
+orphan attributes and then don't put them in a document there will be a memory
 leak unless you explicitly destruct them first with clearOrphan(). **/
 ~Attribute() {clear();}
 /** Is this handle currently holding an attribute? **/
 bool isValid() const {return tiAttr!=0;}
-/** Return true if this Attribute is an orphan, meaning that it is not 
-empty, but is not owned by any element or top-level document. This is 
+/** Return true if this Attribute is an orphan, meaning that it is not
+empty, but is not owned by any element or top-level document. This is
 typically an Attribute object that has just been constructed, or one that
 has been cloned from another Attribute. **/
 bool isOrphan() const;
@@ -577,11 +577,11 @@ const String& getName() const;
 /** If this is a valid attribute handle, get the value of the attribute
 as a String, not including the quotes. **/
 const String& getValue() const;
-/** If this is a valid attribute handle, change its name. 
+/** If this is a valid attribute handle, change its name.
 @return A reference to this attribute that now has the new name. **/
 Attribute& setName(const String& name);
 /** If this is a valid attribute handle, change its value to the given
-String which should not be quoted.  
+String which should not be quoted.
 @return A reference to this attribute that now has the new value. **/
 Attribute& setValue(const String& value);
 
@@ -628,9 +628,9 @@ Attribute& unconst() const {return *const_cast<Attribute*>(this);}
 TiXmlAttribute* tiAttr; // this is the lone data member
 };
 
-/** Output a textual representation of the given Xml::Attribute to an 
-std::ostream. This will be in the form the Attribute would appear in an XML 
-file; that is, name="value" or name='value' with entity substituion for odd 
+/** Output a textual representation of the given Xml::Attribute to an
+std::ostream. This will be in the form the Attribute would appear in an XML
+file; that is, name="value" or name='value' with entity substituion for odd
 characters, without surrounding blanks. @relates Xml::Attribute **/
 // Do this inline so we don't have to pass the ostream through the API.
 inline std::ostream& operator<<(std::ostream& o, const  Attribute& attr) {
@@ -646,10 +646,10 @@ inline std::ostream& operator<<(std::ostream& o, const  Attribute& attr) {
 //------------------------------------------------------------------------------
 /** This is a bidirectional iterator suitable for moving forward or backward
 within a list of Attributes within an Element, for writable access. **/
-class SimTK_SimTKCOMMON_EXPORT attribute_iterator 
+class SimTK_SimTKCOMMON_EXPORT attribute_iterator
 :   public std::iterator<std::bidirectional_iterator_tag, Attribute> {
 public:
-/** Default constructor creates an iterator that compares equal to 
+/** Default constructor creates an iterator that compares equal to
 attribute_end(). **/
 attribute_iterator() {}
 /** Construct this iterator to point to the same attribute as does the
@@ -657,13 +657,13 @@ supplied Attribute handle (or attribute_end() if the handle is empty). **/
 explicit attribute_iterator(Attribute& attr) : attr(attr) {}
 /** Copy constructor takes an attribute_iterator that can be const, but that
 still allows writing to the Attribute. **/
-attribute_iterator(const attribute_iterator& src) 
+attribute_iterator(const attribute_iterator& src)
 :   attr(src->updTiAttrPtr()) {}
 /** An iterator destructor never deletes the object to which it refers. **/
 ~attribute_iterator() {attr.setTiAttrPtr(0);}
 /** Copy assignment takes an attribute_iterator that can be const, but that
 still allows writing to the Attribute. **/
-attribute_iterator& operator=(const attribute_iterator& src) 
+attribute_iterator& operator=(const attribute_iterator& src)
 {   attr.setTiAttrPtr(src->updTiAttrPtr()); return *this; }
 /** Prefix increment operator advances the iterator to the next attribute (or
 attribute_end() if it was already at the last attribute) and
@@ -689,17 +689,17 @@ attribute_iterator operator--(int); // postfix
 iterator; the handle will be invalid if the iterator was attribute_end(). **/
 Attribute& operator*() const {return const_cast<Attribute&>(attr);}
 /** Return a writable pointer to the Attribute referenced by this
-iterator; the pointer will never be null but the handle it points to will be 
+iterator; the pointer will never be null but the handle it points to will be
 invalid if the iterator was attribute_end(). **/
 Attribute* operator->() const {return const_cast<Attribute*>(&attr);}
 /** Comparison return true only if both iterators refer to the same in-memory
-attribute or both are at attribute_end(); iterators referencing two different 
-attributes that happen to have identical properties will not test equal by 
+attribute or both are at attribute_end(); iterators referencing two different
+attributes that happen to have identical properties will not test equal by
 these criteria. **/
-bool operator==(const attribute_iterator& other) const 
+bool operator==(const attribute_iterator& other) const
 {   return other.attr==attr; }
 /** Uses same criteria as operator==(). **/
-bool operator!=(const attribute_iterator& other) const 
+bool operator!=(const attribute_iterator& other) const
 {   return other.attr!=attr; }
 
 //------------------------------------------------------------------------------
@@ -717,8 +717,8 @@ Attribute       attr;   // the lone data member
 //                               XML :: NODE
 //------------------------------------------------------------------------------
 /** Abstract handle for holding any kind of node in an XML tree. The concrete
-node handle types derived from Node are: Comment, Unknown, Text, and Element. 
-Only an Element node may contain other nodes. 
+node handle types derived from Node are: Comment, Unknown, Text, and Element.
+Only an Element node may contain other nodes.
 
 A node may be classified by who owns it. There are three possibilities:
   - Top-level node: The node belongs to the top-level Xml document and does
@@ -737,7 +737,7 @@ Element node. Child nodes and orphans can be of Element and Text type also.
 Normally orphans exist only briefly during the time a new node is constructed
 and the time it is adopted by some element (usually in the same constructor)
 so you can ignore them for the most part. But if you must keep orphan nodes
-around, be aware that they must be referenced by only one handle at a time to 
+around, be aware that they must be referenced by only one handle at a time to
 avoid ownership conflicts. **/
 class SimTK_SimTKCOMMON_EXPORT Node {
 public:
@@ -753,19 +753,19 @@ Node() : tiNode(0) {}
 /** Copy constructor is shallow; that is, this handle will refer to the
 same node as the source. Note that this handle will provide write
 access to the underlying node, even if the source was const. **/
-Node(const Node& src) : tiNode(src.tiNode) {} 
-/** Copy assignment is shallow; the handle is first cleared and then will 
-refer to the same node as the source. Note that this handle will 
+Node(const Node& src) : tiNode(src.tiNode) {}
+/** Copy assignment is shallow; the handle is first cleared and then will
+refer to the same node as the source. Note that this handle will
 provide write access to the underlying node even if the source handle
 was const. @see clear() **/
-Node& operator=(const Node& src) 
+Node& operator=(const Node& src)
 {   if (&src!=this) {clear(); tiNode=src.tiNode;} return *this; }
 /** The clone() method makes a deep copy of this Node and its children and
 returns a new orphan Node with the same contents; ordinary assignment and
 copy construction is shallow. **/
 Node clone() const;
 /** The Node handle destructor does not recover heap space so if you create
-orphan nodes and then don't put them in a document there will be a memory 
+orphan nodes and then don't put them in a document there will be a memory
 leak unless you explicitly destruct them first with clearOrphan(). **/
 ~Node() {clear();}
 /** This method restores the Node handle to its default-constructed
@@ -779,7 +779,7 @@ void clearOrphan();
 /*@}*/
 
 /**@name                  Node classification
-You can find out what concrete type of node this abstract Node handle is 
+You can find out what concrete type of node this abstract Node handle is
 referring to (if any), who owns the node, and if it is owned by a parent
 element you can get access to the parent. **/
 /*@{*/
@@ -806,7 +806,7 @@ object that has just been constructed, or one that has been cloned from another
 Node. **/
 bool isOrphan() const;
 
-/** Return true if this node has a parent, i.e. it is owned by an element; 
+/** Return true if this node has a parent, i.e. it is owned by an element;
 the root element and other top-level nodes are owned by the document and thus
 do not have a parent. @see getParentElement() **/
 bool hasParentElement() const;
@@ -823,8 +823,8 @@ kind of node this is. **/
 /*@{*/
 
 /** Return a text value associated with this Node (\e not including its child
-nodes if any); the behavior depends on the NodeType. This is a convenience 
-that saves downcasting a generic Node to a concrete type when all you want to 
+nodes if any); the behavior depends on the NodeType. This is a convenience
+that saves downcasting a generic Node to a concrete type when all you want to
 do is dump out the text. It is not particularly useful for Element nodes. Here
 is what you get for each type of node:
   - Comment: everything between "<!--" and "-->"
@@ -859,8 +859,8 @@ explicit Node(TiXmlNode* tiNode) : tiNode(tiNode) {}
 const TiXmlNode& getTiNode() const {assert(tiNode);return *tiNode;}
 TiXmlNode&       updTiNode()       {assert(tiNode);return *tiNode;}
 
-// Careful: these "Ptr" methods provide raw access to the contained 
-// pointer without any cleanup or error checking. In particular, 
+// Careful: these "Ptr" methods provide raw access to the contained
+// pointer without any cleanup or error checking. In particular,
 // setTiNodePtr() does not attempt to delete the current contents.
 void setTiNodePtr(TiXmlNode* node) {tiNode=node;}
 const TiXmlNode* getTiNodePtr() const {return tiNode;}
@@ -882,8 +882,8 @@ TiXmlNode*      tiNode; // the lone data member
 };
 
 /** Output a "pretty printed" textual representation of the given XML
-node (and all its contents) to an std::ostream. Pretty printing uses the 
-indent string from the Node's containing Xml::Document, if this Node is in a 
+node (and all its contents) to an std::ostream. Pretty printing uses the
+indent string from the Node's containing Xml::Document, if this Node is in a
 document, otherwise the default of four spaces for each indent level is used.
 @relates Xml::Node **/
 // Do this inline so we don't have to pass the ostream through the API.
@@ -901,24 +901,24 @@ inline std::ostream& operator<<(std::ostream& o, const Node& xmlNode) {
 /** This is a bidirectional iterator suitable for moving forward or backward
 within a list of Nodes, for writable access. By default we will iterate
 over all nodes but you can restrict the types at construction. **/
-class SimTK_SimTKCOMMON_EXPORT node_iterator 
+class SimTK_SimTKCOMMON_EXPORT node_iterator
 :   public std::iterator<std::bidirectional_iterator_tag, Node> {
 public:
 
-explicit node_iterator(NodeType allowed=AnyNodes) 
+explicit node_iterator(NodeType allowed=AnyNodes)
 :   allowed(allowed) {}
-explicit node_iterator(Node& node, NodeType allowed=AnyNodes) 
+explicit node_iterator(Node& node, NodeType allowed=AnyNodes)
 :   node(node), allowed(allowed) {}
 
 /** Copy constructor takes a node_iterator that can be const, but that
 still allows writing to the Node. **/
-node_iterator(const node_iterator& src) 
+node_iterator(const node_iterator& src)
 :   node(*src), allowed(src.allowed) {}
 /** An iterator destructor never deletes the object to which it refers. **/
 ~node_iterator() {node.setTiNodePtr(0);}
 /** Copy assignment takes an node_iterator that can be const, but that
 still allows writing to the Node. **/
-node_iterator& operator=(const node_iterator& src) 
+node_iterator& operator=(const node_iterator& src)
 {   node = *src; allowed = src.allowed; return *this; }
 
 node_iterator& operator++();   // prefix
@@ -936,7 +936,7 @@ bool operator!=(const node_iterator& other) const {return other.node!=node;}
 
 //------------------------------------------------------------------------------
                                  protected:
-explicit node_iterator(TiXmlNode* tiNode, NodeType allowed=AnyNodes) 
+explicit node_iterator(TiXmlNode* tiNode, NodeType allowed=AnyNodes)
 :   node(tiNode), allowed(allowed) {}
 void reassign(TiXmlNode* tiNode)
 {   node.setTiNodePtr(tiNode); }
@@ -966,20 +966,20 @@ public:
 
 /** This is the default constructor which leaves the element_iterator empty, and
 you can optionally set the type of Element which will be iterated over. **/
-explicit element_iterator(const String& tag="") 
+explicit element_iterator(const String& tag="")
 :   node_iterator(ElementNode), tag(tag) {}
-/** Constructor an element_iterator pointing to a given Element, and optionally 
+/** Constructor an element_iterator pointing to a given Element, and optionally
 set the type of Element which will be iterated over. **/
 inline explicit element_iterator(Element& elt, const String& tag=""); // below
 
 /** Copy constructor takes an element_iterator that can be const, but that
 still allows writing to the Element. **/
-element_iterator(const element_iterator& src) 
+element_iterator(const element_iterator& src)
 :   node_iterator(src), tag(src.tag) {}
 
 /** Copy assignment takes an element_iterator that can be const, but that
 still allows writing to the Element. **/
-element_iterator& operator=(const element_iterator& src) 
+element_iterator& operator=(const element_iterator& src)
 {   upcast()=src; tag = src.tag; return *this; }
 
 element_iterator& operator++();   // prefix
@@ -989,23 +989,23 @@ element_iterator operator--(int); // postfix
 inline Element& operator*() const; // below
 inline Element* operator->() const; // below
 
-bool operator==(const element_iterator& other) const 
+bool operator==(const element_iterator& other) const
 {   return other.upcast()==upcast();}
-bool operator!=(const element_iterator& other) const 
+bool operator!=(const element_iterator& other) const
 {   return other.upcast()!=upcast();}
 
 //------------------------------------------------------------------------------
                                    private:
 friend class Element;
 
-explicit element_iterator(TiXmlElement* tiElt, const String& tag="") 
+explicit element_iterator(TiXmlElement* tiElt, const String& tag="")
 :   node_iterator((TiXmlNode*)tiElt, ElementNode), tag(tag) {}
 void reassign(TiXmlElement* tiElt)
 {   upcast().reassign((TiXmlNode*)tiElt); }
 
-const node_iterator& upcast() const 
+const node_iterator& upcast() const
 {   return *static_cast<const node_iterator*>(this); }
-node_iterator& upcast() 
+node_iterator& upcast()
 {   return *static_cast<node_iterator*>(this); }
 
 String          tag;    // lone data member
@@ -1017,18 +1017,18 @@ String          tag;    // lone data member
 //------------------------------------------------------------------------------
 //                               XML :: ELEMENT
 //------------------------------------------------------------------------------
-/** An element has (1) a tagword, (2) a map of (name,value) pairs called 
-attributes, and (3) a list of child nodes. The tag word, which begins with an 
+/** An element has (1) a tagword, (2) a map of (name,value) pairs called
+attributes, and (3) a list of child nodes. The tag word, which begins with an
 underscore or a letter, can serve as either the type or the name of the element
-depending on context. The nodes can be comments, unknowns, text, and child 
-elements (recursively). It is common for "leaf" elements (elements with no 
+depending on context. The nodes can be comments, unknowns, text, and child
+elements (recursively). It is common for "leaf" elements (elements with no
 child elements) to be supplied simply for their values, for example mass might
 be provided via an element "<mass> 29.3 </mass>". We call such elements "value
-elements" since they have a uniquely identifiable value similar to that of 
-attributes. %Value elements have no more than one text node. They may have 
-attributes, and may also have comment and unknown nodes but they cannot have 
-any child elements. This class provides a special set of methods for dealing 
-with value nodes very conveniently; they will fail if you attempt to use them 
+elements" since they have a uniquely identifiable value similar to that of
+attributes. %Value elements have no more than one text node. They may have
+attributes, and may also have comment and unknown nodes but they cannot have
+any child elements. This class provides a special set of methods for dealing
+with value nodes very conveniently; they will fail if you attempt to use them
 on an element that is not a value element. **/
 class SimTK_SimTKCOMMON_EXPORT Element : public Node {
 public:
@@ -1036,7 +1036,7 @@ public:
 /**@name                  Construction and destruction
 As discussed elsewhere, elements come in two varieties: value elements and
 compound elements. New value elements can be created easily since they are
-essentially just a name,value pair. Compound elements require a series of 
+essentially just a name,value pair. Compound elements require a series of
 method calls to create the Element node and then add child nodes to it. In
 either case you may want to add attributes also. **/
 /*@{*/
@@ -1051,18 +1051,18 @@ you provide the initial value as a string, you can access it as any type T to
 which that string can be converted, using the getValueAs<T>() templatized
 method.
 
-If no initial value is provided, then the element will be empty so would print 
-as "<tagWord />". If you provide a value (say "contents") here or add one 
+If no initial value is provided, then the element will be empty so would print
+as "<tagWord />". If you provide a value (say "contents") here or add one
 later, it will print as "<tagWord>contents</tagWord>". In general you can add
-child elements and other node types with subsequent method calls; that would 
-change this element from a value element to a compound element. 
+child elements and other node types with subsequent method calls; that would
+change this element from a value element to a compound element.
 @see getValue(), updValue(), setValue() **/
 explicit Element(const String& tagWord, const String& value="");
 
-/** Create a new value element and set its initial value to the text 
-equivalent of any type T for which a conversion construction String(T) is 
-allowed (generally any type for which a stream insertion operator<<() 
-exists). 
+/** Create a new value element and set its initial value to the text
+equivalent of any type T for which a conversion construction String(T) is
+allowed (generally any type for which a stream insertion operator<<()
+exists).
 @see getValueAs<T>(), setValueAs<T>()**/
 template <class T>
 Element(const String& tagWord, const T& value)
@@ -1073,7 +1073,7 @@ returns a new orphan Element with the same contents; ordinary assignment and
 copy construction are shallow. **/
 Element clone() const;
 
-/** Get the element tag word. This may represent the name or type of the 
+/** Get the element tag word. This may represent the name or type of the
 element depending on context. **/
 const String& getElementTag() const;
 /** Change the tag word that is used to bracket this element. **/
@@ -1082,13 +1082,13 @@ void setElementTag(const String& tag);
 /** Insert a node into the list of this Element's children, just before the
 node pointed to by the supplied iterator (or at the end if the iterator
 is node_end()). The iterator must refer to a node that is a child of this
-Element. This Element takes over ownership of the node which must 
+Element. This Element takes over ownership of the node which must
 not already have a parent. **/
 void insertNodeBefore(const node_iterator& pos, Node node);
 /** Insert a node into the list of this Element's children, just after the
 node pointed to by the supplied iterator (or at the end if the iterator
 is node_end()). The iterator must refer to a node that is a child of this
-Element. This Element takes over ownership of the node which must 
+Element. This Element takes over ownership of the node which must
 not already have a parent. **/
 void insertNodeAfter(const node_iterator& pos, Node node);
 
@@ -1097,14 +1097,14 @@ void appendNode(Node node) {insertNodeAfter(node_end(), node);}
 
 /** Delete the indicated node, which must be a child of this element,
 and must not be node_end(). The node will be removed from this element
-and deleted. The iterator is invalid after this call; be sure not to use it 
-again. Also, there must not be any handles referencing the now-deleted 
+and deleted. The iterator is invalid after this call; be sure not to use it
+again. Also, there must not be any handles referencing the now-deleted
 node. **/
 void eraseNode(const node_iterator& deleteThis);
 /** Remove the indicated node from this element without erasing it, returning
-it as an orphan Node. The node must be a child of this element, and must not be 
-node_end(). The node will be removed from this element and returned as an 
-orphan. The iterator is invalid after this call; be sure not to use it 
+it as an orphan Node. The node must be a child of this element, and must not be
+node_end(). The node will be removed from this element and returned as an
+orphan. The iterator is invalid after this call; be sure not to use it
 again. **/
 Node removeNode(const node_iterator& removeThis);
 /*@}*/
@@ -1122,15 +1122,15 @@ children's values (if this element is compound). **/
 /*@{*/
 
 /** Determine whether this element qualifies as a "value element", defined
-as an element containing zero or one Text nodes and no child elements. 
+as an element containing zero or one Text nodes and no child elements.
 You can treat a value element as you would an attribute -- it can be viewed
 as having a single value, which is just the value of its lone Text node
 (or a null string if it doesn't have any text). **/
 bool isValueElement() const;
 
-/** Get the text value of this value element. An error will be thrown if 
+/** Get the text value of this value element. An error will be thrown if
 this is not a "value element". See the comments for this class for the
-definition of a "value element". 
+definition of a "value element".
 @note This does not return the same text as the base class method
 Node::getNodeText() does in the case of an element node; that returns the
 element tag word not its contents.
@@ -1144,8 +1144,8 @@ to it here with a null-string value so that we can return a reference to it.
 @see isValueElement(), getValue() **/
 String& updValue();
 
-/** Set the text value of this value element. An error will be thrown if 
-this is not a value element. If the element was initially empty and didn't 
+/** Set the text value of this value element. An error will be thrown if
+this is not a value element. If the element was initially empty and didn't
 contain a Text node, one will be added to it here so that we have a place to
 hold the \a value.
 @see isValueElement(), setValueAs<T>() **/
@@ -1155,38 +1155,38 @@ void setValue(const String& value);
 for which a conversion construction String(T) is allowed (generally any
 type for which a stream insertion operator<<() exists). **/
 template <class T>
-void setValueAs(const T& value) 
+void setValueAs(const T& value)
 {   setValue(String(value)); }
 
 /** Assuming this is a "value element", convert its text value to the type
 of the template argument T. It is an error if the text can not be converted,
 in its entirety, to a single object of type T. (But note that type T may
-be a container of some sort, like a Vector or Array.) 
+be a container of some sort, like a Vector or Array.)
 @tparam T   A type that can be read from a stream using the ">>" operator.
 **/
-template <class T> T getValueAs() const 
+template <class T> T getValueAs() const
 {   T out; convertStringTo(getValue(),out); return out;}
 
 /** Alternate form of getValueAs() that avoids unnecessary copying and
 heap allocation for reading in large container objects. **/
-template <class T> void getValueAs(T& out) const 
+template <class T> void getValueAs(T& out) const
 {   convertStringTo(getValue(),out); }
 
-/** Get the text value of a child value element that \e must be present in 
+/** Get the text value of a child value element that \e must be present in
 this element. The child is identified by its tag; if there is more than one
 this refers to the first one. Then the element is expected to contain either
-zero or one Text nodes; if none we'll return a null string, otherwise 
+zero or one Text nodes; if none we'll return a null string, otherwise
 the value of the Text node. Thus an element like "<tag>stuff</tag>" will
 have the value "stuff". An error will be thrown if either the element
 is not found or it is not a "value element". **/
-const String& 
+const String&
 getRequiredElementValue(const String& tag) const
 {   return unconst().getRequiredElement(tag).getValue(); }
 
 /** Get the text value of a child value element that \e may be present in
-this element, otherwise return a default string. If the child element is 
+this element, otherwise return a default string. If the child element is
 found, it must be a "value element" as defined above. **/
-String 
+String
 getOptionalElementValue(const String& tag, const String& def="") const
 {   const Element opt(unconst().getOptionalElement(tag));
     return opt.isValid() ? opt.getValue() : def; }
@@ -1195,27 +1195,27 @@ getOptionalElementValue(const String& tag, const String& def="") const
 of the template argument T. It is an error if the element is present but is
 not a value element, or if the text cannot be converted,
 in its entirety, to a single object of type T. (But note that type T may
-be a container of some sort, like a Vector or Array.) 
+be a container of some sort, like a Vector or Array.)
 @tparam     T   A type that can be read from a stream using the ">>" operator.
 @param[in]  tag The tag of the required child text element.
 @return The value of the text element, converted to an object of type T. **/
-template <class T> T  
+template <class T> T
 getRequiredElementValueAs(const String& tag) const
-{   T out; convertStringTo(unconst().getRequiredElementValue(tag), out); 
+{   T out; convertStringTo(unconst().getRequiredElementValue(tag), out);
     return out; }
 
 /** Convert the text value of an optional child value element, if present, to
 the type of the template argument T. It is an error if the child element is
-present but is not a value element, or if the text cannot be 
-converted, in its entirety, to a single object of type T. (But note that 
-type T may be a container of some sort, like a Vector or Array.) If the 
+present but is not a value element, or if the text cannot be
+converted, in its entirety, to a single object of type T. (But note that
+type T may be a container of some sort, like a Vector or Array.) If the
 child element is not present, then return a supplied default value of type T.
 @tparam     T    A type that can be read from a stream with operator ">>".
 @param[in]  tag  The tag of the optional child element.
 @param[in]  def  The value of type T to return if child element is missing.
 @return The value of element \a tag if it is present, otherwise a copy
 of the supplied default value \a def. **/
-template <class T> T 
+template <class T> T
 getOptionalElementValueAs(const String& tag, const T& def) const
 {   const Element opt(unconst().getOptionalElement(tag));
     if (!opt.isValid()) return def;
@@ -1237,60 +1237,60 @@ void setAttributeValue(const String& name, const String& value);
 
 /** Erase an attribute of this element if it exists, otherwise do nothing.
 If you need to know if the attribute exists, use hasAttribute(). There is
-no removeAttribute() that orphans an existing Attribute, but you can easily 
+no removeAttribute() that orphans an existing Attribute, but you can easily
 recreate one with the same name and value. **/
 void eraseAttribute(const String& name);
 
-/** Get the value of an attribute as a string and throw an error if that 
+/** Get the value of an attribute as a string and throw an error if that
 attribute is not present. **/
-const String& 
+const String&
 getRequiredAttributeValue(const String& name) const
 {   return unconst().getRequiredAttribute(name).getValue(); }
 
 /** Convert the text value of a required attribute to the type
 of the template argument T. It is an error if the text can not be converted,
 in its entirety, to a single object of type T. (But note that type T may
-be a container of some sort, like a Vec3.) 
+be a container of some sort, like a Vec3.)
 @tparam T   A type that can be read from a stream using the ">>" operator.
 **/
-template <class T> T 
+template <class T> T
 getRequiredAttributeValueAs(const String& name) const
 {   T out; convertStringTo(getRequiredAttributeValue(name),out); return out; }
 
-/** Get the value of an attribute as a string if the attribute is present in 
+/** Get the value of an attribute as a string if the attribute is present in
 this element, otherwise return a supplied default value.
 @param[in]  name The name of the optional attribute.
 @param[in]  def  The string to return if the attribute is missing.
 @return The value of attribute \a name if it is present, otherwise a copy
 of the supplied default string \a def. **/
-String 
+String
 getOptionalAttributeValue(const String& name, const String& def="") const
 {   Attribute attr = unconst().getOptionalAttribute(name);
     if (!attr.isValid()) return def;
     return attr.getValue(); }
 
-/** Convert the value of an optional attribute, if present, from a string to 
-the type of the template argument T. It is an error if the text can not be 
-converted, in its entirety, to a single object of type T. (But note that type 
-T may be a container of some sort, like a Vec3.) If the attribute is not 
+/** Convert the value of an optional attribute, if present, from a string to
+the type of the template argument T. It is an error if the text can not be
+converted, in its entirety, to a single object of type T. (But note that type
+T may be a container of some sort, like a Vec3.) If the attribute is not
 present, then return a supplied default value of type T.
 @tparam     T    A type that can be read from a stream with operator ">>".
 @param[in]  name The name of the optional attribute.
 @param[in]  def  The value of type T to return if the attribute is missing.
 @return The value of attribute \a name if it is present, otherwise a copy
 of the supplied default value \a def. **/
-template <class T> T 
+template <class T> T
 getOptionalAttributeValueAs(const String& name, const T& def) const
 {   Attribute attr = unconst().getOptionalAttribute(name);
     if (!attr.isValid()) return def;
     T out; convertStringTo(attr.getValue(), out); return out; }
 
-/** Obtain an Attribute handle referencing a particular attribute of this 
+/** Obtain an Attribute handle referencing a particular attribute of this
 element; an error will be thrown if no such attribute is present. **/
 Attribute getRequiredAttribute(const String& name);
 
-/** Obtain an Attribute handle referencing a particular attribute of this 
-element specified by name, or an empty handle if no such attribute is 
+/** Obtain an Attribute handle referencing a particular attribute of this
+element specified by name, or an empty handle if no such attribute is
 present. **/
 Attribute getOptionalAttribute(const String& name);
 
@@ -1306,11 +1306,11 @@ Array_<Attribute> getAllAttributes()
 {   return Array_<Attribute>(attribute_begin(), attribute_end()); }
 
 
-/** For iterating through all the attributes of this element. If there are no 
-attributes then the returned attribute_iterator tests equal to 
+/** For iterating through all the attributes of this element. If there are no
+attributes then the returned attribute_iterator tests equal to
 attribute_end(). **/
 attribute_iterator attribute_begin();
-/** This attribute_end() iterator indicates the end of a sequence of 
+/** This attribute_end() iterator indicates the end of a sequence of
 attributes. **/
 attribute_iterator attribute_end() const;
 /*@}*/
@@ -1318,9 +1318,9 @@ attribute_iterator attribute_end() const;
 /**@name                    Compound elements
 Many elements contain child nodes, including other elements. When there is
 just a single child Text node and no child elements, we call the element a
-"value element" and it is easiest to work with using the methods in the 
+"value element" and it is easiest to work with using the methods in the
 "Value elements" section. When there are child elements and/or multiple Text
-nodes, the element is called a "compound element" and you need a way to 
+nodes, the element is called a "compound element" and you need a way to
 iterate and recurse through its contents. The methods in this section support
 looking through all contained nodes, nodes of specified types, element nodes,
 or element nodes with a specified tags. You can obtain handles to child
@@ -1333,20 +1333,20 @@ bool hasElement(const String& tag) const;
 allowed by the NodeType filter if one is supplied. **/
 bool hasNode(NodeType allowed=AnyNodes) const;
 
-/** Get a reference to a child element that \e must be present in this 
+/** Get a reference to a child element that \e must be present in this
 element. The child is identified by its tag; if there is more than one
 only the first one is returned. If you want to see all children with this
 tag, use getAllElements() or use an element_iterator. **/
 Element getRequiredElement(const String& tag);
 
-/** Get a reference to a child element that \e may be present in this 
+/** Get a reference to a child element that \e may be present in this
 element; otherwise return an invalid Element handle. Test using the
 Element's isValid() method. **/
 Element getOptionalElement(const String& tag);
 
 /** Return an array containing Element handles referencing all the
-immediate child elements contained in this element, or all the child 
-elements of a particular type (that is, with a given tag word). Elements 
+immediate child elements contained in this element, or all the child
+elements of a particular type (that is, with a given tag word). Elements
 are returned in the order they are seen in the document. This is just a
 shortcut for @code
     Array_<Element>(element_begin(tag), element_end());
@@ -1355,29 +1355,29 @@ Array_<Element> getAllElements(const String& tag="")
 {   return Array_<Element>(element_begin(tag), element_end()); }
 
 /** Return an array containing Node handles referencing all the
-immediate child nodes contained in this element, or all the child 
-nodes of a particular type or types. Nodes are returned in the order they 
+immediate child nodes contained in this element, or all the child
+nodes of a particular type or types. Nodes are returned in the order they
 are seen in the document. This is just a shortcut for @code
     Array_<Node>(node_begin(allowed), node_end());
 @endcode **/
 Array_<Node> getAllNodes(NodeType allowed=AnyNodes)
 {   return Array_<Node>(node_begin(allowed), node_end()); }
 
-/** For iterating through the immediate child elements of this element, or the 
-child elements that have the indicated tag if one is supplied. If there are no 
-children with the \a allowed tag then the returned element_iterator tests 
+/** For iterating through the immediate child elements of this element, or the
+child elements that have the indicated tag if one is supplied. If there are no
+children with the \a allowed tag then the returned element_iterator tests
 equal to element_end(). **/
 element_iterator element_begin(const String& tag="");
-/** This element_end() iterator indicates the end of any sequence of elements 
+/** This element_end() iterator indicates the end of any sequence of elements
 regardless of the tag restriction on the iterator being used. **/
 element_iterator element_end() const;
 
-/** For iterating through the immediate child nodes of this element, or the 
-child nodes of the type(s) allowed by the NodeType filter if one is 
+/** For iterating through the immediate child nodes of this element, or the
+child nodes of the type(s) allowed by the NodeType filter if one is
 supplied. If there are no children of the \a allowed types then the returned
 node_iterator tests equal to node_end(). **/
 node_iterator node_begin(NodeType allowed=AnyNodes);
-/** This node_end() iterator indicates the end of any sequence of nodes 
+/** This node_end() iterator indicates the end of any sequence of nodes
 regardless of the NodeType restriction on the iterator being used. **/
 node_iterator node_end() const;
 /*@}*/
@@ -1401,18 +1401,18 @@ static Element& getAs(Node& node);
 friend class Node;
 friend class element_iterator;
 
-explicit Element(TiXmlElement* tiElt) 
+explicit Element(TiXmlElement* tiElt)
 :   Node(reinterpret_cast<TiXmlNode*>(tiElt)) {}
 
-TiXmlElement& updTiElement() 
-{   return reinterpret_cast<TiXmlElement&>(updTiNode()); } 
+TiXmlElement& updTiElement()
+{   return reinterpret_cast<TiXmlElement&>(updTiNode()); }
 const TiXmlElement& getTiElement() const
 {   return reinterpret_cast<const TiXmlElement&>(getTiNode()); }
 
-// Careful: these "Ptr" methods provide raw access to the contained 
-// pointer without any cleanup or error checking. In particular, 
+// Careful: these "Ptr" methods provide raw access to the contained
+// pointer without any cleanup or error checking. In particular,
 // setTiElementPtr() does not attempt to delete the current contents.
-const TiXmlElement* getTiElementPtr() const 
+const TiXmlElement* getTiElementPtr() const
 {   return reinterpret_cast<const TiXmlElement*>(getTiNodePtr()); }
 TiXmlElement*       updTiElementPtr()
 {   return reinterpret_cast<TiXmlElement*>(updTiNodePtr()); }
@@ -1430,11 +1430,11 @@ Element& unconst() const {return *const_cast<Element*>(this);}
 // A few element_iterator inline definitions had to wait for Element to be
 // defined.
 inline element_iterator::element_iterator
-   (Element& elt, const String& tag) 
+   (Element& elt, const String& tag)
 :   node_iterator(elt, ElementNode), tag(tag) {}
-inline Element& element_iterator::operator*() const 
+inline Element& element_iterator::operator*() const
 {   return Element::getAs(*upcast());}
-inline Element* element_iterator::operator->() const 
+inline Element* element_iterator::operator->() const
 {   return &Element::getAs(*upcast());}
 
 
@@ -1454,8 +1454,8 @@ Text() : Node() {}
 any XML document. **/
 explicit Text(const String& text);
 
-/** The clone() method makes a deep copy of this Text node and returns a new 
-orphan Text node with the same contents; ordinary assignment and copy 
+/** The clone() method makes a deep copy of this Text node and returns a new
+orphan Text node with the same contents; ordinary assignment and copy
 construction are shallow. **/
 Text clone() const;
 
@@ -1484,7 +1484,7 @@ static Text& getAs(Node& node);
                                    private:
 // no data members; see Node
 
-explicit Text(TiXmlText* tiText) 
+explicit Text(TiXmlText* tiText)
 :   Node(reinterpret_cast<TiXmlNode*>(tiText)) {}
 };
 
@@ -1501,13 +1501,13 @@ to other Comment nodes. **/
 Comment() : Node() {}
 
 /** Create a new Comment node with the given text; the node is not yet owned by
-any XML document. Don't include the comment delimiters "<!--" and "-->" in the 
+any XML document. Don't include the comment delimiters "<!--" and "-->" in the
 text; those will be added automatically if the document is serialized to a
 file or string. **/
 explicit Comment(const String& text);
 
-/** The clone() method makes a deep copy of this Comment node and returns a new 
-orphan Comment node with the same contents; ordinary assignment and copy 
+/** The clone() method makes a deep copy of this Comment node and returns a new
+orphan Comment node with the same contents; ordinary assignment and copy
 construction are shallow. **/
 Comment clone() const;
 
@@ -1529,7 +1529,7 @@ static Comment& getAs(Node& node);
                                    private:
 // no data members; see Node
 
-explicit Comment(TiXmlComment* tiComment) 
+explicit Comment(TiXmlComment* tiComment)
 :   Node(reinterpret_cast<TiXmlNode*>(tiComment)) {}
 };
 
@@ -1545,8 +1545,8 @@ public:
 to other Unknown nodes. **/
 Unknown() : Node() {}
 
-/** Create a new Unknown node with the given contents; the node is not yet 
-owned by any XML document. Don't include the tag delimiters "<" and ">" in the 
+/** Create a new Unknown node with the given contents; the node is not yet
+owned by any XML document. Don't include the tag delimiters "<" and ">" in the
 contents; those will be added automatically if the document is serialized to a
 file or string. That is, if you want "<!SOMETHING blah blah>", the contents
 you provide should be "!SOMETHING blah blah". **/
@@ -1556,11 +1556,11 @@ explicit Unknown(const String& contents);
 children of the given Element. The Element becomes the owner of the new
 Unknown node although the handle retains a reference to it. **/
 Unknown(Element& element, const String& contents)
-{   new(this) Unknown(contents); 
+{   new(this) Unknown(contents);
     element.insertNodeBefore(element.node_end(), *this); }
 
-/** The clone() method makes a deep copy of this Unknown node and returns a new 
-orphan Unknown node with the same contents; ordinary assignment and copy 
+/** The clone() method makes a deep copy of this Unknown node and returns a new
+orphan Unknown node with the same contents; ordinary assignment and copy
 construction are shallow. **/
 Unknown clone() const;
 
@@ -1589,7 +1589,7 @@ static Unknown& getAs(Node& node);
                                    private:
 // no data members; see Node
 
-explicit Unknown(TiXmlUnknown* tiUnknown) 
+explicit Unknown(TiXmlUnknown* tiUnknown)
 :   Node(reinterpret_cast<TiXmlNode*>(tiUnknown)) {}
 };
 
@@ -1599,17 +1599,17 @@ explicit Unknown(TiXmlUnknown* tiUnknown)
 /** Default implementation of serialization to an XML element for objects whose
 class does not define a member function `toXmlElement(name)`. A name can be
 provided for this value; by default that will be used as the element's tag word
-so make sure it is a legal XML tag. If `name` is empty we'll use `<value>` as 
-the tag. This default implementation uses Simbody's stream serialization method 
-`SimTK::writeUnformatted<T>()`. Specialize this free function or provide a 
+so make sure it is a legal XML tag. If `name` is empty we'll use `<value>` as
+the tag. This default implementation uses Simbody's stream serialization method
+`SimTK::writeUnformatted<T>()`. Specialize this free function or provide a
 member function if that doesn't provide the behavior you want.
 
-If type `T` provides a member function or specialization of this method, it may 
-choose any tag word, in which case the given name if any should be added as an 
+If type `T` provides a member function or specialization of this method, it may
+choose any tag word, in which case the given name if any should be added as an
 attribute `name="name"` ("value" is not used in that case if `name` is empty).
 
 A helper function `toXmlElementHelper<T>` is available for invoking the member
-function `T::toXmlElement()` if it exists, otherwise the appropriate 
+function `T::toXmlElement()` if it exists, otherwise the appropriate
 specialization of this free function. Invoke the helper like this:
 @code
     Xml::Element e = toXmlElementHelper(T, "name", true);
@@ -1626,7 +1626,7 @@ toXmlElement(const T& thing, const std::string& name) {
 }
 
 /** Helper function for toXmlElement() that selects the member function if it
-exists. @see toXmlElement() 
+exists. @see toXmlElement()
 @relates SimTK::Xml::Element **/
 template <class T> inline
 auto toXmlElementHelper(const T& thing, const std::string& name, bool)
@@ -1635,27 +1635,27 @@ auto toXmlElementHelper(const T& thing, const std::string& name, bool)
 }
 
 /** Helper function for toXmlElement() that selects the free function if no
-member function exists. @see toXmlElement() 
+member function exists. @see toXmlElement()
 @relates SimTK::Xml::Element **/
 template <class T> inline
-auto toXmlElementHelper(const T& thing, const std::string& name, int) 
+auto toXmlElementHelper(const T& thing, const std::string& name, int)
     -> Xml::Element  {
     return toXmlElement(thing, name); // call free function
 }
 
-/** Default implementation of deserialization from an XML element for objects 
+/** Default implementation of deserialization from an XML element for objects
 whose class does not define a member function `fromXmlElement(elt,name)`. The
 name is optional but if provided then we require that the given element has
 that name. For this default implementation, we'll expect the element's tag word
 to be the given name; specializations or member functions are free to use a
 different tag with the name as an attribute.
 
-This default implementation uses Simbody's stream deserialization method 
-`SimTK::readUnformatted<T>()`. Specialize this free function or provide a 
+This default implementation uses Simbody's stream deserialization method
+`SimTK::readUnformatted<T>()`. Specialize this free function or provide a
 member function if that doesn't provide the behavior you want.
 
 A helper function `fromXmlElementHelper<T>` is available for invoking the member
-function `T::fromXmlElement()` if it exists, otherwise the appropriate 
+function `T::fromXmlElement()` if it exists, otherwise the appropriate
 specialization of this free function. Invoke the helper like this:
 @code
     fromXmlElementHelper(T, element, "requiredName", true);
@@ -1665,12 +1665,12 @@ function over the free function if both exist, using SFINAE.
 @see fromXmlElementHelper(), toXmlElement()
 @relates SimTK::Xml::Element **/
 template <class T> inline void
-fromXmlElement(T& thing, Xml::Element& elt, 
+fromXmlElement(T& thing, Xml::Element& elt,
                const std::string& requiredName="") {
     if (!requiredName.empty()) {
         const String& name = elt.getElementTag();
         SimTK_ERRCHK2_ALWAYS(name==requiredName, "fromXmlElement<T>",
-        "Expected element name '%s' but got '%s'.", requiredName.c_str(), 
+        "Expected element name '%s' but got '%s'.", requiredName.c_str(),
                                                     name.c_str());
     }
     std::istringstream is(elt.getValue());
@@ -1682,28 +1682,28 @@ fromXmlElement(T& thing, Xml::Element& elt,
 }
 
 /** Helper function for fromXmlElement() that selects the member function if it
-exists. @see fromXmlElement() 
+exists. @see fromXmlElement()
 @relates SimTK::Xml::Element **/
 template <class T> inline
-auto fromXmlElementHelper(T& thing, Xml::Element& elt, 
+auto fromXmlElementHelper(T& thing, Xml::Element& elt,
                           const std::string& requiredTag, bool)
     -> decltype(std::declval<T>().fromXmlElement(elt,requiredTag)) {
     return thing.fromXmlElement(elt,requiredTag); // call member function
 }
 
 /** Helper function for fromXmlElement() that selects the free function if no
-member function exists. @see fromXmlElement() 
+member function exists. @see fromXmlElement()
 @relates SimTK::Xml::Element **/
 template <class T> inline
-auto fromXmlElementHelper(T& thing, Xml::Element& elt, 
-                          const std::string& requiredTag, int) 
+auto fromXmlElementHelper(T& thing, Xml::Element& elt,
+                          const std::string& requiredTag, int)
     -> void {
     fromXmlElement(thing, elt, requiredTag); // call free function
 }
 
 
-// Definition of these functions (which should really be methods of 
-// the Array_ classes) has to wait until Xml classes are declared because Xml 
+// Definition of these functions (which should really be methods of
+// the Array_ classes) has to wait until Xml classes are declared because Xml
 // uses Array_.
 
 /** Partial specialization for XML serialization of ArrayViewConst_ objects.
@@ -1728,8 +1728,8 @@ Xml::Element toXmlElement(const ArrayViewConst_<T,X>& thing,
     return e;
 }
 
-/** Partial specialization for XML serialization of ArrayView_ objects. The 
-result is a single element with tag word `<Array>` with the given name (if any) 
+/** Partial specialization for XML serialization of ArrayView_ objects. The
+result is a single element with tag word `<Array>` with the given name (if any)
 and a version number as attributes. Then each entry is a subelement, as produced
 by type T's `toXmlElement()` method.
 @relates SimTK::ArrayView_ **/
@@ -1739,8 +1739,8 @@ Xml::Element toXmlElement(const ArrayView_<T,X>& thing,
     return toXmlElement(static_cast<const ArrayViewConst_<T,X>&>(thing),name);
 }
 
-/** Partial specialization for XML serialization of Array_ objects. The 
-result is a single element with tag word `<Array>` with the given name (if any) 
+/** Partial specialization for XML serialization of Array_ objects. The
+result is a single element with tag word `<Array>` with the given name (if any)
 and a version number as attributes. Then each entry is a subelement, as produced
 by type T's `toXmlElement()` method.
 @relates SimTK::Array_ **/


### PR DESCRIPTION
Removal of trailing whitespace precedes planned changes in String.h and possibly Xml.h.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/759)
<!-- Reviewable:end -->
