### PR TITLE
Added access to State indices for ExponentialSpringForce

### DIFF
--- a/Simbody/include/simbody/internal/ExponentialSpringForce.h
+++ b/Simbody/include/simbody/internal/ExponentialSpringForce.h
@@ -116,7 +116,7 @@ publication:
 
 The current class makes several improvements to that contact model, most
 notably including 1) the ability to rotate and translate the contact plane and
-2) the ability to specify both a static and a kinetic coefficient of friction. 
+2) the ability to specify both a static and a kinetic coefficient of friction.
 The computational details of the contact model implemented by this class
 follow below.
 
@@ -405,6 +405,13 @@ public:
     at Stage::Topology is streamlined. */
     const ExponentialSpringParameters& getParameters() const;
 
+    /** Get the State index of the static coefficient of friction (μₛ) for
+    this exponential spring. Typically, you will not need to use this index.
+    It is exposed to allow low-level, generic access to the state by other
+    modeling frameworks writen on top of Simbody, such as OpenSim.
+    @return State index for μₛ. */
+    DiscreteVariableIndex getMuStaticStateIndex() const;
+
     /** Set the static coefficient of friction (μₛ) for this exponential
     spring. The value of μₛ is held in the System's State object. Unlike the
     parameters managed by ExponentialSpringParameters, μₛ can be set at any
@@ -419,6 +426,13 @@ public:
     state for this exponential spring.
     @param state State object from which to retrieve μₛ. */
     Real getMuStatic(const State& state) const;
+
+    /** Get the State index assinged to the kinetic coefficient of friction
+    (μₖ) for this exponential spring. Typically, you will not need to use this
+    index. It is exposed to allow low-level, generic access to the state by
+    other modeling frameworks writen on top of Simbody, such as OpenSim.
+    @return State index for μₖ. */
+    DiscreteVariableIndex getMuKineticStateIndex() const;
 
     /** Set the kinetic coefficient of friction (μₖ) for this exponential
     spring. The value of μₖ is held in the System's State object. Unlike the
@@ -435,9 +449,38 @@ public:
     @param state State object from which to retrieve μₖ. */
     Real getMuKinetic(const State& state) const;
 
-    /** Get the Sliding state of the spring.
-    @param state State object from which to retrieve Sliding. */
+    /** Get the State index assinged to the sliding State (K) of this
+    exponential spring. Typically, you will not need to use this index.
+    It is exposed to allow low-level, generic access to the state by other
+    modeling frameworks writen on top of Simbody, such as OpenSim.
+    @return State index for K. */
+    DiscreteVariableIndex getSlidingStateIndex() const;
+
+    /** Get the Sliding state of this exponential spring after it has been
+    updated to be consistent with the System State. This value should be used
+    when analyzing or visualizing the dynamic behavior of this exponential
+    spring. The System must be realized to Stage::Dynamics to access this data.
+    @param state State object from which to retrieve the Sliding state. */
     Real getSliding(const State& state) const;
+
+    /** Get the State index assinged to the elastic anchor point (p₀) of this
+    exponential spring. Typically, you will not need to use this index.
+    It is exposed to allow low-level, generic access to the state by other
+    modeling frameworks writen on top of Simbody, such as OpenSim.
+    @return State index for p₀. */
+    DiscreteVariableIndex getAnchorPointStateIndex() const;
+
+    /** Get the position of the elastic anchor point (p₀), which will always
+    lie in the Contact Plane. p₀ is the spring zero of the damped linear
+    spring used in Friction Model 2. The system must be realized to
+    Stage::Dynamics to access this data.
+    @param state State object on which to base the calculations.
+    @param inGround Flag for choosing the frame in which the returned quantity
+    will be expressed. If true (the default), the quantity will be expressed
+    in the Ground frame. If false, the quantity will be expressed in the frame
+    of the contact plane. */
+    Vec3 getAnchorPointPosition(const State& state,
+        bool inGround = true) const;
 
     /** Reset the elastic anchor point (friction spring zero) so that it
      coincides with the projection of the body station onto the contact
@@ -560,18 +603,6 @@ public:
     in the Ground frame. If false, the quantity will be expressed in the frame
     of the contact plane. */
     Vec3 getStationVelocity(const State& state, bool inGround = true) const;
