### PR TITLE
Fix O(N^2) vector growth when reading mesh files

### DIFF
--- a/SimTKcommon/BigMatrix/include/SimTKcommon/internal/BigMatrix.h
+++ b/SimTKcommon/BigMatrix/include/SimTKcommon/internal/BigMatrix.h
@@ -1131,13 +1131,17 @@ std::istream& readVectorFromStreamHelper
 
         // Now read in an element of type T.
         // The extractor T::operator>>() will ignore leading white space.
-        if (!isFixedSize)
-            out.resizeKeep(out.size()+1); // grow by one (default consructed)
+        if (!isFixedSize && nextIndex >= out.size())
+        {
+            // grow output vector geometrically (resized to actual size after loop)
+            out.resizeKeep(out.size() == 0 ? 1 : 2*out.size());
+        }
         in >> out[nextIndex]; if (in.fail()) break;
         ++nextIndex;
 
         if (!in.good()) break; // might be eof
     }
+    out.resizeKeep(nextIndex);  // cut off trailing elements
 
     // We will get here under a number of circumstances:
     //  - the fail bit is set in the istream, or


### PR DESCRIPTION
Hi,

Random performance improvement related to loading mesh files.

I have a test suite that loads every available OpenSim model file, finalizes them, assembles them, and generates 3D decorations for them. It's a system-level sanity check method, but it is also one of the slowest tests in my suite. This is because it involves a lot of IO (esp. mesh loading).

If I profile the test suite in VS, I see all kinds of optimization candidates (e.g. 45 % of it's in OpenSim, with a lot of that being related to copying objects etc.) but one hotspot stood out as particularly suspicious:

![image](https://github.com/simbody/simbody/assets/4730570/ab494ed6-6173-42d9-94e4-f83b0d8ec5a9)

The reason why is because I wouldn't expect 17.5 % of performance to be spent on a reallocations in that part of the code. When I investigated it, it turns out that it's because the vector that's used to read floats only grows one element at a time, which will have O(N^2) performance (allocate N-1, copy N-1, append Nth, etc. etc.) - this PR hopefully minimally patches the behavior

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/773)
<!-- Reviewable:end -->
