### PR TITLE
Replace std::iterator with std::iterator_traits-compatible equivalent

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/Xml.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Xml.h
@@ -646,9 +646,14 @@ inline std::ostream& operator<<(std::ostream& o, const  Attribute& attr) {
 //------------------------------------------------------------------------------
 /** This is a bidirectional iterator suitable for moving forward or backward
 within a list of Attributes within an Element, for writable access. **/
-class SimTK_SimTKCOMMON_EXPORT attribute_iterator
-:   public std::iterator<std::bidirectional_iterator_tag, Attribute> {
+class SimTK_SimTKCOMMON_EXPORT attribute_iterator {
 public:
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type = Attribute;
+  using difference_type = std::ptrdiff_t;
+  using pointer = Attribute*;
+  using reference = Attribute&;
+
 /** Default constructor creates an iterator that compares equal to
 attribute_end(). **/
 attribute_iterator() {}


### PR DESCRIPTION
Minor nit, but it would help with my downstream project.

In [opensim-creator](https://github.com/ComputationalBiomechanicsLab/opensim-creator) I'm compiling with `/W4`, `-pedantic`, C++20, with all warnings upgraded to errors etc. All of the simbody headers get through except for this one, which requires me to explicitly ignore the warning:

- https://github.com/ComputationalBiomechanicsLab/opensim-creator/blob/2ba887a1a3a828a81284c08fd18f9e9924d3c65f/src/OpenSimCreator/CMakeLists.txt#L343

It's because `std::iterator` was deprecated, and the modern convention is for `std::iterator_traits<UserType>` to query the object for the relevant typedefs. I went through `std::iterator` and ensured that the typedefs added by this patch are identical to what `std::iterator` used to add.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/770)
<!-- Reviewable:end -->
