### PR TITLE
Migrate sprintf() to snprintf()

### DIFF
--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
@@ -34,25 +34,25 @@
 #include <cstdarg>
 
 namespace SimTK {
- 
-/** This is the type to use for Stage version numbers that get incremented 
-whenever a state variable change invalidates a Stage. Whenever time or any state 
+
+/** This is the type to use for Stage version numbers that get incremented
+whenever a state variable change invalidates a Stage. Whenever time or any state
 variable is modified, we increment the %StageVersion for any Stage that gets
-invalidated. -1 means "uninitialized". 0 is never used as a %StageVersion, but 
-is allowed as a remembered %StageVersion which is guaranteed never to look 
+invalidated. -1 means "uninitialized". 0 is never used as a %StageVersion, but
+is allowed as a remembered %StageVersion which is guaranteed never to look
 valid. **/
 typedef long long StageVersion;
 
-/** This is the type to use for state variable version numbers that get 
-incremented whenever a state value changes. Whenever time or any state variable 
-is modified, we increment a version number for the state variable that changes, 
-so that cache entries can have finer-grained prerequisites than just on whole 
-stages. -1 means "uninitialized". 0 is never used as a %ValueVersion, but is 
+/** This is the type to use for state variable version numbers that get
+incremented whenever a state value changes. Whenever time or any state variable
+is modified, we increment a version number for the state variable that changes,
+so that cache entries can have finer-grained prerequisites than just on whole
+stages. -1 means "uninitialized". 0 is never used as a %ValueVersion, but is
 allowed as a remembered version which is guaranteed never to look valid. **/
 typedef long long ValueVersion;
 
 /** This class is basically a glorified enumerated type, type-safe and range
-checked but permitting convenient (if limited) arithmetic. Constants look like 
+checked but permitting convenient (if limited) arithmetic. Constants look like
 Stage::Position, and loops can be written like
 @code
     for(Stage s = Stage::LowestValid; s <= Stage::HighestValid; ++s) {
@@ -62,7 +62,7 @@ Stage::Position, and loops can be written like
 Stage constants (of type Stage::Level) are implicitly converted to type
 Stage when necessary.
 
-Default construction gives Stage::Empty which really means "invalid". **/    
+Default construction gives Stage::Empty which really means "invalid". **/
 class Stage  {
 public:
     enum Level {
@@ -88,7 +88,7 @@ public:
         NValid = HighestValid-LowestValid+1,
         NRuntime = HighestRuntime-LowestRuntime+1
     };
-    
+
     /** Default construction gives Stage::Empty. **/
     Stage() : level(Stage::Empty) {}
     /** This is an implicit conversion from Stage::Level to Stage. **/
@@ -120,23 +120,23 @@ public:
     // Prefix operators
     const Stage& operator++()
     {   assert(level<HighestValid); level=Level(level+1); return *this; }
-    const Stage& operator--() 
+    const Stage& operator--()
     {   assert(level>LowestValid);  level=Level(level-1); return *this;}
     // Postfix operators
-    Stage operator++(int)     
+    Stage operator++(int)
     {   assert(level<HighestValid); level=Level(level+1); return prev(); }
-    Stage operator--(int)     
+    Stage operator--(int)
     {   assert(level>LowestValid);  level=Level(level-1); return next(); }
 
     /** Return the Stage following this one, with Stage::Infinity returned
     if this Stage is already at its highest value, Stage::Report. An exception
     is thrown if this Stage is already Stage::Infinity. **/
-    Stage next() const 
+    Stage next() const
     {   assert(level<HighestValid); return Stage(Level(level+1)); }
     /** Return the Stage before this one, with Stage::Empty returned
     if this Stage is already at its lowest value, Stage::Topology. An exception
     is thrown if this Stage is already Stage::Empty. **/
-    Stage prev() const 
+    Stage prev() const
     {   assert(level>LowestValid); return Stage(Level(level-1)); }
 
     /** Return a printable name corresponding to the stage level currently
@@ -168,8 +168,8 @@ public:
     /** Return true if this Stage has one of the meaningful values between
     Stage::Topology and Stage::Report, rather than one of the end markers
     Stage::Empty or Stage::Infinity. **/
-    bool isInRuntimeRange() const 
-    {   return    Stage::LowestRuntime <= level 
+    bool isInRuntimeRange() const
+    {   return    Stage::LowestRuntime <= level
                && level <= Stage::HighestRuntime; }
 
 private:
@@ -207,10 +207,10 @@ public:
        int sysTopoVersion,
        int stateTopoVersion) : Base(fn,ln)
     {
-        setMessage(String(methodName) 
-        + ": The given State's Topology stage version number (" 
+        setMessage(String(methodName)
+        + ": The given State's Topology stage version number ("
         + String(stateTopoVersion)
-        + ") doesn't match the current topology cache version number (" 
+        + ") doesn't match the current topology cache version number ("
         + String(sysTopoVersion)
         + ") of " + String(objectType) + " " + String(objectName) + "."
         + " That means there has been a topology change to this System since this"
@@ -270,13 +270,13 @@ public:
 class CacheEntryOutOfDate : public Base {
 public:
     CacheEntryOutOfDate(const char* fn, int ln,
-        Stage currentStage, Stage dependsOn, 
-        StageVersion dependsOnVersion, StageVersion lastCalculatedVersion) 
+        Stage currentStage, Stage dependsOn,
+        StageVersion dependsOnVersion, StageVersion lastCalculatedVersion)
     :   Base(fn,ln)
     {
-        setMessage("State Cache entry was out of date at Stage " + currentStage.getName() 
-           + ". This entry depends on version " + String(dependsOnVersion) 
-           + " of Stage " + dependsOn.getName() 
+        setMessage("State Cache entry was out of date at Stage " + currentStage.getName()
+           + ". This entry depends on version " + String(dependsOnVersion)
+           + " of Stage " + dependsOn.getName()
            + " but was last updated at version " + String(lastCalculatedVersion) + ".");
     }
     virtual ~CacheEntryOutOfDate() throw() { }
@@ -285,7 +285,7 @@ public:
 // An attempt to realize a particular subsystem to a particular stage failed.
 class RealizeCheckFailed : public Base {
 public:
-    RealizeCheckFailed(const char* fn, int ln, Stage g, 
+    RealizeCheckFailed(const char* fn, int ln, Stage g,
                        int subsystemId, const char* subsystemName,
                        const char* fmt, ...) : Base(fn,ln)
     {
@@ -307,8 +307,8 @@ public:
 
 } // namespace Exception
 
-inline std::ostream& operator<<(std::ostream& o, Stage g) 
-{   o << g.getName(); return o; }    
+inline std::ostream& operator<<(std::ostream& o, Stage g)
+{   o << g.getName(); return o; }
 
 
 } // namespace SimTK
@@ -341,5 +341,5 @@ inline std::ostream& operator<<(std::ostream& o, Stage g)
                     (stage),(subsysIx),(subsysName),(msg),(a1),(a2),(a3),(a4),(a5));    \
     }while(false)
 
-    
+
 #endif // SimTK_SimTKCOMMON_STAGE_H_

--- a/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
+++ b/SimTKcommon/Simulation/include/SimTKcommon/internal/Stage.h
@@ -289,10 +289,11 @@ public:
                        int subsystemId, const char* subsystemName,
                        const char* fmt, ...) : Base(fn,ln)
     {
-        char buf[1024];
+        const int n = 1024;
+        char buf[n];
         va_list args;
         va_start(args, fmt);
-        vsprintf(buf, fmt, args);
+        vsnprintf(buf, n, fmt, args);
         setMessage("Couldn't realize subsystem " + String(subsystemId)
                    + "(" + String(subsystemName) + ") to Stage "
                    + g.getName() + ": " + String(buf) + ".");

--- a/SimTKcommon/include/SimTKcommon/internal/Exception.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Exception.h
@@ -41,12 +41,12 @@ namespace Exception {
 #pragma warning(push)
 #pragma warning(disable:4996)
 #endif
-    
-// SimTK::Exception::Base    
+
+// SimTK::Exception::Base
 class Base : public std::exception {
 public:
-    explicit Base(const char* fn="<UNKNOWN>", int ln=0) 
-      : fileName(fn), lineNo(ln) { } 
+    explicit Base(const char* fn="<UNKNOWN>", int ln=0)
+      : fileName(fn), lineNo(ln) { }
     virtual ~Base() throw() { }
     const std::string& getMessage()     const { return msg; }
     const std::string& getMessageText() const { return text; }
@@ -60,38 +60,40 @@ protected:
     }
 private:
     std::string    fileName;    // where the exception was thrown
-    int            lineNo;    
+    int            lineNo;
     std::string    msg;        // a message formatted for display by catcher
     std::string text;      // the original passed-in text
-    
-    static std::string shortenFileName(const std::string& fn) 
+
+    static std::string shortenFileName(const std::string& fn)
     {   std::string::size_type pos = fn.find_last_of("/\\");
         if (pos+1>=fn.size()) pos=0;
         return std::string(fn,(int)(pos+1),(int)(fn.size()-(pos+1)));
     }
-    
+
     std::string where() const {
-        char buf[32];
-        sprintf(buf,"%d",lineNo);
-        return shortenFileName(fileName) + ":" + std::string(buf); 
-    } 
+        const int n = 32;
+        char buf[n];
+        snprintf(buf,n,"%d",lineNo);
+        return shortenFileName(fileName) + ":" + std::string(buf);
+    }
 };
 
-/// This is for reporting internally-detected bugs only, not problems induced by 
+/// This is for reporting internally-detected bugs only, not problems induced by
 /// confused users (that is, it is for confused developers instead). The exception
 /// message accepts printf-style arguments and should contain lots of useful
-/// information for developers. Don't throw 
-/// this exception directly; use one of the family of SimTK_ASSERT and 
+/// information for developers. Don't throw
+/// this exception directly; use one of the family of SimTK_ASSERT and
 /// SimTK_ASSERT_ALWAYS macros.
 class Assert : public Base {
 public:
-    Assert(const char* fn, int ln, const char* assertion, 
+    Assert(const char* fn, int ln, const char* assertion,
              const char* fmt ...) : Base(fn,ln)
     {
-        char buf[1024];
+        const int n = 1024;
+        char buf[n];
         va_list args;
         va_start(args, fmt);
-        vsprintf(buf, fmt, args);
+        vsnprintf(buf, n, fmt, args);
 
         setMessage("Internal bug detected: " + std::string(buf)
                    + "\n  (Assertion '" + std::string(assertion) + "' failed).\n"
@@ -105,23 +107,24 @@ public:
 /// This is for reporting errors occurring during execution of SimTK core methods,
 /// beyond those caused by mere improper API arguments, which should be reported with
 /// APIArgcheck instead.  Nor is this intended for detection of internal
-/// bugs; use Assert instead for that. It is expected that this error resulted from 
-/// something the API user did, so the messages should be suitable for reporting to 
-/// that programmer. The exception message accepts printf-style arguments and should 
-/// contain lots of useful information for the API user. Don't throw this exception 
+/// bugs; use Assert instead for that. It is expected that this error resulted from
+/// something the API user did, so the messages should be suitable for reporting to
+/// that programmer. The exception message accepts printf-style arguments and should
+/// contain lots of useful information for the API user. Don't throw this exception
 /// directly; use one of the family SimTK_ERRCHK and SimTK_ERRCHK_ALWAYS macros.
 class ErrorCheck : public Base {
 public:
-    ErrorCheck(const char* fn, int ln, const char* assertion, 
+    ErrorCheck(const char* fn, int ln, const char* assertion,
            const char* whereChecked,    // e.g., ClassName::methodName()
            const char* fmt ...) : Base(fn,ln)
     {
-        char buf[1024];
+        const int n = 1024;
+        char buf[n];
         va_list args;
         va_start(args, fmt);
-        vsprintf(buf, fmt, args);
+        vsnprintf(buf, n, fmt, args);
 
-        setMessage("Error detected by Simbody method " 
+        setMessage("Error detected by Simbody method "
             + std::string(whereChecked) + ": "
             + std::string(buf)
             + "\n  (Required condition '" + std::string(assertion) + "' was not met.)\n");
@@ -133,9 +136,9 @@ public:
 /// This is for reporting problems detected by checking the caller's supplied arguments
 /// to a SimTK API method. Messages should be suitable for SimTK API users. This is not
 /// intended for detection of internal bugs where a SimTK developer passed bad arguments
-/// to some internal routine -- use Assert instead for that. The exception message 
-/// accepts printf-style arguments and should contain useful information for the API user. 
-/// Don't throw this exception directly; use one of the family SimTK_APIARGCHECK and 
+/// to some internal routine -- use Assert instead for that. The exception message
+/// accepts printf-style arguments and should contain useful information for the API user.
+/// Don't throw this exception directly; use one of the family SimTK_APIARGCHECK and
 /// SimTK_APIARGCHECK_ALWAYS macros.
 class APIArgcheckFailed : public Base {
 public:
@@ -143,11 +146,12 @@ public:
                       const char* className, const char* methodName,
                       const char* fmt ...) : Base(fn,ln)
     {
-        char buf[1024];
+        const int n = 1024;
+        char buf[n];
         va_list args;
         va_start(args, fmt);
-        vsprintf(buf, fmt, args);
-        setMessage("Bad call to Simbody API method " 
+        vsnprintf(buf, n, fmt, args);
+        setMessage("Bad call to Simbody API method "
                    + std::string(className) + "::" + std::string(methodName) + "(): "
                    + std::string(buf)
                    + "\n  (Required condition '" + std::string(assertion) + "' was not met.)");
@@ -163,9 +167,10 @@ public:
                     long long lb, long long index, long long ub, const char* where)
       : Base(fn,ln)
     {
-        char buf[1024];
+        const int n = 1024;
+        char buf[n];
 
-        sprintf(buf, "Index out of range in %s: expected %lld <= %s < %lld but %s=%lld.",
+        snprintf(buf, n, "Index out of range in %s: expected %lld <= %s < %lld but %s=%lld.",
             where,lb,indexName,ub,indexName,index);
         setMessage(std::string(buf));
     }
@@ -178,9 +183,10 @@ public:
                    unsigned long long sz, unsigned long long maxsz, const char* where)
       : Base(fn,ln)
     {
-        char buf[1024];
+        const int n = 1024;
+        char buf[n];
 
-        sprintf(buf, "Size out of range in %s: expected 0 <= %s <= %llu but %s=%llu.",
+        snprintf(buf, n, "Size out of range in %s: expected 0 <= %s <= %llu but %s=%llu.",
             where,szName,maxsz,szName,sz);
         setMessage(std::string(buf));
     }
@@ -193,9 +199,10 @@ public:
                    unsigned long long sz, const char* where)
       : Base(fn,ln)
     {
-        char buf[1024];
+        const int n = 1024;
+        char buf[n];
 
-        sprintf(buf, "Size argument was negative in %s: expected 0 <= %s but %s=%llu.",
+        snprintf(buf, n, "Size argument was negative in %s: expected 0 <= %s but %s=%llu.",
             where,szName,szName,sz);
         setMessage(std::string(buf));
     }
@@ -205,13 +212,14 @@ public:
 class ValueOutOfRange : public Base {
 public:
     ValueOutOfRange(const char* fn, int ln, const char* valueName,
-                    double lowerBound, double value, double upperBound, 
+                    double lowerBound, double value, double upperBound,
                     const char* where)
       : Base(fn,ln)
     {
-        char buf[1024];
+        const int n = 1024;
+        char buf[n];
 
-        sprintf(buf, "Value out of range in %s: expected %g <= %s <= %g but %s=%g.",
+        snprintf(buf, n, "Value out of range in %s: expected %g <= %s <= %g but %s=%g.",
             where,lowerBound,valueName,upperBound,valueName,value);
         setMessage(std::string(buf));
     }
@@ -224,9 +232,10 @@ public:
                      double value, const char* where)
       : Base(fn,ln)
     {
-        char buf[1024];
+        const int n = 1024;
+        char buf[n];
 
-        sprintf(buf, "Expected non-negative value for %s in %s but got %g.",
+        snprintf(buf, n, "Expected non-negative value for %s in %s but got %g.",
             valueName,where,value);
         setMessage(std::string(buf));
     }
@@ -235,9 +244,9 @@ public:
 
 class UnimplementedMethod : public Base {
 public:
-    UnimplementedMethod(const char* fn, int ln, std::string methodName) 
+    UnimplementedMethod(const char* fn, int ln, std::string methodName)
     :   Base(fn,ln)
-    { 
+    {
         setMessage("The method " + methodName
             + "is not yet implemented. Please post to the Simbody forum"
               " to find a workaround or request implementation.");
@@ -247,11 +256,11 @@ public:
 
 class UnimplementedVirtualMethod : public Base {
 public:
-    UnimplementedVirtualMethod(const char* fn, int ln, 
-        std::string baseClass, std::string methodName) 
+    UnimplementedVirtualMethod(const char* fn, int ln,
+        std::string baseClass, std::string methodName)
         : Base(fn,ln)
-    { 
-        setMessage("The base class " + baseClass + 
+    {
+        setMessage("The base class " + baseClass +
             " dummy implementation of method " + methodName
             + "() was invoked because a derived class did not provide an implementation.");
     }
@@ -272,7 +281,7 @@ public:
     OperationNotAllowedOnView(const char* fn, int ln, const std::string& op) : Base(fn,ln)
     {
         setMessage("Operation '" + op + "' allowed only for owners, not views");
-    }   
+    }
     virtual ~OperationNotAllowedOnView() throw() { }
 };
 
@@ -281,7 +290,7 @@ public:
     OperationNotAllowedOnOwner(const char* fn, int ln, const std::string& op) : Base(fn,ln)
     {
         setMessage("Operation '" + op + "' allowed only for views, not owners");
-    }   
+    }
     virtual ~OperationNotAllowedOnOwner() throw() { }
 };
 
@@ -290,7 +299,7 @@ public:
     OperationNotAllowedOnNonconstReadOnlyView(const char* fn, int ln, const std::string& op) : Base(fn,ln)
     {
         setMessage("Operation '" + op + "' not allowed on non-const readonly view");
-    }   
+    }
     virtual ~OperationNotAllowedOnNonconstReadOnlyView() throw() { }
 };
 
@@ -300,7 +309,7 @@ public:
     Cant(const char* fn, int ln, const std::string& s) : Base(fn,ln)
     {
         setMessage("Can't perform operation: " + s);
-    }    
+    }
     virtual ~Cant() throw() { }
 };
 

--- a/SimTKcommon/src/String.cpp
+++ b/SimTKcommon/src/String.cpp
@@ -49,7 +49,7 @@ String::String(float r, const char* fmt) {
             "Unrecognized non-finite value %g.", (double)r);
         return;
     }
-    char buf[64]; sprintf(buf,fmt,r); (*this)=buf; 
+    char buf[64]; sprintf(buf,fmt,r); (*this)=buf;
 }
 
 String::String(double r, const char* fmt) {
@@ -60,7 +60,7 @@ String::String(double r, const char* fmt) {
             "Unrecognized non-finite value %g.", r);
         return;
     }
-    char buf[64]; sprintf(buf,fmt,r); (*this)=buf; 
+    char buf[64]; sprintf(buf,fmt,r); (*this)=buf;
 }
 
 static String cleanUp(const String& in) {
@@ -80,9 +80,9 @@ bool String::tryConvertToFloat(float& out) const {
     const String adjusted = cleanUp(*this);
     if (adjusted=="nan")  {out=NTraits<float>::getNaN();  return true;}
     if (   adjusted=="inf" || adjusted=="infinity"
-        || adjusted=="+inf" || adjusted=="+infinity") 
+        || adjusted=="+inf" || adjusted=="+infinity")
     {   out = NTraits<float>::getInfinity(); return true;}
-    if (adjusted=="-inf" || adjusted=="-infinity") 
+    if (adjusted=="-inf" || adjusted=="-infinity")
     {   out = -NTraits<float>::getInfinity(); return true;}
     std::istringstream sstream(adjusted);
     sstream >> out;
@@ -93,9 +93,9 @@ bool String::tryConvertToDouble(double& out) const {
     const String adjusted = cleanUp(*this);
     if (adjusted=="nan")  {out=NTraits<double>::getNaN();  return true;}
     if (   adjusted=="inf" || adjusted=="infinity"
-        || adjusted=="+inf" || adjusted=="+infinity") 
+        || adjusted=="+inf" || adjusted=="+infinity")
     {   out = NTraits<double>::getInfinity(); return true;}
-    if (adjusted=="-inf" || adjusted=="-infinity") 
+    if (adjusted=="-inf" || adjusted=="-infinity")
     {   out = -NTraits<double>::getInfinity(); return true;}
     std::istringstream sstream(adjusted);
     sstream >> out;

--- a/SimTKcommon/src/String.cpp
+++ b/SimTKcommon/src/String.cpp
@@ -49,7 +49,8 @@ String::String(float r, const char* fmt) {
             "Unrecognized non-finite value %g.", (double)r);
         return;
     }
-    char buf[64]; sprintf(buf,fmt,r); (*this)=buf;
+    const int n = 64;
+    char buf[n]; snprintf(buf,n,fmt,r); (*this)=buf;
 }
 
 String::String(double r, const char* fmt) {
@@ -60,7 +61,8 @@ String::String(double r, const char* fmt) {
             "Unrecognized non-finite value %g.", r);
         return;
     }
-    char buf[64]; sprintf(buf,fmt,r); (*this)=buf;
+    const int n = 64;
+    char buf[n]; snprintf(buf,n,fmt,r); (*this)=buf;
 }
 
 static String cleanUp(const String& in) {

--- a/SimTKmath/Optimizers/src/CFSQPOptimizer.cpp
+++ b/SimTKmath/Optimizers/src/CFSQPOptimizer.cpp
@@ -159,14 +159,14 @@ void CFSQPOptimizer::bindToCFSQPLibrary()
     if(!libraryHandle) {
         const char *msg=LoadLibraryErrorMessage();
         if(msg)
-            SimTK_THROW1(SimTK::Exception::Cant, std::string("Could not load CFSQP library '") + CFSQP_LIBRARY_NAME + "': " + msg); 
+            SimTK_THROW1(SimTK::Exception::Cant, std::string("Could not load CFSQP library '") + CFSQP_LIBRARY_NAME + "': " + msg);
         else
-            SimTK_THROW1(SimTK::Exception::Cant, std::string("Could not load CFSQP library '") + CFSQP_LIBRARY_NAME + "'"); 
+            SimTK_THROW1(SimTK::Exception::Cant, std::string("Could not load CFSQP library '") + CFSQP_LIBRARY_NAME + "'");
     }
 
     cfsqp_fptr = (CFSQP_FUNCTION)GetProcAddress(libraryHandle, "cfsqp");
     if(!cfsqp_fptr) {
-        SimTK_THROW1(SimTK::Exception::Cant, std::string("CFSQP library '") + CFSQP_LIBRARY_NAME + "' not valid (could not find 'cfsqp' symbol)"); 
+        SimTK_THROW1(SimTK::Exception::Cant, std::string("CFSQP library '") + CFSQP_LIBRARY_NAME + "' not valid (could not find 'cfsqp' symbol)");
     }
 
     std::cout << "Successfully linked to CFSQP library '" << CFSQP_LIBRARY_NAME << "'" << std::endl;
@@ -229,10 +229,11 @@ optimize(Vector &results)
     }
 
     if(diagnosticsLevel > 0) PrintInform(_inform,std::cout);
-    
+
     if (_inform != 0 && _inform != 3 && _inform != 4 && _inform != 8) {
-        char buf[1024];
-        sprintf(buf, "CFSQP failed with status = %d",_inform);
+        const int nbuf = 1024;
+        char buf[nbuf];
+        snprintf(buf, nbuf, "CFSQP failed with status = %d",_inform);
         SimTK_THROW1(SimTK::Exception::OptimizerFailed, SimTK::String(buf));
     }
 
@@ -386,7 +387,7 @@ computeConstraint(const SimTK::Vector &x, const bool new_coefficients, double &c
     bool cached_value_available = false;
     if(_cachedConstraintParameters.size()) {
         cached_value_available = true;
-        for(int i=0; i<nx; i++) 
+        for(int i=0; i<nx; i++)
             if(x[i] != _cachedConstraintParameters[i]) {
                 cached_value_available = false;
                 break;
@@ -397,7 +398,7 @@ computeConstraint(const SimTK::Vector &x, const bool new_coefficients, double &c
         status = getOptimizerSystem().constraintFunc(x,new_coefficients,_cachedConstraint);
         _cachedConstraintParameters.resize(nx);
         _cachedConstraintParameters = x;
-    } 
+    }
     c = _cachedConstraint[ic];
 #else
     SimTK::Vector allc(nc);
@@ -416,7 +417,7 @@ computeConstraintGradient(const SimTK::Vector &x, const bool new_coefficients, S
     bool cached_value_available = false;
     if(_cachedConstraintJacobianParameters.size()) {
         cached_value_available = true;
-        for(int i=0; i<nx; i++) 
+        for(int i=0; i<nx; i++)
             if(x[i] != _cachedConstraintJacobianParameters[i]) {
                 cached_value_available = false;
                 break;
@@ -427,7 +428,7 @@ computeConstraintGradient(const SimTK::Vector &x, const bool new_coefficients, S
         status = getOptimizerSystem().constraintJacobian(x,new_coefficients,_cachedConstraintJacobian);
         _cachedConstraintJacobianParameters.resize(nx);
         _cachedConstraintJacobianParameters = x;
-    } 
+    }
     for(int col=0;col<nx;col++) dcdx[col]=_cachedConstraintJacobian(ic,col);
 #else
     SimTK::Matrix jacobian(nc,nx);

--- a/SimTKmath/Optimizers/src/InteriorPointOptimizer.cpp
+++ b/SimTKmath/Optimizers/src/InteriorPointOptimizer.cpp
@@ -68,7 +68,7 @@ InteriorPointOptimizer::InteriorPointOptimizer( const OptimizerSystem& sys )
         if( n < 1 ) {
             const char* where = " InteriorPointOptimizer Initialization";
             const char* szName = "dimension";
-            SimTK_THROW5(SimTK::Exception::ValueOutOfRange, szName, 1, n, INT_MAX, where); 
+            SimTK_THROW5(SimTK::Exception::ValueOutOfRange, szName, 1, n, INT_MAX, where);
         }
 
         // Initialize arrays to store multipliers -- will be used for warm starts
@@ -91,7 +91,7 @@ InteriorPointOptimizer::InteriorPointOptimizer( const OptimizerSystem& sys )
         }
 
         firstOptimization = true;
-    } 
+    }
 
 
     SimTK::Real InteriorPointOptimizer::optimize(  Vector &results ) {
@@ -118,13 +118,13 @@ InteriorPointOptimizer::InteriorPointOptimizer( const OptimizerSystem& sys )
 
         SimTK::Real *x = &results[0];
 
-        IpoptProblem nlp = CreateIpoptProblem(n, x_L, x_U, m, g_L, g_U, nele_jac, 
-                           nele_hess, index_style, objectiveFuncWrapper, constraintFuncWrapper, 
+        IpoptProblem nlp = CreateIpoptProblem(n, x_L, x_U, m, g_L, g_U, nele_jac,
+                           nele_hess, index_style, objectiveFuncWrapper, constraintFuncWrapper,
                            gradientFuncWrapper, constraintJacobianWrapper, hessianWrapper);
 
         // If you want to verify which options are getting set in the optimizer, you can create a file ipopt.opt
         // with "print_user_options yes", and set print_level to (at least 1).  It will then print the options to the screen.
-        
+
         // sherm 100302: you have to set all of these tolerances to get IpOpt to change
         // its convergence criteria; see OptimalityErrorConvergenceCheck::CheckConvergence().
         // We'll set acceptable tolerances to the same value to disable them.
@@ -146,50 +146,50 @@ InteriorPointOptimizer::InteriorPointOptimizer( const OptimizerSystem& sys )
 
         int i;
         static const char *advancedRealOptions[] = {
-                                                    "compl_inf_tol", 
-                                                    "dual_inf_tol", 
-                                                    "constr_viol_tol", 
-                                                    "acceptable_tol", 
-                                                    "acceptable_compl_inf_tol", 
-                                                    "acceptable_constr_viol_tol", 
-                                                    "acceptable_dual_inf_tol", 
-                                                    "diverging_iterates_tol", 
-                                                    "barrier_tol_factor", 
-                                                    "obj_scaling_factor", 
-                                                    "nlp_scaling_max_gradient", 
-                                                    "bounds_relax_factor", 
-                                                    "recalc_y_feas_tol", 
-                                                    "mu_init", 
-                                                    "mu_max_fact", 
-                                                    "mu_max", 
-                                                    "mu_min", 
-                                                    "mu_linear_decrease_factor", 
-                                                    "mu_superlinear_decrease_factor", 
-                                                    "bound_frac", 
-                                                    "bound_push", 
-                                                    "bound_mult_init_val", 
-                                                    "constr_mult_init_max", 
-                                                    "constr_mult_init_val", 
-                                                    "warm_start_bound_push", 
-                                                    "warm_start_bound_frac", 
-                                                    "warm_start_mult_bound_push", 
-                                                    "warm_start_mult_init_max", 
-                                                    "recalc_y_feas_tol", 
-                                                    "expect_infeasible_problem_ctol", 
-                                                    "soft_resto_pderror_reduction_factor", 
-                                                    "required_infeasibility_reduction", 
-                                                    "bound_mult_reset_threshold", 
-                                                    "constr_mult_reset_threshold", 
-                                                    "max_hessian_perturbation", 
-                                                    "min_hessian_perturbation", 
-                                                    "first_hessian_perturbation", 
-                                                    "perturb_inc_fact_first", 
-                                                    "perturb_inc_fact", 
-                                                    "perturb_dec_fact", 
-                                                    "jacobian_reqularization_value", 
-                                                    "derivative_test_perturbation", 
-                                                    "derivative_test_tol", 
-                                                    0}; 
+                                                    "compl_inf_tol",
+                                                    "dual_inf_tol",
+                                                    "constr_viol_tol",
+                                                    "acceptable_tol",
+                                                    "acceptable_compl_inf_tol",
+                                                    "acceptable_constr_viol_tol",
+                                                    "acceptable_dual_inf_tol",
+                                                    "diverging_iterates_tol",
+                                                    "barrier_tol_factor",
+                                                    "obj_scaling_factor",
+                                                    "nlp_scaling_max_gradient",
+                                                    "bounds_relax_factor",
+                                                    "recalc_y_feas_tol",
+                                                    "mu_init",
+                                                    "mu_max_fact",
+                                                    "mu_max",
+                                                    "mu_min",
+                                                    "mu_linear_decrease_factor",
+                                                    "mu_superlinear_decrease_factor",
+                                                    "bound_frac",
+                                                    "bound_push",
+                                                    "bound_mult_init_val",
+                                                    "constr_mult_init_max",
+                                                    "constr_mult_init_val",
+                                                    "warm_start_bound_push",
+                                                    "warm_start_bound_frac",
+                                                    "warm_start_mult_bound_push",
+                                                    "warm_start_mult_init_max",
+                                                    "recalc_y_feas_tol",
+                                                    "expect_infeasible_problem_ctol",
+                                                    "soft_resto_pderror_reduction_factor",
+                                                    "required_infeasibility_reduction",
+                                                    "bound_mult_reset_threshold",
+                                                    "constr_mult_reset_threshold",
+                                                    "max_hessian_perturbation",
+                                                    "min_hessian_perturbation",
+                                                    "first_hessian_perturbation",
+                                                    "perturb_inc_fact_first",
+                                                    "perturb_inc_fact",
+                                                    "perturb_dec_fact",
+                                                    "jacobian_reqularization_value",
+                                                    "derivative_test_perturbation",
+                                                    "derivative_test_tol",
+                                                    0};
         Real value;
         for(i=0;advancedRealOptions[i];i++) {
             if(getAdvancedRealOption(advancedRealOptions[i],value))
@@ -197,21 +197,21 @@ InteriorPointOptimizer::InteriorPointOptimizer( const OptimizerSystem& sys )
         }
 
         static const std::string advancedStrOptions[] = {"nlp_scaling_method",
-                                                         "honor_original_bounds", 
-                                                         "check_derivatives_for_naninf", 
-                                                         "mu_strategy", 
-                                                         "mu_oracle", 
-                                                         "fixed_mu_oracle", 
-                                                         "alpha_for_y", 
-                                                         "recalc_y", 
-                                                         "expect_infeasible_problem", 
-                                                         "print_options_documentation", 
-                                                         "print_user_options", 
-                                                         "start_with_resto", 
-                                                         "evaluate_orig_obj_at_resto_trial", 
-                                                         "hessian_approximation", 
-                                                         "derivative_test", 
-                                                         ""}; 
+                                                         "honor_original_bounds",
+                                                         "check_derivatives_for_naninf",
+                                                         "mu_strategy",
+                                                         "mu_oracle",
+                                                         "fixed_mu_oracle",
+                                                         "alpha_for_y",
+                                                         "recalc_y",
+                                                         "expect_infeasible_problem",
+                                                         "print_options_documentation",
+                                                         "print_user_options",
+                                                         "start_with_resto",
+                                                         "evaluate_orig_obj_at_resto_trial",
+                                                         "hessian_approximation",
+                                                         "derivative_test",
+                                                         ""};
         std::string svalue;
         for(i=0;!advancedStrOptions[i].empty();i++) {
             if(getAdvancedStrOption(advancedStrOptions[i], svalue))
@@ -227,27 +227,27 @@ InteriorPointOptimizer::InteriorPointOptimizer( const OptimizerSystem& sys )
                                                          "limited_memory_max_history",
                                                          "limited_memory_max_skipping",
                                                          "derivative_test_print_all",
-                                                         0}; 
+                                                         0};
         int ivalue;
         for(i=0;advancedIntOptions[i];i++) {
             if(getAdvancedIntOption(advancedIntOptions[i], ivalue))
                 AddIpoptIntOption(nlp, advancedIntOptions[i], ivalue);
         }
 
-        // Only makes sense to do a warm start if this is not the first call to optimize() (since we need 
+        // Only makes sense to do a warm start if this is not the first call to optimize() (since we need
         // reasonable starting multiplier values)
         bool use_warm_start=false;
         if(getAdvancedBoolOption("warm_start", use_warm_start) && use_warm_start && !firstOptimization) {
             AddIpoptStrOption(nlp, "warm_start_init_point", "yes");
             AddIpoptStrOption(nlp, "warm_start_entire_iterate", "yes");
             //AddIpoptStrOption(nlp, "warm_start_same_structure", "yes"); // couldn't get this one to work
-        } 
+        }
 
         SimTK::Real obj;
 
         int status = IpoptSolve(nlp, x, NULL, &obj, mult_g, mult_x_L, mult_x_U, (void *)this );
 
-        FreeIpoptProblem(nlp); 
+        FreeIpoptProblem(nlp);
 
         // Only delete these if they aren't pointing to existing parameter limits
         if( !getOptimizerSystem().getHasLimits() ) {
@@ -259,8 +259,9 @@ InteriorPointOptimizer::InteriorPointOptimizer( const OptimizerSystem& sys )
             std::cout << "Ipopt: Solved to acceptable level" << std::endl;
         } else if (status != Solve_Succeeded) {
             if( status != NonIpopt_Exception_Thrown) {
-                char buf[1024];
-                sprintf(buf, "Ipopt: %s (status %d)",applicationReturnStatusToString(status).c_str(),status);
+                const int nbuf = 1024;
+                char buf[nbuf];
+                snprintf(buf, nbuf, "Ipopt: %s (status %d)",applicationReturnStatusToString(status).c_str(),status);
                 SimTK_THROW1(SimTK::Exception::OptimizerFailed, SimTK::String(buf));
             }
         }

--- a/SimTKmath/Optimizers/src/IpOpt/IpCompoundMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpCompoundMatrix.cpp
@@ -417,8 +417,9 @@ namespace SimTKIpopt
                              prefix.c_str(), irow, jcol);
         if (ConstComp(irow, jcol)) {
           DBG_ASSERT(name.size()<200);
-          char buffer[256];
-          sprintf(buffer, "%s[%2d][%2d]", name.c_str(), irow, jcol);
+          const int n = 256;
+          char buffer[n];
+          snprintf(buffer, n, "%s[%2d][%2d]", name.c_str(), irow, jcol);
           std::string term_name = buffer;
           ConstComp(irow, jcol)->Print(&jnlst, level, category, term_name,
                                        indent+1, prefix);

--- a/SimTKmath/Optimizers/src/IpOpt/IpCompoundSymMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpCompoundSymMatrix.cpp
@@ -190,8 +190,9 @@ namespace SimTKIpopt
                              prefix.c_str(), irow, jcol);
         if (ConstComp(irow,jcol)) {
           DBG_ASSERT(name.size()<200);
-          char buffer[256];
-          sprintf(buffer, "%s[%d][%d]", name.c_str(), irow, jcol);
+          const int n = 256;
+          char buffer[n];
+          snprintf(buffer, n, "%s[%d][%d]", name.c_str(), irow, jcol);
           std::string term_name = buffer;
           ConstComp(irow,jcol)->Print(&jnlst, level, category, term_name,
                                       indent+1, prefix);

--- a/SimTKmath/Optimizers/src/IpOpt/IpCompoundVector.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpCompoundVector.cpp
@@ -416,8 +416,9 @@ namespace SimTKIpopt
                            "%sComponent %d:\n", prefix.c_str(), i+1);
       if (ConstComp(i)) {
         DBG_ASSERT(name.size()<200);
-        char buffer[256];
-        sprintf(buffer, "%s[%2d]", name.c_str(), i);
+        const int n = 256;
+        char buffer[n];
+        snprintf(buffer, n, "%s[%2d]", name.c_str(), i);
         std::string term_name = buffer;
         ConstComp(i)->Print(&jnlst, level, category, term_name,
                             indent+1, prefix);

--- a/SimTKmath/Optimizers/src/IpOpt/IpLoqoMuOracle.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpLoqoMuOracle.cpp
@@ -72,10 +72,11 @@ namespace SimTKIpopt
                    "  Barrier parameter proposed by LOQO rule is %lf\n", mu);
 
     // DELETEME
-    char ssigma[40];
-    sprintf(ssigma, " sigma=%8.2e", sigma);
+    const int n = 40;
+    char ssigma[n];
+    snprintf(ssigma, n, " sigma=%8.2e", sigma);
     IpData().Append_info_string(ssigma);
-    sprintf(ssigma, " xi=%8.2e ", IpCq().curr_centrality_measure());
+    snprintf(ssigma, n, " xi=%8.2e ", IpCq().curr_centrality_measure());
     IpData().Append_info_string(ssigma);
 
     new_mu = Max(Min(mu_max, mu), mu_min);

--- a/SimTKmath/Optimizers/src/IpOpt/IpMultiVectorMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpMultiVectorMatrix.cpp
@@ -259,8 +259,9 @@ namespace SimTKIpopt
     for (Index i=0; i<NCols(); i++) {
       if (ConstVec(i)) {
         DBG_ASSERT(name.size()<200);
-        char buffer[256];
-        sprintf(buffer, "%s[%2d]", name.c_str(), i);
+        const int n = 256;
+        char buffer[n];
+        snprintf(buffer, n, "%s[%2d]", name.c_str(), i);
         std::string term_name = buffer;
         ConstVec(i)->Print(&jnlst, level, category, term_name,
                            indent+1, prefix);

--- a/SimTKmath/Optimizers/src/IpOpt/IpOptionsList.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpOptionsList.cpp
@@ -126,8 +126,9 @@ namespace SimTKIpopt
                                     bool allow_clobber, /* = true */
                                     bool dont_print /* = false */)
   {
-    char buffer[256];
-    sprintf(buffer, "%g", value);
+    const int n = 256;
+    char buffer[n];
+    snprintf(buffer, n, "%g", value);
 
     if (IsValid(reg_options_)) {
       SmartPtr<const RegisteredOption> option = reg_options_->GetOption(tag);
@@ -201,8 +202,9 @@ namespace SimTKIpopt
                                     bool allow_clobber, /* = true */
                                     bool dont_print /* = false */)
   {
-    char buffer[256];
-    sprintf(buffer, "%d", value);
+    const int n = 256;
+    char buffer[n];
+    snprintf(buffer, n, "%d", value);
 
     if (IsValid(reg_options_)) {
       SmartPtr<const RegisteredOption> option = reg_options_->GetOption(tag);
@@ -501,13 +503,14 @@ namespace SimTKIpopt
   void OptionsList::PrintList(std::string& list) const
   {
     list.clear();
-    char buffer[256];
-    sprintf(buffer, "%40s   %-20s %s\n", "Name", "Value", "# times used");
+    const int n = 256;
+    char buffer[n];
+    snprintf(buffer, n, "%40s   %-20s %s\n", "Name", "Value", "# times used");
     list += buffer;
     for(std::map< std::string, OptionValue >::const_iterator p = options_.begin();
         p != options_.end();
         ++p ) {
-      sprintf(buffer, "%40s = %-20s %6d\n", p->first.c_str(),
+      snprintf(buffer, n, "%40s = %-20s %6d\n", p->first.c_str(),
               p->second.Value().c_str(), p->second.Counter());
       list += buffer;
     }
@@ -516,8 +519,9 @@ namespace SimTKIpopt
   void OptionsList::PrintUserOptions(std::string& list) const
   {
     list.clear();
+    const int n = 256;
     char buffer[256];
-    sprintf(buffer, "%40s   %-20s %s\n", "Name", "Value", "used");
+    snprintf(buffer, n, "%40s   %-20s %s\n", "Name", "Value", "used");
     list += buffer;
     for(std::map< std::string, OptionValue >::const_iterator p = options_.begin();
         p != options_.end();
@@ -532,7 +536,7 @@ namespace SimTKIpopt
         else {
           used = no;
         }
-        sprintf(buffer, "%40s = %-20s %4s\n", p->first.c_str(),
+        snprintf(buffer, n, "%40s = %-20s %4s\n", p->first.c_str(),
                 p->second.Value().c_str(), used);
         list += buffer;
       }

--- a/SimTKmath/Optimizers/src/IpOpt/IpOrigIterationOutput.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpOrigIterationOutput.cpp
@@ -101,14 +101,15 @@ namespace SimTKIpopt
     char alpha_primal_char = IpData().info_alpha_primal_char();
     Number alpha_dual = IpData().info_alpha_dual();
     Number regu_x = IpData().info_regu_x();
-    char regu_x_buf[8];
+    const int n = 8;
+    char regu_x_buf[n];
     char dashes[]="   - ";
     char *regu_x_ptr;
     if (regu_x==.0) {
       regu_x_ptr = dashes;
     }
     else {
-      sprintf(regu_x_buf, "%5.1f", log10(regu_x));
+      snprintf(regu_x_buf, n, "%5.1f", log10(regu_x));
       regu_x_ptr = regu_x_buf;
     }
     Index ls_count = IpData().info_ls_count();

--- a/SimTKmath/Optimizers/src/IpOpt/IpProbingMuOracle.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpProbingMuOracle.cpp
@@ -149,8 +149,9 @@ namespace SimTKIpopt
     IpData().set_delta_aff(step);
     IpData().SetHaveAffineDeltas(true);
 
-    char ssigma[40];
-    sprintf(ssigma, " sigma=%8.2e", sigma);
+    const int n = 40;
+    char ssigma[n];
+    snprintf(ssigma, n, " sigma=%8.2e", sigma);
     IpData().Append_info_string(ssigma);
     //sprintf(ssigma, " xi=%8.2e ", IpCq().curr_centrality_measure());
     //IpData().Append_info_string(ssigma);

--- a/SimTKmath/Optimizers/src/IpOpt/IpQualityFunctionMuOracle.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpQualityFunctionMuOracle.cpp
@@ -520,8 +520,9 @@ namespace SimTKIpopt
 
     //#define tracequalityfunction
 #ifdef tracequalityfunction
-    char fname[100];
-    sprintf(fname, "qf_values_%d.dat", IpData().iter_count());
+    const int n1 = 100;
+    char fname[n1];
+    snprintf(fname, n1, "qf_values_%d.dat", IpData().iter_count());
     FILE* fid = fopen(fname, "w");
 
     Number sigma_1 = sigma_max_;
@@ -603,10 +604,11 @@ namespace SimTKIpopt
     curr_slack_s_U_ = NULL;
 
     // DELETEME
-    char ssigma[40];
-    sprintf(ssigma, " sigma=%8.2e", sigma);
+    const int n2 = 40;
+    char ssigma[n2];
+    snprintf(ssigma, n2, " sigma=%8.2e", sigma);
     IpData().Append_info_string(ssigma);
-    sprintf(ssigma, " qf=%d", count_qf_evals_);
+    snprintf(ssigma, n2, " qf=%d", count_qf_evals_);
     IpData().Append_info_string(ssigma);
     /*
     sprintf(ssigma, " xi=%8.2e ", IpCq().curr_centrality_measure());

--- a/SimTKmath/Optimizers/src/IpOpt/IpRegOptions.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRegOptions.cpp
@@ -255,8 +255,9 @@ namespace SimTKIpopt
 
   std::string RegisteredOption::MakeValidLatexNumber(Number value) const
   {
-    char buffer[256];
-    sprintf(buffer, "%g", value);
+    const int n = 256;
+    char buffer[n];
+    snprintf(buffer, n, "%g", value);
     std::string source = buffer;
     std::string dest;
 

--- a/SimTKmath/Optimizers/src/IpOpt/IpRestoIterationOutput.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpRestoIterationOutput.cpp
@@ -129,14 +129,15 @@ namespace SimTKIpopt
     char alpha_primal_char = IpData().info_alpha_primal_char();
     Number alpha_dual = IpData().info_alpha_dual();
     Number regu_x = IpData().info_regu_x();
-    char regu_x_buf[8];
+    const int n = 8;
+    char regu_x_buf[n];
     char dashes[]="   - ";
     char *regu_x_ptr;
     if (regu_x==.0) {
       regu_x_ptr = dashes;
     }
     else {
-      sprintf(regu_x_buf, "%5.1f", log10(regu_x));
+      snprintf(regu_x_buf, n, "%5.1f", log10(regu_x));
       regu_x_ptr = regu_x_buf;
     }
     Index ls_count = IpData().info_ls_count();

--- a/SimTKmath/Optimizers/src/IpOpt/IpStdAugSystemSolver.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpStdAugSystemSolver.cpp
@@ -172,8 +172,9 @@ namespace SimTKIpopt
       augrhs->SetComp(1, *rhs_sV[i]);
       augrhs->SetComp(2, *rhs_cV[i]);
       augrhs->SetComp(3, *rhs_dV[i]);
-      char buffer[16];
-      sprintf(buffer, "RHS[%2d]", i);
+      const int n = 16;
+      char buffer[n];
+      snprintf(buffer, n, "RHS[%2d]", i);
       augrhs->Print(Jnlst(), J_MOREVECTOR, J_LINEAR_ALGEBRA, buffer);
       augmented_rhsV[i] = GetRawPtr(augrhs);
     }
@@ -218,8 +219,9 @@ namespace SimTKIpopt
     if (retval==SYMSOLVER_SUCCESS) {
       Jnlst().Printf(J_DETAILED, J_LINEAR_ALGEBRA, "Factorization successful.\n");
       for (Index i=0; i<nrhs; i++) {
-        char buffer[16];
-        sprintf(buffer, "SOL[%2d]", i);
+        const int n = 16;
+        char buffer[n];
+        snprintf(buffer, n, "SOL[%2d]", i);
         augmented_solV[i]->Print(Jnlst(), J_MOREVECTOR, J_LINEAR_ALGEBRA,
                                  buffer);
       }

--- a/SimTKmath/Optimizers/src/IpOpt/IpSumMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSumMatrix.cpp
@@ -129,8 +129,9 @@ namespace SimTKIpopt
       jnlst.PrintfIndented(level, category, indent,
                            "%sTerm %d with factor %23.16e and the following matrix:\n",
                            prefix.c_str(), iterm, factors_[iterm]);
+      const int n = 256;
       char buffer[256];
-      sprintf(buffer, "Term: %d", iterm);
+      snprintf(buffer, n, "Term: %d", iterm);
       std::string name = buffer;
       matrices_[iterm]->Print(&jnlst, level, category, name, indent+1, prefix);
     }

--- a/SimTKmath/Optimizers/src/IpOpt/IpSumSymMatrix.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpSumSymMatrix.cpp
@@ -108,8 +108,9 @@ namespace SimTKIpopt
       jnlst.PrintfIndented(level, category, indent,
                            "%sTerm %d with factor %23.16e and the following matrix:\n",
                            prefix.c_str(), iterm, factors_[iterm]);
-      char buffer[256];
-      sprintf(buffer, "Term: %d", iterm);
+      const int n = 256;
+      char buffer[n];
+      snprintf(buffer, n, "Term: %d", iterm);
       std::string name = buffer;
       matrices_[iterm]->Print(&jnlst, level, category, name, indent+1, prefix);
     }

--- a/SimTKmath/Optimizers/src/IpOpt/IpTNLPAdapter.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpTNLPAdapter.cpp
@@ -292,8 +292,9 @@ namespace SimTKIpopt
           }
         }
         else if (lower_bound > upper_bound) {
-          char string[256];
-          sprintf(string, "There are inconsistent bounds on variable %d: lower = %25.16e and upper = %25.16e.", i, lower_bound, upper_bound);
+          const int nbuf1 = 256;
+          char string[nbuf1];
+          snprintf(string, nbuf1, "There are inconsistent bounds on variable %d: lower = %25.16e and upper = %25.16e.", i, lower_bound, upper_bound);
           delete [] x_not_fixed_map;
           delete [] x_fixed_map_tmp;
           delete [] x_l_map;
@@ -386,8 +387,9 @@ namespace SimTKIpopt
           n_c++;
         }
         else if (lower_bound > upper_bound) {
-          char string[256];
-          sprintf(string, "There are inconsistent bounds on constraint %d: lower = %25.16e and upper = %25.16e.", i, lower_bound, upper_bound);
+          const int nbuf2 = 256;
+          char string[nbuf2];
+          snprintf(string, nbuf2, "There are inconsistent bounds on constraint %d: lower = %25.16e and upper = %25.16e.", i, lower_bound, upper_bound);
           delete [] d_map;
           delete [] c_map;
           delete [] d_u_map;

--- a/SimTKmath/Optimizers/src/lbfgs.cpp
+++ b/SimTKmath/Optimizers/src/lbfgs.cpp
@@ -25,16 +25,16 @@
 
 
 #include "LBFGSOptimizer.h"
-#include "../src/Simmath_f2c.h" 
+#include "../src/Simmath_f2c.h"
 
-#include <iostream> 
+#include <iostream>
 #include <cmath>
 
 #ifdef _MSC_VER
 #pragma warning(disable:4996) // don't warn about strcat, sprintf, etc.
 #endif
 
-#define NUMBER_OF_CORRECTIONS 5   
+#define NUMBER_OF_CORRECTIONS 5
 
 #if SimTK_DEFAULT_PRECISION==1 // float
 #define DAXPY   saxpy_
@@ -103,7 +103,7 @@ void lbp1d_(char* msg, int* i);
 
 
 void SimTK::LBFGSOptimizer::lbfgs_
-   (int n, int m, SimTK::Real *x, SimTK::Real *f, 
+   (int n, int m, SimTK::Real *x, SimTK::Real *f,
     int *iprint, SimTK::Real *eps, SimTK::Real *xtol)
 {
 
@@ -279,8 +279,8 @@ void SimTK::LBFGSOptimizer::lbfgs_
 
 /*     INITIALIZE */
 /*     ---------- */
-
-    char buf[256];
+    const int nbuf = 256;
+    char buf[nbuf];
     Real *diag, *gradient, *w;
     int info;
     bool converged = false;
@@ -452,9 +452,9 @@ void SimTK::LBFGSOptimizer::lbfgs_
        }
 
        do {
-          SimTK::LBFGSOptimizer::mcsrch_(&n, x, f, gradient, 
-                                         &w[ispt + point * n], 
-                                         &stp, &ftol, xtol, 
+          SimTK::LBFGSOptimizer::mcsrch_(&n, x, f, gradient,
+                                         &w[ispt + point * n],
+                                         &stp, &ftol, xtol,
                                          &maxfev, &info, &nfev, diag);
           if (info == -1) {
               objectiveFuncWrapper( n, x, true, f, this);
@@ -464,8 +464,8 @@ void SimTK::LBFGSOptimizer::lbfgs_
               delete [] gradient;
               delete [] w;
               if (lb3_1.lp > 0) {
-                 SimTK_THROW1(SimTK::Exception::OptimizerFailed , 
-                 "LBFGS LINE SEARCH FAILED POSSIBLE CAUSES: FUNCTION OR GRADIENT ARE INCORRECT OR INCORRECT TOLERANCES");  
+                 SimTK_THROW1(SimTK::Exception::OptimizerFailed ,
+                 "LBFGS LINE SEARCH FAILED POSSIBLE CAUSES: FUNCTION OR GRADIENT ARE INCORRECT OR INCORRECT TOLERANCES");
               } else if( info == 0) {
                  SimTK_THROW1(SimTK::Exception::OptimizerFailed,
                  "LBFGS ERROR: IMPROPER INPUT PARAMETERS");
@@ -485,13 +485,13 @@ void SimTK::LBFGSOptimizer::lbfgs_
                  SimTK_THROW1(SimTK::Exception::OptimizerFailed,
                  "LBFGS ERROR: ROUNDING ERRORS PREVENT FURTHER PROGRESS.\n THERE MAY NOT BE A STEP WHICH SATISFIES THE SUFFICIENT DECREASE AND CURVATURE\n CONDITIONS. TOLERANCES MAY BE TOO SMALL.");
              } else if( info == 7){
-                 SimTK_THROW1(SimTK::Exception::OptimizerFailed , "Error in input parameters to MCSRCH"); 
+                 SimTK_THROW1(SimTK::Exception::OptimizerFailed , "Error in input parameters to MCSRCH");
              } else if( info == 8){
                  SimTK_THROW1(SimTK::Exception::OptimizerFailed , "THE SEARCH DIRECTION IS NOT A DESCENT DIRECTION");
              } else if( info == 9){
-                 SimTK_THROW1(SimTK::Exception::OptimizerFailed , "Error in input parameters to mcstep_"); 
+                 SimTK_THROW1(SimTK::Exception::OptimizerFailed , "Error in input parameters to mcstep_");
              } else {
-                 sprintf(buf, "LBFGS ERROR: info = %d \n",info );
+                 snprintf(buf, nbuf, "LBFGS ERROR: info = %d \n",info );
                  SimTK_THROW1(SimTK::Exception::OptimizerFailed, SimTK::String(buf) );
              }
           }
@@ -533,7 +533,7 @@ void SimTK::LBFGSOptimizer::lbfgs_
         converged = (gnorm <= *eps);
 
         if (iprint[0] > 0)
-            lb1_(iprint, &iter, &nfun, &gnorm, &n, &m, 
+            lb1_(iprint, &iter, &nfun, &gnorm, &n, &m,
                  x, f, gradient, &stp, &converged);
 
     }  // end while loop
@@ -663,7 +663,7 @@ void SimTK::LBFGSOptimizer::lbfgs_
 /* Subroutine */
 void SimTK::LBFGSOptimizer::mcsrch_
    (integer *n, Real *x, Real *f, Real *g, Real *s, Real *stp,
-    Real *ftol, Real *xtol, integer *maxfev, 
+    Real *ftol, Real *xtol, integer *maxfev,
     integer *info, integer *nfev, Real *wa)
 {
     /* Initialized data */
@@ -866,7 +866,7 @@ L30:
     for (j = 0; j < *n; ++j) {
         x[j] = wa[j] + *stp * s[j];
     }
-    
+
     objectiveFuncWrapper( *n, x, true, f, this);
     gradientFuncWrapper( *n,  x, false, g, this);
 
@@ -1265,7 +1265,7 @@ static void write50(Real* v, int n)
 //C     AMOUNT OF OUTPUT ARE CONTROLLED BY IPRINT.
 //C     -------------------------------------------------------------
 */
-void lb1_( int *iprint, int *iter, int *nfun, Real *gnorm, int *n, 
+void lb1_( int *iprint, int *iter, int *nfun, Real *gnorm, int *n,
            int *m, Real *x, Real *f, Real *g, Real *stp, bool *finish) /* bool*/
 {
   (void)m;

--- a/SimTKmath/include/simmath/internal/common.h
+++ b/SimTKmath/include/simmath/internal/common.h
@@ -1,5 +1,5 @@
 #ifndef SimTK_SIMMATH_COMMON_H_
-#define SimTK_SIMMATH_COMMON_H_ 
+#define SimTK_SIMMATH_COMMON_H_
 
 /* -------------------------------------------------------------------------- *
  *                        Simbody(tm): SimTKmath                              *
@@ -106,7 +106,7 @@ private:
 
 class IllegalLapackArg : public Base {
 public:
-        IllegalLapackArg( const char *fn, int ln, const char *lapackRoutine, 
+        IllegalLapackArg( const char *fn, int ln, const char *lapackRoutine,
                   int info ) : Base(fn, ln)
         {
         char buf[1024];
@@ -121,7 +121,7 @@ private:
 };
 class IncorrectArrayLength : public Base {
 public:
-        IncorrectArrayLength( const char *fn, int ln, const char *valueName, int length,  
+        IncorrectArrayLength( const char *fn, int ln, const char *valueName, int length,
                               const char *paramName, int paramValue, const char *where) : Base(fn, ln)
         {
         char buf[1024];
@@ -136,7 +136,7 @@ private:
 
 class SingularMatrix : public Base {
 public:
-        SingularMatrix( const char *fn, int ln, int index,  
+        SingularMatrix( const char *fn, int ln, int index,
                                const char *where) : Base(fn, ln)
         {
         char buf[1024];
@@ -151,7 +151,7 @@ private:
 
 class ConvergedFailed : public Base {
 public:
-        ConvergedFailed( const char *fn, int ln, const char *algorithm,  
+        ConvergedFailed( const char *fn, int ln, const char *algorithm,
                                const char *where) : Base(fn, ln)
         {
         char buf[1024];
@@ -165,7 +165,7 @@ private:
 
 class NotPositiveDefinite : public Base {
 public:
-        NotPositiveDefinite( const char *fn, int ln, int index,  
+        NotPositiveDefinite( const char *fn, int ln, int index,
                                const char *where) : Base(fn, ln)
         {
         char buf[1024];

--- a/SimTKmath/include/simmath/internal/common.h
+++ b/SimTKmath/include/simmath/internal/common.h
@@ -109,9 +109,10 @@ public:
         IllegalLapackArg( const char *fn, int ln, const char *lapackRoutine,
                   int info ) : Base(fn, ln)
         {
-        char buf[1024];
+        const int n = 1024;
+        char buf[n];
 
-        sprintf(buf, "SimTK internal error: %s called with an illegal value to"
+        snprintf(buf, n, "SimTK internal error: %s called with an illegal value to"
             " argument #%d.\nPlease report this at SimTK.org.",
             lapackRoutine, -info );
         setMessage(String(buf));
@@ -124,9 +125,10 @@ public:
         IncorrectArrayLength( const char *fn, int ln, const char *valueName, int length,
                               const char *paramName, int paramValue, const char *where) : Base(fn, ln)
         {
+        const int n = 1024;
         char buf[1024];
 
-        sprintf(buf, "Incorrect array length in %s : %s is %d and must equal %s which is %d",
+        snprintf(buf, n, "Incorrect array length in %s : %s is %d and must equal %s which is %d",
             where, valueName, length, paramName, paramValue );
         setMessage(String(buf));
 
@@ -139,9 +141,10 @@ public:
         SingularMatrix( const char *fn, int ln, int index,
                                const char *where) : Base(fn, ln)
         {
-        char buf[1024];
+        const int n = 1024;
+        char buf[n];
 
-        sprintf(buf, "%s failed because index %d in matrix was singular and factorization failed",
+        snprintf(buf, n, "%s failed because index %d in matrix was singular and factorization failed",
             where, index );
         setMessage(String(buf));
 
@@ -154,9 +157,10 @@ public:
         ConvergedFailed( const char *fn, int ln, const char *algorithm,
                                const char *where) : Base(fn, ln)
         {
-        char buf[1024];
+        const int n = 1024;
+        char buf[n];
 
-        sprintf(buf, "%s failed because %s failed to converge", where, algorithm );
+        snprintf(buf, n, "%s failed because %s failed to converge", where, algorithm );
         setMessage(String(buf));
 
         }
@@ -168,9 +172,10 @@ public:
         NotPositiveDefinite( const char *fn, int ln, int index,
                                const char *where) : Base(fn, ln)
         {
-        char buf[1024];
+        const int n = 1024;
+        char buf[n];
 
-        sprintf(buf, "%s failed because index %d in matrix was not positive definite and factorization failed ",
+        snprintf(buf, n, "%s failed because index %d in matrix was not positive definite and factorization failed ",
             where, index );
         setMessage(String(buf));
 

--- a/SimTKmath/src/MultibodyGraphMaker.cpp
+++ b/SimTKmath/src/MultibodyGraphMaker.cpp
@@ -21,7 +21,7 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-/* This is the implementation of MultibodyGraphMaker and its auxiliary classes. 
+/* This is the implementation of MultibodyGraphMaker and its auxiliary classes.
 */
 
 #include "SimTKcommon.h"
@@ -49,7 +49,7 @@ namespace SimTK {
 MultibodyGraphMaker::MultibodyGraphMaker()
 :   weldTypeName("weld"), freeTypeName("free")
 {   initialize(); }
- 
+
 
 //------------------------------------------------------------------------------
 //                          GET GROUND BODY NAME
@@ -73,13 +73,13 @@ addJointType(const std::string&     name,
              void*                  userRef)
 {
     if (!(0 <= numMobilities && numMobilities <= 6)) throw std::runtime_error
-       ("addJointType(): Illegal number of mobilities for joint type '" 
+       ("addJointType(): Illegal number of mobilities for joint type '"
         + name + "'");
 
     // Reject duplicate type name, and reserved type names.
     if (name==getWeldJointTypeName() || name==getFreeJointTypeName())
-        throw std::runtime_error("addJointType(): Joint type '" + name 
-            + "' is reserved (you can change the reserved names).");   
+        throw std::runtime_error("addJointType(): Joint type '" + name
+            + "' is reserved (you can change the reserved names).");
     std::map<std::string,int>::const_iterator p = jointTypeName2Num.find(name);
     if (p != jointTypeName2Num.end()) throw std::runtime_error
        ("addJointType(): Duplicate joint type '" + name + "'");
@@ -87,7 +87,7 @@ addJointType(const std::string&     name,
     const int jointTypeNum = (int)jointTypes.size(); // next available
     jointTypeName2Num[name] = jointTypeNum; // provide fast name lookup
 
-    jointTypes.push_back(JointType(name, numMobilities, 
+    jointTypes.push_back(JointType(name, numMobilities,
                                    haveGoodLoopJointAvailable, userRef));
 
     return jointTypeNum;
@@ -97,8 +97,8 @@ addJointType(const std::string&     name,
 //------------------------------------------------------------------------------
 //                                 ADD BODY
 //------------------------------------------------------------------------------
-void MultibodyGraphMaker::addBody(const std::string& name, 
-                                  double             mass, 
+void MultibodyGraphMaker::addBody(const std::string& name,
+                                  double             mass,
                                   bool               mustBeBaseBody,
                                   void*              userRef)
 {
@@ -176,22 +176,22 @@ void MultibodyGraphMaker::addJoint(const std::string&  name,
 
     const int typeNum = getJointTypeNum(type);
     if (typeNum < 0) throw std::runtime_error
-       ("addJoint(): Joint " + name + " had unrecognized joint type '" 
+       ("addJoint(): Joint " + name + " had unrecognized joint type '"
         + type + "'");
 
     const int parentBodyNum = getBodyNum(parentBodyName);
     if (parentBodyNum < 0) throw std::runtime_error
-       ("addJoint(): Joint " + name + " had unrecognized parent body '" 
+       ("addJoint(): Joint " + name + " had unrecognized parent body '"
         + parentBodyName + "'");
 
     const int childBodyNum = getBodyNum(childBodyName);
     if (childBodyNum < 0) throw std::runtime_error
-       ("addJoint(): Joint " + name + " had unrecognized child body '" 
+       ("addJoint(): Joint " + name + " had unrecognized child body '"
         + childBodyName + "'");
 
     const int jointNum = (int)joints.size(); // next available slot
     jointName2Num[name] = jointNum; // provide fast name lookup
-  
+
     joints.push_back(Joint(name, typeNum, parentBodyNum, childBodyNum,
                            mustBeLoopJoint, userRef));
 
@@ -212,20 +212,20 @@ bool MultibodyGraphMaker::deleteJoint(const std::string&  name)
     const int jointNum = p->second;
     jointName2Num.erase(p);
 
-    std::vector<int>& jointsAsParent = 
+    std::vector<int>& jointsAsParent =
         updBody(joints[jointNum].parentBodyNum).jointsAsParent;
-    std::vector<int>::iterator it = 
+    std::vector<int>::iterator it =
         std::find(jointsAsParent.begin(), jointsAsParent.end(), jointNum);
     if (it == jointsAsParent.end()) throw std::runtime_error
-        ("deleteJoint(): Joint " + name + 
+        ("deleteJoint(): Joint " + name +
          " doesn't exist in jointsAsParent of parent body ");
     jointsAsParent.erase(it);
 
-    std::vector<int>& jointsAsChild = 
+    std::vector<int>& jointsAsChild =
         updBody(joints[jointNum].childBodyNum).jointsAsChild;
     it = std::find(jointsAsChild.begin(), jointsAsChild.end(), jointNum);
     if (it == jointsAsChild.end()) throw std::runtime_error
-        ("deleteJoint(): Joint " + name + 
+        ("deleteJoint(): Joint " + name +
          " doesn't exist in jointsAsChild of child body ");
     jointsAsChild.erase(it);
 
@@ -262,7 +262,7 @@ void MultibodyGraphMaker::generateGraph() {
     //
     // While we're at it, look for dangling massless bodies -- they are only
     // allowed if they were originally connected to at least two other bodies
-    // by given tree-eligible joints, or if they are connected by a weld 
+    // by given tree-eligible joints, or if they are connected by a weld
     // joint and thus have no mobility.
     // TODO: "must be loop joint" joints shouldn't count but we're not
     // checking.
@@ -272,25 +272,25 @@ void MultibodyGraphMaker::generateGraph() {
         if (body.mass == 0) {
             if (nJoints == 0) {
                 throw std::runtime_error(
-                    "generateGraph(): body " + body.name + 
+                    "generateGraph(): body " + body.name +
                     " is massless but free (no joint). Must be internal or"
                     " welded to a massful body.");
             }
             if (nJoints == 1) {
-                const int jnum = body.jointsAsChild.empty() 
-                                    ? body.jointsAsParent[0] 
+                const int jnum = body.jointsAsChild.empty()
+                                    ? body.jointsAsParent[0]
                                     : body.jointsAsChild[0];
                 const Joint& joint = getJoint(jnum);
                 const JointType& jtype = getJointType(joint.jointTypeNum);
                 if (jtype.numMobilities > 0) {
                     throw std::runtime_error(
-                        "generateGraph(): body " + body.name + 
+                        "generateGraph(): body " + body.name +
                         " is massless but not internal and not welded to"
                         " a massful body.");
-                }                               
+                }
             }
         }
-        if (nJoints==0 || (body.mustBeBaseBody && !bodiesAreConnected(bn, 0))) 
+        if (nJoints==0 || (body.mustBeBaseBody && !bodiesAreConnected(bn, 0)))
             connectBodyToGround(bn);
     }
 
@@ -301,7 +301,7 @@ void MultibodyGraphMaker::generateGraph() {
     while (true) {
         growTree();
         const int newBaseBody = chooseNewBaseBody();
-        if (newBaseBody < 0) 
+        if (newBaseBody < 0)
             break; // all bodies are in the tree
         // Add joint to Ground.
         connectBodyToGround(newBaseBody);
@@ -346,7 +346,7 @@ void MultibodyGraphMaker::dumpGraph(std::ostream& o) const {
     o << "\n" << getNumBodies() << " BODIES:\n";
     for (int i=0; i < getNumBodies(); ++i) {
         const MultibodyGraphMaker::Body& body  = getBody(i);
-        sprintf(buf, "%2d %2d: %s mass=%g mob=%d master=%d %s\n", 
+        sprintf(buf, "%2d %2d: %s mass=%g mob=%d master=%d %s\n",
             i, body.level,
             body.name.c_str(), body.mass, body.mobilizer, body.master,
             body.mustBeBaseBody?"MUST BE BASE BODY":"");
@@ -384,9 +384,9 @@ void MultibodyGraphMaker::dumpGraph(std::ostream& o) const {
         const MultibodyGraphMaker::Body&      inb   = getBody(mo.inboardBody);
         const MultibodyGraphMaker::Body&      outb  = getBody(mo.outboardBody);
         sprintf(buf, "%2d %2d: %20s %20s->%-20s %10s %2d %3s\n",
-            i, mo.level, joint.name.c_str(), 
-            inb.name.c_str(), outb.name.c_str(), 
-            mo.getJointTypeName().c_str(), 
+            i, mo.level, joint.name.c_str(),
+            inb.name.c_str(), outb.name.c_str(),
+            mo.getJointTypeName().c_str(),
             mo.joint, mo.isReversed?"REV":"");
         o << buf;
     }
@@ -443,7 +443,7 @@ int MultibodyGraphMaker::splitBody(int masterBodyNum) {
 //                          CHOOSE NEW BASE BODY
 //------------------------------------------------------------------------------
 // We've tried to build the tree but might not have succeeded in using
-// all the bodies. That means we'll have to connect one of them to Ground. 
+// all the bodies. That means we'll have to connect one of them to Ground.
 // Select the best unattached body to use as a base body, or -1 if all bodies
 // are already included in the spanning tree. We hope to find a body that is
 // serving as a parent but has never been listed as a child; that is crying out
@@ -455,9 +455,9 @@ int MultibodyGraphMaker::chooseNewBaseBody() const {
     // Skip the Ground body.
     for (int bx=1; bx < getNumBodies(); ++bx) {
         const Body& body = bodies[bx];
-        if (body.isInTree()) 
+        if (body.isInTree())
             continue; // unavailable
-        if (parentOnlyBodySeen && !body.jointsAsChild.empty()) 
+        if (parentOnlyBodySeen && !body.jointsAsChild.empty())
             continue; // already seen parent-only bodies; no need for this one
         if (!parentOnlyBodySeen && body.jointsAsChild.empty()) {
             // This is our first parent-only body; it is automatically the
@@ -466,7 +466,7 @@ int MultibodyGraphMaker::chooseNewBaseBody() const {
             bestBody = bx; nChildren = (int)body.jointsAsParent.size();
         } else { // Keep the body that has the most children.
             if ((int)body.jointsAsParent.size() > nChildren) {
-                bestBody  = bx; 
+                bestBody  = bx;
                 nChildren = (int)body.jointsAsParent.size();
             }
         }
@@ -485,7 +485,7 @@ void MultibodyGraphMaker::connectBodyToGround(int bodyNum) {
     const Body& body = getBody(bodyNum);
     assert(!body.isInTree());
     const std::string jointName = "#" + getGroundBodyName() + "_" + body.name;
-    addJoint(jointName, getFreeJointTypeName(), 
+    addJoint(jointName, getFreeJointTypeName(),
                     getGroundBodyName(), body.name, false, NULL);
     updJoint(jointName).isAddedBaseJoint = true;
 }
@@ -495,8 +495,8 @@ void MultibodyGraphMaker::connectBodyToGround(int bodyNum) {
 //                          ADD MOBILIZER FOR JOINT
 //------------------------------------------------------------------------------
 // We've already determined this joint is eligible to become a mobilizer; now
-// make it so. Given a joint for which either the parent or child is in the 
-// tree, but not both, create a mobilizer implementing this joint and attaching 
+// make it so. Given a joint for which either the parent or child is in the
+// tree, but not both, create a mobilizer implementing this joint and attaching
 // the unattached body (which will be the mobilizer's outboard body) to the
 // tree. The mobilizer number is returned and also recorded in the joint
 // and outboard body.
@@ -511,13 +511,13 @@ int MultibodyGraphMaker::addMobilizerForJoint(int jointNum) {
     assert(parent.isInTree() ^ child.isInTree());
 
     const int mobNum = (int)mobilizers.size(); // next available
-    if (parent.isInTree()) { 
+    if (parent.isInTree()) {
         // Child is outboard body (forward joint)
         child.level = parent.level + 1;
         mobilizers.push_back(Mobilizer(jointNum,child.level,
                                        pNum,cNum,false,this));
         child.mobilizer = mobNum;
-    } else if (child.isInTree()) { 
+    } else if (child.isInTree()) {
         // Parent is outboard body (reverse joint)
         parent.level = child.level + 1;
         mobilizers.push_back(Mobilizer(jointNum,parent.level,
@@ -532,10 +532,10 @@ int MultibodyGraphMaker::addMobilizerForJoint(int jointNum) {
 //------------------------------------------------------------------------------
 //                   FIND HEAVIEST UNASSIGNED FORWARD JOINT
 //------------------------------------------------------------------------------
-// Starting with a given body that is in the tree already, look at its 
-// unassigned children (meaning bodies connected by joints that aren't 
-// mobilizers yet) and return the joint connecting it to the child with the 
-// largest mass. (The idea is that this would be a good direction to extend the 
+// Starting with a given body that is in the tree already, look at its
+// unassigned children (meaning bodies connected by joints that aren't
+// mobilizers yet) and return the joint connecting it to the child with the
+// largest mass. (The idea is that this would be a good direction to extend the
 // chain.) Return -1 if this body has no children.
 int MultibodyGraphMaker::
 findHeaviestUnassignedForwardJoint(int inboardBody) const {
@@ -562,8 +562,8 @@ findHeaviestUnassignedForwardJoint(int inboardBody) const {
 //------------------------------------------------------------------------------
 //                   FIND HEAVIEST UNASSIGNED REVERSE JOINT
 //------------------------------------------------------------------------------
-// Same as previous method, but now we are looking for unassigned joints where 
-// the given body serves as the child so we would have to reverse the joint to 
+// Same as previous method, but now we are looking for unassigned joints where
+// the given body serves as the child so we would have to reverse the joint to
 // add it to the tree. (This is less desirable so is a fallback.)
 int MultibodyGraphMaker::
 findHeaviestUnassignedReverseJoint(int inboardBody) const {
@@ -590,24 +590,24 @@ findHeaviestUnassignedReverseJoint(int inboardBody) const {
 //------------------------------------------------------------------------------
 //                                 GROW TREE
 //------------------------------------------------------------------------------
-// Process unused joints for which one body is in the tree (at level h) and the 
-// other is not. Add the other body to the tree at level h+1, marking the joint 
-// as forward (other body is child) or reverse (other body is parent). Repeat 
-// until no changes are made. Does not assign loop joints or any bodies that 
-// don't have a path to Ground. Extend the multibody tree starting with the 
-// lowest-level eligible joints and moving outwards. We're doing this 
-// breadth-first so that we get roughly even-length chains and we'll stop at 
-// the first level at which we fail to find any joint. If we fail to consume 
-// all the bodies, the caller will have to add a level 1 joint to attach a 
+// Process unused joints for which one body is in the tree (at level h) and the
+// other is not. Add the other body to the tree at level h+1, marking the joint
+// as forward (other body is child) or reverse (other body is parent). Repeat
+// until no changes are made. Does not assign loop joints or any bodies that
+// don't have a path to Ground. Extend the multibody tree starting with the
+// lowest-level eligible joints and moving outwards. We're doing this
+// breadth-first so that we get roughly even-length chains and we'll stop at
+// the first level at which we fail to find any joint. If we fail to consume
+// all the bodies, the caller will have to add a level 1 joint to attach a
 // previously-disconnected base body to Ground and then call this again.
 //
-// We violate the breadth-first heuristic to avoid ending a branch with a 
+// We violate the breadth-first heuristic to avoid ending a branch with a
 // massless body, unless it is welded to its parent. If we add a mobile massless
-// body, we'll keep going out along its branch until we hit a massful body. It 
-// is a disaster if we fail to find a massful body because a tree that 
-// terminates in a mobile massless body will generate a singular mass matrix. 
-// We'll throw an exception in that case, but note that this may just be a 
-// failure of the heuristic; there may be some tree that could have avoided the 
+// body, we'll keep going out along its branch until we hit a massful body. It
+// is a disaster if we fail to find a massful body because a tree that
+// terminates in a mobile massless body will generate a singular mass matrix.
+// We'll throw an exception in that case, but note that this may just be a
+// failure of the heuristic; there may be some tree that could have avoided the
 // terminal massless body but we failed to discover it.
 //
 // TODO: keep a list of unprocessed joints so we don't have to go through
@@ -632,7 +632,7 @@ void MultibodyGraphMaker::growTree() {
                     if (mob.getLevel() == level)
                         anyMobilizerAdded = true; // Added one at level.
                 }
-                continue; 
+                continue;
             }
             if (joint.mustBeLoopJoint) continue; // can't be a tree joint
             const Body& parent = getBody(joint.parentBodyNum);
@@ -643,14 +643,14 @@ void MultibodyGraphMaker::growTree() {
                 if (parent.level != level-1) continue; // not time yet
             } else { // child is in tree
                 if (child.level != level-1) continue; // not time yet
-            } 
+            }
             addMobilizerForJoint(jNum);
             jointsAdded.insert(jNum);
             anyMobilizerAdded = true;
 
-            // We just made joint jNum a mobilizer. If its outboard body 
-            // is massless and the mobilizer was not a weld, we need to keep 
-            // extending this branch of the tree until we can end it with a 
+            // We just made joint jNum a mobilizer. If its outboard body
+            // is massless and the mobilizer was not a weld, we need to keep
+            // extending this branch of the tree until we can end it with a
             // massful body.
             const Body& outboard = getBody(mobilizers.back().outboardBody);
             const JointType& jtype = getJointType(joint.jointTypeNum);
@@ -676,7 +676,7 @@ void MultibodyGraphMaker::growTree() {
                     break;
                 }
 
-                // Couldn't find a massful body to add. Add another massless 
+                // Couldn't find a massful body to add. Add another massless
                 // body (if there is one) and keep trying.
                 if (jfwd >= 0) {
                     addMobilizerForJoint(jfwd);
@@ -693,13 +693,13 @@ void MultibodyGraphMaker::growTree() {
                 // We're ending this chain with a massless body; not good.
                 throw std::runtime_error("growTree(): algorithm produced an"
                     " invalid tree containing a terminal massless body ("
-                    + getBody(bNum).name + "). This may be due to an invalid" 
+                    + getBody(bNum).name + "). This may be due to an invalid"
                     " model or failure of heuristics. In the latter case you"
                     " may be able to get a valid tree by forcing a different"
                     " loop break or changing parent->child ordering.");
             }
         }
-        if (!anyMobilizerAdded) 
+        if (!anyMobilizerAdded)
             break;
     }
 }
@@ -710,9 +710,9 @@ void MultibodyGraphMaker::growTree() {
 //------------------------------------------------------------------------------
 // Find any remaining unused joints, which will have both parent and
 // child bodies already in the tree. This includes joints that the user
-// told us must be loop joints, and ones picked by the algorithm. 
+// told us must be loop joints, and ones picked by the algorithm.
 // For each of those, implement the joint with a loop constraint if one
-// is provided, otherwise implement it with a mobilizer and split off a 
+// is provided, otherwise implement it with a mobilizer and split off a
 // slave body from the child body, use that slave as the outboard body
 // for the mobilizer, and add a weld constraint to reconnect the slave to
 // its master (the original child body).
@@ -731,7 +731,7 @@ void MultibodyGraphMaker::breakLoops() {
             continue;
         }
 
-        // No usable loop constraint for this type of joint. Add a new slave 
+        // No usable loop constraint for this type of joint. Add a new slave
         // body so we can use a mobilizer. (Body references are invalidated here
         // since we're adding a new body -- don't reuse them.)
         const int sx = splitBody(cx);
@@ -771,7 +771,7 @@ bool MultibodyGraphMaker::bodiesAreConnected(int b1, int b2) const {
 //------------------------------------------------------------------------------
 // Restore the Body to its state prior to generateGraph()
 void MultibodyGraphMaker::Body::forgetGraph(MultibodyGraphMaker& graph)
-{   
+{
     level = -1;
     mobilizer = -1;
     master = -1;

--- a/SimTKmath/src/MultibodyGraphMaker.cpp
+++ b/SimTKmath/src/MultibodyGraphMaker.cpp
@@ -340,13 +340,14 @@ void MultibodyGraphMaker::clearGraph() {
 //                               DUMP GRAPH
 //------------------------------------------------------------------------------
 void MultibodyGraphMaker::dumpGraph(std::ostream& o) const {
-    char buf[1024];
+    const int nbuf = 1024;
+    char buf[nbuf];
     o << "\nMULTIBODY GRAPH\n";
     o <<   "---------------\n";
     o << "\n" << getNumBodies() << " BODIES:\n";
     for (int i=0; i < getNumBodies(); ++i) {
         const MultibodyGraphMaker::Body& body  = getBody(i);
-        sprintf(buf, "%2d %2d: %s mass=%g mob=%d master=%d %s\n",
+        snprintf(buf, nbuf, "%2d %2d: %s mass=%g mob=%d master=%d %s\n",
             i, body.level,
             body.name.c_str(), body.mass, body.mobilizer, body.master,
             body.mustBeBaseBody?"MUST BE BASE BODY":"");
@@ -366,7 +367,7 @@ void MultibodyGraphMaker::dumpGraph(std::ostream& o) const {
     o << "\n" << getNumJoints() << " JOINTS:\n";
     for (int i=0; i < getNumJoints(); ++i) {
         const MultibodyGraphMaker::Joint& joint = getJoint(i);
-        sprintf(buf, "%2d %2d: %20s %20s->%-20s %10s loopc=%2d %s %s\n",
+        snprintf(buf, nbuf, "%2d %2d: %20s %20s->%-20s %10s loopc=%2d %s %s\n",
             i, joint.mobilizer, joint.name.c_str(),
             getBody(joint.parentBodyNum).name.c_str(),
             getBody(joint.childBodyNum).name.c_str(),
@@ -383,7 +384,7 @@ void MultibodyGraphMaker::dumpGraph(std::ostream& o) const {
         const MultibodyGraphMaker::Joint&     joint = getJoint(mo.joint);
         const MultibodyGraphMaker::Body&      inb   = getBody(mo.inboardBody);
         const MultibodyGraphMaker::Body&      outb  = getBody(mo.outboardBody);
-        sprintf(buf, "%2d %2d: %20s %20s->%-20s %10s %2d %3s\n",
+        snprintf(buf, nbuf, "%2d %2d: %20s %20s->%-20s %10s %2d %3s\n",
             i, mo.level, joint.name.c_str(),
             inb.name.c_str(), outb.name.c_str(),
             mo.getJointTypeName().c_str(),
@@ -396,7 +397,7 @@ void MultibodyGraphMaker::dumpGraph(std::ostream& o) const {
         const MultibodyGraphMaker::LoopConstraint& lc = getLoopConstraint(i);
         const MultibodyGraphMaker::Body parent = getBody(lc.parentBody);
         const MultibodyGraphMaker::Body child  = getBody(lc.childBody);
-        sprintf(buf, "%d: %s parent=%s child=%s jointNum=%d\n",
+        snprintf(buf, nbuf, "%d: %s parent=%s child=%s jointNum=%d\n",
             i, lc.type.c_str(), parent.name.c_str(), child.name.c_str(),
             lc.joint);
         o << buf;

--- a/Simbody/Visualizer/src/VisualizerProtocol.cpp
+++ b/Simbody/Visualizer/src/VisualizerProtocol.cpp
@@ -55,7 +55,7 @@ using namespace std;
 #endif
 
 // gcc 4.4.3 complains bitterly if you don't check the return
-// status from the write() system call. This avoids those 
+// status from the write() system call. This avoids those
 // warnings and maybe, someday, will catch an error.
 #define WRITE(pipeno, buf, len) \
    {int status=WRITEFUNC((pipeno), (buf), (len)); \
@@ -104,7 +104,7 @@ static int createPipeViz2Sim(int viz2sim[2]) {
 // this platform. We take two executables to try in order,
 // and return after the first one succeeds. If neither works, we throw
 // an error that is hopefully helful.
-static void spawnViz(const Array_<String>& searchPath, const String& appName, 
+static void spawnViz(const Array_<String>& searchPath, const String& appName,
                      int sim2vizPipe[2], int viz2simPipe[2])
 {
     int status;
@@ -120,7 +120,7 @@ static void spawnViz(const Array_<String>& searchPath, const String& appName,
     intptr_t handle;
     for (unsigned i=0; i < searchPath.size(); ++i) {
         exePath = searchPath[i] + appName;
-        handle = _spawnl(P_NOWAIT, exePath.c_str(), appName.c_str(), 
+        handle = _spawnl(P_NOWAIT, exePath.c_str(), appName.c_str(),
                          vizReadFromSim, vizWriteToSim, (const char*)0);
         if (handle != -1) {
             // success: visualizer is running
@@ -138,8 +138,8 @@ static void spawnViz(const Array_<String>& searchPath, const String& appName,
         close(viz2simPipe[0]); // read end(belongs to simulator)
         for (unsigned i=0; i < searchPath.size(); ++i) {
             exePath = searchPath[i] + appName;
-            status = execl(exePath.c_str(), appName.c_str(), 
-                           vizReadFromSim, vizWriteToSim, (const char*)0); 
+            status = execl(exePath.c_str(), appName.c_str(),
+                           vizReadFromSim, vizWriteToSim, (const char*)0);
             // if we get here the execl() failed
         }
         // fall through -- we failed on every try
@@ -161,7 +161,7 @@ static void spawnViz(const Array_<String>& searchPath, const String& appName,
 
         SimTK_ERRCHK4_ALWAYS(status == 0, "VisualizerProtocol::ctor()",
             "Unable to spawn executable '%s' from directories:\n%s"
-            "Final system error was errno=%d (%s).", 
+            "Final system error was errno=%d (%s).",
             appName.c_str(), failedPath.c_str(), errno, strerror(errno));
     }
 }
@@ -175,7 +175,7 @@ static void readDataFromPipe(int srcPipe, unsigned char* buffer, int bytes) {
     while (totalRead < bytes) {
         auto retval = READ(srcPipe, buffer + totalRead, bytes - totalRead);
         SimTK_ERRCHK4_ALWAYS(retval!=-1, "VisualizerProtocol",
-            "An attempt to read() %d bytes from pipe %d failed with errno=%d (%s).", 
+            "An attempt to read() %d bytes from pipe %d failed with errno=%d (%s).",
             bytes - totalRead, srcPipe, errno, strerror(errno));
         // The pipe was closed, perhaps because simbody-visualizer was closed,
         // or shutdownGUI() or ~VisualizerProtocol() was called.
@@ -249,7 +249,7 @@ static void listenForVisualizerEvents(Visualizer& visualizer) {
 }
 
 VisualizerProtocol::VisualizerProtocol
-   (Visualizer& visualizer, const Array_<String>& userSearchPath) 
+   (Visualizer& visualizer, const Array_<String>& userSearchPath)
 {
     // Launch the GUI application. We'll first look for one in the same
     // directory as the running executable; then if that doesn't work we'll
@@ -410,14 +410,14 @@ void VisualizerProtocol::shakeHandsWithGUI(int toGUIPipe, int fromGUIPipe) {
 
 void VisualizerProtocol::shutdownGUI() {
     // Don't wait for scene completion; kill GUI now.
-    
+
     // We no longer need to listen for events from the GUI. Stop the listener
     // thread before writing to the out pipe, because attempting to write to
     // the pipe may throw an exception. Shutting down the listener thread was
     // added to solve an issue with OpenSim MATLAB bindings, wherein MATLAB
     // would use more and more CPU each time a Visualizer was created.
     stopListeningIfNecessary();
-    
+
     char command = Shutdown;
     WRITE(outPipe, &command, 1);
 }
@@ -546,11 +546,11 @@ void VisualizerProtocol::drawPolygonalMesh(const PolygonalMesh& mesh, const Tran
             faces.push_back((unsigned short) newIndex);
         }
     }
-    SimTK_ERRCHK1_ALWAYS(vertices.size() <= 65535*3, 
+    SimTK_ERRCHK1_ALWAYS(vertices.size() <= 65535*3,
         "VisualizerProtocol::drawPolygonalMesh()",
         "Can't display a DecorativeMesh with more than 65535 vertices;"
         " received one with %llu.", (unsigned long long)vertices.size());
-    SimTK_ERRCHK1_ALWAYS(faces.size() <= 65535*3, 
+    SimTK_ERRCHK1_ALWAYS(faces.size() <= 65535*3,
         "VisualizerProtocol::drawPolygonalMesh()",
         "Can't display a DecorativeMesh with more than 65535 vertices;"
         " received one with %llu.", (unsigned long long)faces.size());
@@ -559,7 +559,7 @@ void VisualizerProtocol::drawPolygonalMesh(const PolygonalMesh& mesh, const Tran
     SimTK_ERRCHK_ALWAYS(index <= 65535,
         "VisualizerProtocol::drawPolygonalMesh()",
         "Too many unique DecorativeMesh objects; max is 65535.");
-    
+
     meshes[impl] = (unsigned short)index;    // insert new mesh
     WRITE(outPipe, &DefineMesh, 1);
     unsigned short numVertices = (unsigned short)(vertices.size()/3);
@@ -573,12 +573,12 @@ void VisualizerProtocol::drawPolygonalMesh(const PolygonalMesh& mesh, const Tran
 }
 
 void VisualizerProtocol::
-drawMesh(const Transform& X_GM, const Vec3& scale, const Vec4& color, 
+drawMesh(const Transform& X_GM, const Vec3& scale, const Vec4& color,
          short representation, unsigned short meshIndex, unsigned short resolution)
 {
-    char command = (representation == DecorativeGeometry::DrawPoints 
-                    ? AddPointMesh 
-                    : (representation == DecorativeGeometry::DrawWireframe 
+    char command = (representation == DecorativeGeometry::DrawPoints
+                    ? AddPointMesh
+                    : (representation == DecorativeGeometry::DrawWireframe
                         ? AddWireframeMesh : AddSolidMesh));
     WRITE(outPipe, &command, 1);
     float buffer[13];
@@ -622,7 +622,7 @@ drawLine(const Vec3& end1, const Vec3& end2, const Vec4& color, Real thickness)
 }
 
 void VisualizerProtocol::
-drawText(const Transform& X_GT, const Vec3& scale, const Vec4& color, 
+drawText(const Transform& X_GT, const Vec3& scale, const Vec4& color,
          const string& string, bool faceCamera, bool isScreenText) {
     SimTK_ERRCHK1_ALWAYS(string.size() <= 256,
         "VisualizerProtocol::drawText()",
@@ -741,8 +741,8 @@ void VisualizerProtocol::setMaxFrameRate(Real rate) const {
 
 void VisualizerProtocol::setBackgroundColor(const Vec3& color) const {
     float buffer[3];
-    buffer[0] = (float)color[0]; 
-    buffer[1] = (float)color[1]; 
+    buffer[0] = (float)color[0];
+    buffer[1] = (float)color[1];
     buffer[2] = (float)color[2];
     std::lock_guard<std::mutex> lock(sceneMutex);
     WRITE(outPipe, &SetBackgroundColor, 1);

--- a/Simbody/Visualizer/src/VisualizerProtocol.cpp
+++ b/Simbody/Visualizer/src/VisualizerProtocol.cpp
@@ -110,9 +110,11 @@ static void spawnViz(const Array_<String>& searchPath, const String& appName,
     int status;
 
     // Pass pipe numbers as command line arguments to the visualizer.
-    char vizReadFromSim[32], vizWriteToSim[32];
-    sprintf(vizReadFromSim, "%d", sim2vizPipe[0]);
-    sprintf(vizWriteToSim, "%d", viz2simPipe[1]);
+    const int nbufr = 32;
+    const int nbufw = 32;
+    char vizReadFromSim[nbufr], vizWriteToSim[nbufw];
+    snprintf(vizReadFromSim, nbufr, "%d", sim2vizPipe[0]);
+    snprintf(vizWriteToSim, nbufw, "%d", viz2simPipe[1]);
 
     String exePath; // search path + appName
 


### PR DESCRIPTION
Mac builds are failing due to the use of sprintf(), which has been deprecated.

In this PR, instances of sprintf() are replaced by snprintf().  Likewise, instances of vsprintf() are replaced by vsnprintf().

In some files, trailing whitespace is also removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/760)
<!-- Reviewable:end -->
