### PR TITLE
Drop deprecated std::iterator usage from node_iterator

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/Xml.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Xml.h
@@ -906,9 +906,13 @@ inline std::ostream& operator<<(std::ostream& o, const Node& xmlNode) {
 /** This is a bidirectional iterator suitable for moving forward or backward
 within a list of Nodes, for writable access. By default we will iterate
 over all nodes but you can restrict the types at construction. **/
-class SimTK_SimTKCOMMON_EXPORT node_iterator
-:   public std::iterator<std::bidirectional_iterator_tag, Node> {
+class SimTK_SimTKCOMMON_EXPORT node_iterator {
 public:
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type = Node;
+  using difference_type = std::ptrdiff_t;
+  using pointer = Node*;
+  using reference = Node&;
 
 explicit node_iterator(NodeType allowed=AnyNodes)
 :   allowed(allowed) {}


### PR DESCRIPTION
Related: #770 

I (stupidly) forgot to grep for other usages of `std::iterator` during #770, and only noticed this usage when I integrated Simbody+OpenSim into opensim-creator's development build with the appropriate warning enabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/772)
<!-- Reviewable:end -->
