### PR TITLE
Ensure simbody links transitive DLLs (e.g. libgfortran) 

### DIFF
--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -195,7 +195,15 @@ endforeach()
 # All the platform libraries (including quadmath, etc.) still must be on the
 # PATH when running executables using Simbody.
 if(WIN32 AND NOT BUILD_USING_OTHER_LAPACK)
-    # transitive dependencies for blas/lapack
+    # declare transitive dependencies for blas/lapack (see simbody/simbody#771)
+    #
+    # the transitive dependencies don't, themselves, have IMPLIBs, because
+    # they have already been linked by blas/lapack. However, cmake can become
+    # confused when it sees a library with no IMPLIB, so we include blas's
+    # here to satisfy cmake
+    #
+    # (if you link to blas or lapack, you're going to link to the blas IMPLIB
+    # anyway, so it makes no difference)
     add_library(libgcc_s_sjlj-1 SHARED IMPORTED)
     set_target_properties(libgcc_s_sjlj-1 PROPERTIES
         IMPORTED_IMPLIB "${LIB_ABI_DIR}/libblas.lib"
@@ -218,7 +226,7 @@ if(WIN32 AND NOT BUILD_USING_OTHER_LAPACK)
     set_target_properties(blas PROPERTIES
         IMPORTED_IMPLIB "${LIB_ABI_DIR}/libblas.lib"
         )
-    # link transitive dependencies
+    # link to transitive dependencies
     target_link_libraries(blas INTERFACE libgcc_s_sjlj-1 libgfortran-3 libquadmath-0)
     
     add_library(lapack SHARED IMPORTED GLOBAL)

--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -217,9 +217,9 @@ if(WIN32 AND NOT BUILD_USING_OTHER_LAPACK)
     add_library(blas SHARED IMPORTED GLOBAL)
     set_target_properties(blas PROPERTIES
         IMPORTED_IMPLIB "${LIB_ABI_DIR}/libblas.lib"
-        # link transitive dependencies
-        INTERFACE_LINK_LIBRARIES libgcc_s_sjlj-1 libgfortran-3 libquadmath-0
         )
+    # link transitive dependencies
+    target_link_libraries(blas INTERFACE libgcc_s_sjlj-1 libgfortran-3 libquadmath-0)
     
     add_library(lapack SHARED IMPORTED GLOBAL)
     set_target_properties(lapack PROPERTIES

--- a/Platform/CMakeLists.txt
+++ b/Platform/CMakeLists.txt
@@ -195,11 +195,30 @@ endforeach()
 # All the platform libraries (including quadmath, etc.) still must be on the
 # PATH when running executables using Simbody.
 if(WIN32 AND NOT BUILD_USING_OTHER_LAPACK)
+    # transitive dependencies for blas/lapack
+    add_library(libgcc_s_sjlj-1 SHARED IMPORTED)
+    set_target_properties(libgcc_s_sjlj-1 PROPERTIES
+        IMPORTED_IMPLIB "${LIB_ABI_DIR}/libblas.lib"
+        IMPORTED_LOCATION "${LIB_ABI_DIR}/libgcc_s_sjlj-1.dll"
+        )
+    add_library(libgfortran-3 SHARED IMPORTED)
+    set_target_properties(libgfortran-3 PROPERTIES
+        IMPORTED_IMPLIB "${LIB_ABI_DIR}/libblas.lib"
+        IMPORTED_LOCATION "${LIB_ABI_DIR}/libgfortran-3.dll"
+        )
+    add_library(libquadmath-0 SHARED IMPORTED)
+    set_target_properties(libquadmath-0 PROPERTIES
+        IMPORTED_IMPLIB "${LIB_ABI_DIR}/libblas.lib"
+        IMPORTED_LOCATION "${LIB_ABI_DIR}/libquadmath-0.dll"
+        )
+
     # Without GLOBAL, this target is only available in this dir. and below,
     # but we want to use these targets everywhere in this project.
     add_library(blas SHARED IMPORTED GLOBAL)
     set_target_properties(blas PROPERTIES
         IMPORTED_IMPLIB "${LIB_ABI_DIR}/libblas.lib"
+        # link transitive dependencies
+        INTERFACE_LINK_LIBRARIES libgcc_s_sjlj-1 libgfortran-3 libquadmath-0
         )
     
     add_library(lapack SHARED IMPORTED GLOBAL)

--- a/cmake/SimbodyConfig.cmake.in
+++ b/cmake/SimbodyConfig.cmake.in
@@ -77,7 +77,16 @@ include("${CMAKE_CURRENT_LIST_DIR}/SimbodyTargets.cmake")
 # use the appropriate library paths below.
 set(SIMBODY_WAS_BUILT_USING_OTHER_LAPACK "@BUILD_USING_OTHER_LAPACK@")
 if(WIN32 AND NOT SIMBODY_WAS_BUILT_USING_OTHER_LAPACK)
-    # transitive dependencies for blas/lapack
+
+    # declare transitive dependencies for blas/lapack (see simbody/simbody#771)
+    #
+    # the transitive dependencies don't, themselves, have IMPLIBs, because
+    # they have already been linked by blas/lapack. However, cmake can become
+    # confused when it sees a library with no IMPLIB, so we include blas's
+    # here to satisfy cmake
+    #
+    # (if you link to blas or lapack, you're going to link to the blas IMPLIB
+    # anyway, so it makes no difference)
     add_library(libgcc_s_sjlj-1 SHARED IMPORTED)
     set_target_properties(libgcc_s_sjlj-1 PROPERTIES
         IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
@@ -99,6 +108,7 @@ if(WIN32 AND NOT SIMBODY_WAS_BUILT_USING_OTHER_LAPACK)
         IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
         IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libblas.dll"
         )
+    # link to transitive dependencies
     target_link_libraries(blas INTERFACE libgcc_s_sjlj-1 libgfortran-3 libquadmath-0)
 
     add_library(lapack SHARED IMPORTED)

--- a/cmake/SimbodyConfig.cmake.in
+++ b/cmake/SimbodyConfig.cmake.in
@@ -77,10 +77,29 @@ include("${CMAKE_CURRENT_LIST_DIR}/SimbodyTargets.cmake")
 # use the appropriate library paths below.
 set(SIMBODY_WAS_BUILT_USING_OTHER_LAPACK "@BUILD_USING_OTHER_LAPACK@")
 if(WIN32 AND NOT SIMBODY_WAS_BUILT_USING_OTHER_LAPACK)
+    # transitive dependencies for blas/lapack
+    add_library(libgcc_s_sjlj-1 SHARED IMPORTED)
+    set_target_properties(libgcc_s_sjlj-1 PROPERTIES
+        IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
+        IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libgcc_s_sjlj-1.dll"
+        )
+    add_library(libgfortran-3 SHARED IMPORTED)
+    set_target_properties(libgfortran-3 PROPERTIES
+        IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
+        IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libgfortran-3.dll"
+        )
+    add_library(libquadmath-0 SHARED IMPORTED)
+    set_target_properties(libquadmath-0 PROPERTIES
+        IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
+        IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libquadmath-0.dll"
+        )
+
     add_library(blas SHARED IMPORTED)
     set_target_properties(blas PROPERTIES
         IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
         IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libblas.dll"
+        # link transitive dependencies
+        INTERFACE_LINK_LIBRARIES libgcc_s_sjlj-1 libgfortran-3 libquadmath-0
         )
 
     add_library(lapack SHARED IMPORTED)

--- a/cmake/SimbodyConfig.cmake.in
+++ b/cmake/SimbodyConfig.cmake.in
@@ -98,9 +98,8 @@ if(WIN32 AND NOT SIMBODY_WAS_BUILT_USING_OTHER_LAPACK)
     set_target_properties(blas PROPERTIES
         IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
         IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libblas.dll"
-        # link transitive dependencies
-        INTERFACE_LINK_LIBRARIES libgcc_s_sjlj-1 libgfortran-3 libquadmath-0
         )
+    target_link_libraries(blas INTERFACE libgcc_s_sjlj-1 libgfortran-3 libquadmath-0)
 
     add_library(lapack SHARED IMPORTED)
     set_target_properties(lapack PROPERTIES


### PR DESCRIPTION
The simbody cmake install doesn't explicitly link all transitive DLLs that it may depend on, which means that downstream projects (e.g. [OpenSim Core](https://github.com/opensim-org/opensim-core), [OpenSim Creator](https://github.com/ComputationalBiomechanicsLab/opensim-creator)) have to manually copy DLL files etc. around when packaging downstream applications that depend on the libraries.

---

**Downstream Example**: [here](https://github.com/ComputationalBiomechanicsLab/opensim-creator/blob/2ba887a1a3a828a81284c08fd18f9e9924d3c65f/src/OpenSimCreator/CMakeLists.txt#L329)

In the example, I create fake `IMPORTED` targets for the `OpenSimCreator` library. The reason I do this, rather than manually copy the DLLs, is so that all downstream executables (e.g. the application, application packaging, unit tests, benchmarks, etc.) can generically copy runtime libraries next to the executable. This is necessary when (e.g.) running things from Visual Studio ([example usage](https://github.com/ComputationalBiomechanicsLab/opensim-creator/blob/2ba887a1a3a828a81284c08fd18f9e9924d3c65f/apps/osc/CMakeLists.txt#L62))

I'm aware that I could copy+dump all binaries into one directory, but the utility of doing it this way is that changing the dependencies of OSC automatically propagates any runtime file dependencies downstream - regardless of filesystem location.

---

This PR fixes the issue by telling CMake about the transitive dependency. **I'm not sure if I've done it correctly (I'm assuming these are all needed by BLAS and LAPACK)**. The reason why IMPLIB is `blas` is because the affected DLLs have no IMPLIB, but CMake's linking regieme gets a bit confused by that.

Automatic reproduction of the issue (Windows, git bash):

```bash
 # on Windows, in `git bash` terminal
 
 # configure simbody
cmake -S . -B simbody-build -DCMAKE_INSTALL_PREFIX=${PWD}/simbody-install

 # build + install simbody (locally)
cmake --build simbody-build -j$(nproc) --target install

# clean-generate downstream project
rm -rf downstream downstream-build
mkdir downstream
cat << EOF > downstream/main.cpp
#include <Simbody.h>

int main(char**,int)
{
    SimTK::Body b;  // ensure linkage
    return 0;
}
EOF

cat << EOF > downstream/CMakeLists.txt
cmake_minimum_required(VERSION 3.15)

project(example VERSION 0.0.1 LANGUAGES CXX)

find_package(Simbody)

add_executable(example main.cpp)
target_link_libraries(example SimTKcommon SimTKmath SimTKsimbody)

if (WIN32)
    add_custom_command(
        TARGET example
        PRE_BUILD
        COMMAND \${CMAKE_COMMAND} -E copy_if_different \$<TARGET_RUNTIME_DLLS:example> $<TARGET_FILE_DIR:example>
        COMMAND_EXPAND_LISTS
    )
endif()
EOF

# configure downstream project
cmake -S downstream -B downstream-build -DCMAKE_PREFIX_PATH=${PWD}/simbody-install

# build downstream project (works)
cmake --build downstream-build

# list libraries used by downstream project (should contain everything?)
ls downstream-build/Debug
```

Before this PR:

```bash
$ bash repro.sh
# build messages
SimTKcommon_d.dll  SimTKmath_d.dll  SimTKsimbody_d.dll  example.exe  example.pdb  libblas.dll  liblapack.dll
```

After this PR:

```bash
$ bash repro.sh
# build messages
SimTKcommon_d.dll  SimTKmath_d.dll  SimTKsimbody_d.dll  example.exe  example.pdb  libblas.dll  libgcc_s_sjlj-1.dll  libgfortran-3.dll  liblapack.dll  libquadmath-0.dll
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/771)
<!-- Reviewable:end -->
