### PR TITLE
Fixed size of string buffer in IpOptionsList.cpp

### DIFF
--- a/SimTKmath/Optimizers/src/IpOpt/IpOptionsList.cpp
+++ b/SimTKmath/Optimizers/src/IpOpt/IpOptionsList.cpp
@@ -520,7 +520,7 @@ namespace SimTKIpopt
   {
     list.clear();
     const int n = 256;
-    char buffer[256];
+    char buffer[n];
     snprintf(buffer, n, "%40s   %-20s %s\n", "Name", "Value", "used");
     list += buffer;
     for(std::map< std::string, OptionValue >::const_iterator p = options_.begin();


### PR DESCRIPTION
Recently in PR #760, ```sprintf()```s were migrated to ```snprintf()```s.  In IpOptionsList.cpp, the change to ```snprintf()``` was done correctly but the size of the ```buffer[256]``` array should have used the local variable '''const int n=256'' to specify the size of the buffer.  That is, ```buffer[n]```.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/761)
<!-- Reviewable:end -->