-
-    /** Get the position of the elastic anchor point (p₀), which will always
-    lie in the Contact Plane. p₀ is the spring zero of the damped linear
-    spring used in Friction Model 2. The system must be realized to
-    Stage::Dynamics to access this data.
-    @param state State object on which to base the calculations.
-    @param inGround Flag for choosing the frame in which the returned quantity
-    will be expressed. If true (the default), the quantity will be expressed
-    in the Ground frame. If false, the quantity will be expressed in the frame
-    of the contact plane. */
-    Vec3 getAnchorPointPosition(const State& state,
-        bool inGround=true) const;
 
 private:
     SimTK_INSERT_DERIVED_HANDLE_DECLARATIONS(

--- a/Simbody/include/simbody/internal/ExponentialSpringForce.h
+++ b/Simbody/include/simbody/internal/ExponentialSpringForce.h
@@ -405,13 +405,6 @@ public:
     at Stage::Topology is streamlined. */
     const ExponentialSpringParameters& getParameters() const;
 
-    /** Get the State index of the static coefficient of friction (μₛ) for
-    this exponential spring. Typically, you will not need this index. It is
-    exposed to allow low-level, generic access to the state by modeling
-    frameworks written on top of Simbody, such as OpenSim.
-    @return State index for μₛ. */
-    DiscreteVariableIndex getMuStaticStateIndex() const;
-
     /** Set the static coefficient of friction (μₛ) for this exponential
     spring. The value of μₛ is held in the System's State object. Unlike the
     parameters managed by ExponentialSpringParameters, μₛ can be set at any
@@ -426,13 +419,6 @@ public:
     state for this exponential spring.
     @param state State object from which to retrieve μₛ. */
     Real getMuStatic(const State& state) const;
-
-    /** Get the State index assinged to the kinetic coefficient of friction
-    (μₖ) for this exponential spring. Typically, you will not need this index.
-    It is exposed to allow low-level, generic access to the state by modeling
-    frameworks written on top of Simbody, such as OpenSim.
-    @return State index for μₖ. */
-    DiscreteVariableIndex getMuKineticStateIndex() const;
 
     /** Set the kinetic coefficient of friction (μₖ) for this exponential
     spring. The value of μₖ is held in the System's State object. Unlike the
@@ -449,26 +435,12 @@ public:
     @param state State object from which to retrieve μₖ. */
     Real getMuKinetic(const State& state) const;
 
-    /** Get the State index assinged to the sliding State (K) of this
-    exponential spring. Typically, you will not need this index. It is exposed
-    to allow low-level, generic access to the state by modeling frameworks
-    written on top of Simbody, such as OpenSim.
-    @return State index for K. */
-    DiscreteVariableIndex getSlidingStateIndex() const;
-
     /** Get the Sliding state of this exponential spring after it has been
     updated to be consistent with the System State. This value should be used
     when analyzing or visualizing the dynamic behavior of this exponential
     spring. The System must be realized to Stage::Dynamics to access this data.
     @param state State object from which to retrieve the Sliding state. */
     Real getSliding(const State& state) const;
-
-    /** Get the State index assinged to the elastic anchor point (p₀) of this
-    exponential spring. Typically, you will not need this index. It is exposed
-    to allow low-level, generic access to the state by modeling frameworks
-    written on top of Simbody, such as OpenSim.
-    @return State index for p₀. */
-    DiscreteVariableIndex getAnchorPointStateIndex() const;
 
     /** Get the position of the elastic anchor point (p₀), which will always
     lie in the Contact Plane. p₀ is the spring zero of the damped linear
@@ -603,6 +575,42 @@ public:
     in the Ground frame. If false, the quantity will be expressed in the frame
     of the contact plane. */
     Vec3 getStationVelocity(const State& state, bool inGround = true) const;
+
+
+    // ADVANCED METHODS BELOW HERE
+
+    /** @name State Indices (Advanced)
+    If the State index of a discrete variable is known, the value of the
+    variable can be accessed in a generic way by calling
+    Subsystem::getDiscreteVariable() or Subsystem::updDiscreteVariable().
+    Such access is typically used by modeling frameworks, written on top of
+    Simbody, to get and set State values in bulk (e.g., during serialization
+    and deserialization). To support this functionality, a 'get' method for
+    the State index of each discrete variable possessed by an
+    ExponentialSpringForce instance is provided. */
+    ///@{
+
+    /** Get the State index of the static coefficient of friction (μₛ) for
+    this exponential spring.
+    @return Index of μₛ. */
+    DiscreteVariableIndex getMuStaticStateIndex() const;
+
+    /** Get the State index of the kinetic coefficient of friction (μₖ) for
+    this exponential spring.
+    @return Index of μₖ. */
+    DiscreteVariableIndex getMuKineticStateIndex() const;
+
+    /** Get the State index of the sliding state (K) for this exponential
+    spring.
+    @return Index of K. */
+    DiscreteVariableIndex getSlidingStateIndex() const;
+
+    /** Get the State index of the elastic anchor point (p₀) for this
+    exponential spring.
+    @return Index of p₀. */
+    DiscreteVariableIndex getAnchorPointStateIndex() const;
+
+    ///@}
 
 private:
     SimTK_INSERT_DERIVED_HANDLE_DECLARATIONS(

--- a/Simbody/include/simbody/internal/ExponentialSpringForce.h
+++ b/Simbody/include/simbody/internal/ExponentialSpringForce.h
@@ -406,9 +406,9 @@ public:
     const ExponentialSpringParameters& getParameters() const;
 
     /** Get the State index of the static coefficient of friction (μₛ) for
-    this exponential spring. Typically, you will not need to use this index.
-    It is exposed to allow low-level, generic access to the state by other
-    modeling frameworks writen on top of Simbody, such as OpenSim.
+    this exponential spring. Typically, you will not need this index. It is
+    exposed to allow low-level, generic access to the state by modeling
+    frameworks written on top of Simbody, such as OpenSim.
     @return State index for μₛ. */
     DiscreteVariableIndex getMuStaticStateIndex() const;
 
@@ -428,9 +428,9 @@ public:
     Real getMuStatic(const State& state) const;
 
     /** Get the State index assinged to the kinetic coefficient of friction
-    (μₖ) for this exponential spring. Typically, you will not need to use this
-    index. It is exposed to allow low-level, generic access to the state by
-    other modeling frameworks writen on top of Simbody, such as OpenSim.
+    (μₖ) for this exponential spring. Typically, you will not need this index.
+    It is exposed to allow low-level, generic access to the state by modeling
+    frameworks written on top of Simbody, such as OpenSim.
     @return State index for μₖ. */
     DiscreteVariableIndex getMuKineticStateIndex() const;
 
@@ -450,9 +450,9 @@ public:
     Real getMuKinetic(const State& state) const;
 
     /** Get the State index assinged to the sliding State (K) of this
-    exponential spring. Typically, you will not need to use this index.
-    It is exposed to allow low-level, generic access to the state by other
-    modeling frameworks writen on top of Simbody, such as OpenSim.
+    exponential spring. Typically, you will not need this index. It is exposed
+    to allow low-level, generic access to the state by modeling frameworks
+    written on top of Simbody, such as OpenSim.
     @return State index for K. */
     DiscreteVariableIndex getSlidingStateIndex() const;
 
@@ -464,9 +464,9 @@ public:
     Real getSliding(const State& state) const;
 
     /** Get the State index assinged to the elastic anchor point (p₀) of this
-    exponential spring. Typically, you will not need to use this index.
-    It is exposed to allow low-level, generic access to the state by other
-    modeling frameworks writen on top of Simbody, such as OpenSim.
+    exponential spring. Typically, you will not need this index. It is exposed
+    to allow low-level, generic access to the state by modeling frameworks
+    written on top of Simbody, such as OpenSim.
     @return State index for p₀. */
     DiscreteVariableIndex getAnchorPointStateIndex() const;
 

--- a/Simbody/src/ExponentialSpringForce.cpp
+++ b/Simbody/src/ExponentialSpringForce.cpp
@@ -179,6 +179,9 @@ public:
     }
 
     // ELASTIC ANCHOR POINT
+    DiscreteVariableIndex getAnchorPointStateIndex() const {
+        return indexAnchorPoint;
+    }
     const Vec3& getAnchorPoint(const State& state) const {
         return Value<Vec3>::downcast(
             getDiscreteVariable(state, indexAnchorPoint));
@@ -199,6 +202,7 @@ public:
     }
 
     // SLIDING
+    DiscreteVariableIndex getSlidingStateIndex() const { return indexSliding; }
     const Real& getSliding(const State& state) const {
         return Value<Real>::downcast(
             getDiscreteVariable(state, indexSliding));
@@ -219,6 +223,7 @@ public:
     }
 
     // STATIC COEFFICENT OF FRICTION
+    DiscreteVariableIndex getMuStaticStateIndex() const { return indexMus; }
     const Real& getMuStatic(const State& state) const {
         return Value<Real>::downcast(
             getDiscreteVariable(state, indexMus));
@@ -237,6 +242,7 @@ public:
     }
 
     // KINETIC COEFFICENT OF FRICTION
+    DiscreteVariableIndex getMuKineticStateIndex() const { return indexMuk; }
     const Real& getMuKinetic(const State& state) const {
         return Value<Real>::downcast(
             getDiscreteVariable(state, indexMuk));
@@ -287,7 +293,7 @@ public:
             fsub.getDiscreteVarUpdateIndex(state, indexAnchorPoint);
 
         // Sliding (K --> for "Kinetic")
-        mutableThis->indexSliding = 
+        mutableThis->indexSliding =
             fsub.allocateAutoUpdateDiscreteVariable(state, Stage::Dynamics,
                 new Value<Real>(defaultSliding), Stage::Dynamics);
         mutableThis->indexSlidingInCache =
@@ -694,6 +700,12 @@ getParameters() const {
 }
 
 //_____________________________________________________________________________
+DiscreteVariableIndex
+ExponentialSpringForce::
+getMuStaticStateIndex() const {
+    return getImpl().getMuStaticStateIndex();
+}
+//_____________________________________________________________________________
 void
 ExponentialSpringForce::
 setMuStatic(State& state, Real mus) {
@@ -707,6 +719,12 @@ getMuStatic(const State& state) const {
 }
 
 //_____________________________________________________________________________
+DiscreteVariableIndex
+ExponentialSpringForce::
+getMuKineticStateIndex() const {
+    return getImpl().getMuKineticStateIndex();
+}
+//_____________________________________________________________________________
 void
 ExponentialSpringForce::
 setMuKinetic(State& state, Real muk) {
@@ -718,6 +736,9 @@ ExponentialSpringForce::
 getMuKinetic(const State& state) const {
     return getImpl().getMuKinetic(state);
 }
+
+
+
 //_____________________________________________________________________________
 void
 ExponentialSpringForce::
@@ -850,6 +871,12 @@ getStationVelocity(const State& state, bool inGround) const {
 // Auto Update Discrete States
 //-----------------------------------------------------------------------------
 //_____________________________________________________________________________
+DiscreteVariableIndex
+ExponentialSpringForce::
+getAnchorPointStateIndex() const {
+    return getImpl().getAnchorPointStateIndex();
+}
+//_____________________________________________________________________________
 // Only the updated value stored in the data cache for the elastic anchor
 // point is guaranteed to be consistent with the state. Therefore, in order
 // for this method to give a correct value, the System must be realized
@@ -864,6 +891,13 @@ getAnchorPointPosition(const State& state, bool inGround) const {
         p0 = getContactPlaneTransform().shiftFrameStationToBase(p0);
     }
     return p0;
+}
+
+//_____________________________________________________________________________
+DiscreteVariableIndex
+ExponentialSpringForce::
+getSlidingStateIndex() const {
+    return getImpl().getSlidingStateIndex();
 }
 //_____________________________________________________________________________
 // Only the updated value stored in the data cache for the sliding state is


### PR DESCRIPTION
Class ExponentialSpringForce has 4 states:
- Static coefficient of friction (discrete)
- Kinetic coefficient of friction (discrete)
- Sliding state (auto-update discrete)
- Elastic anchor point (auto-update discrete)

A 'get' method for the State index of each of the above states has been added:
- ```ExponentialSpringForce::getMuStaticStateIndex()```
- ```ExponentialSpringForce::getMuKineticStateIndex()```
- ```ExponentialSpringForce::getSlidingStateIndex()```
- ```ExponentialSpringForce::getAnchorPointStateIndex()```

A typical user will not need to call these methods.

Access to the indices is provided so that modeling frameworks written on top of Simbody, such as OpenSim, can get the values of the states in a generic way.  For example, a discrete state value can be obtained by calling the following method if its state index is know: 
```
SimTK::Subsystem::getDiscreteVariable(const State& s, DiscreteVariableIndex index)
```
Tests for these methods have been added to the unit test for class ExponentialSpringForce (see TestExponentialSpring.cpp). Documentation for these new methods has also been added.

A few trailing white spaces were also removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/763)
<!-- Reviewable:end -->
