### PR TITLE
Precision set to LosslessNumDigitsReal in SimTK::String::String(const T&)

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -27,6 +27,7 @@
 #include "SimTKcommon/internal/common.h"
 #include "SimTKcommon/internal/ExceptionMacros.h"
 
+#include <iomanip>
 #include <cstdio>
 #include <string>
 #include <limits>

--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -41,6 +41,8 @@
 
 namespace SimTK {
 
+extern SimTK_SimTKCOMMON_EXPORT const int LosslessNumDigitsReal;
+
 template <class N> class negator;
 template <class R> class conjugate;
 
@@ -357,12 +359,15 @@ auto stringStreamExtractHelper(std::istringstream& is, T& t, int)
 
 /** Generic templatized %String constructor uses stream insertion
 `operator<<(T)` to generate the %String when no specialization of this
-constructor is available. A *runtime* error is thrown if this method is
+constructor is available. The generated String will have a sufficient number
+of significant digits (i.e., up to ~20) to represent each converted
+SimTK::Real without loss. A *runtime* error is thrown if this method is
 invoked and neither a specialization nor stream insertion operator is
 available. **/
 template <class T> inline
 String::String(const T& t) {
     std::ostringstream os;
+    os << std::setprecision(LosslessNumDigitsReal);
     *this = stringStreamInsertHelper(os, t, true).str();
 }
 


### PR DESCRIPTION
The templatized constructor ```SimTK::String::String(const T& value)``` can be used to convert a value of type ```T``` to a ```String``` provided class ```T``` has implemented ```operator<<()```.

Previously, conversion was done in ```String::String(const T& value)``` using the default precision of ```std::ostringstream```, which is typically ~6.  While an output precision of 6 is sufficient for many applications, it is insufficient when lossless conversion is needed, such as during serialization.

To achieve lossless conversion, the precision is now explicitly set to ```SimTK::LosslessNumDigitsReal```, which is typically ~20.  This change in precision only applies to the local ```ostringstream``` in ```String::String(const T&)```; other instances of ```ostringstream``` in SimTK are unaffected.

This change will affect ```SimTK::Xml::setValueAs<T>(const T& value)```, as this method calls ```String::String(const T&)```. Now, XML elements representing doubles will have  up to ~20 significant digits instead of ~6, rendering class ```SimTK::Xml``` a viable framework for lossless serialization.

The Doxygen compliant comments for ```String::String(const T&)``` have been revised to reflect the change in precision.

Note that a nice feature would be to add a ```precision``` argument that would allow a non-default number of significant digits to be specified:
```
SimTK::String::String(const T& value, int precision=SimTK::LosslessNumDigitsReal)
```
However, in the absence of a clear need for variable precision, the current solution, which avoids a change in the API, is adopted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/762)
<!-- Reviewable:end -->
