### PR TITLE
Fix RigidBodyNode API to allow returning locally-computed spatial vecs

### DIFF
--- a/Simbody/src/RigidBodyNode.h
+++ b/Simbody/src/RigidBodyNode.h
@@ -587,10 +587,10 @@ virtual void multiplyByMPass2Inward(
   { SimTK_THROW2(Exception::UnimplementedVirtualMethod, "RigidBodeNode", "multiplyByMPass2Inward"); }
 
 // Note that this requires columns of H to be packed like SpatialVec.
-virtual const SpatialVec& getHCol(const SBTreePositionCache&, int j) const 
+virtual SpatialVec getHCol(const SBTreePositionCache&, int j) const
 {SimTK_THROW2(Exception::UnimplementedVirtualMethod, "RigidBodeNode", "getHCol");}
 
-virtual const SpatialVec& getH_FMCol(const SBTreePositionCache&, int j) const 
+virtual SpatialVec getH_FMCol(const SBTreePositionCache&, int j) const
 {SimTK_THROW2(Exception::UnimplementedVirtualMethod, "RigidBodeNode", "getH_FMCol");}
 
 

--- a/Simbody/src/RigidBodyNodeSpec.h
+++ b/Simbody/src/RigidBodyNodeSpec.h
@@ -446,14 +446,14 @@ void multiplyByMPass2Inward(
     Real*                       allTau) const override;
 
 // Get a column of H_PB_G, which is what Jain calls H* and Schwieters calls H^T.
-const SpatialVec& 
+SpatialVec
 getHCol(const SBTreePositionCache& pc, int j) const override {
     return getH(pc)(j);
 }
 
 // Get a column of H_FM the local cross-mobilizer hinge matrix expressed in the
 // parent (inboard) mobilizer frame F.
-const SpatialVec& 
+SpatialVec
 getH_FMCol(const SBTreePositionCache& pc, int j) const override {
     return getH_FM(pc)(j);
 }

--- a/Simbody/src/RigidBodyNode_LoneParticle.cpp
+++ b/Simbody/src/RigidBodyNode_LoneParticle.cpp
@@ -405,8 +405,8 @@ void multiplyByMPass2Inward(
     tau = F[1];
 }
 
-const SpatialVec& getHCol(const SBTreePositionCache& pc, 
-                          int j) const override {
+SpatialVec getHCol(const SBTreePositionCache& pc,
+                   int j) const override {
     Mat<2,3,Vec3> H = Mat<2,3,Vec3>::getAs(&pc.storageForH[2*uIndex]);
     SpatialVec& col = H(j);
     col = SpatialVec(Vec3(0), Vec3(0));
@@ -414,8 +414,8 @@ const SpatialVec& getHCol(const SBTreePositionCache& pc,
     return col;
 }
 
-const SpatialVec& getH_FMCol(const SBTreePositionCache& pc, 
-                             int j) const override {
+SpatialVec getH_FMCol(const SBTreePositionCache& pc,
+                      int j) const override {
     Mat<2,3,Vec3> H = Mat<2,3,Vec3>::getAs(&pc.storageForH_FM[2*uIndex]);
     SpatialVec& col = H(j);
     col = SpatialVec(Vec3(0), Vec3(0));


### PR DESCRIPTION
Fixes a warning that is emitted by newer versions of clang/gcc, e.g.:

```text
/home/adam/opensim-core/dependencies/simbody/Simbody/src/RigidBodyNode_LoneParticle.cpp: In member function ‘virtual const SpatialVec& RBNodeLoneParticle::getHCol(const SBTreePositionCache&, int) const’:
/home/adam/opensim-core/dependencies/simbody/Simbody/src/RigidBodyNode_LoneParticle.cpp:414:12: warning: function returns address of local variable [-Wreturn-local-addr]
  414 |     return col;
      |            ^~~
/home/adam/opensim-core/dependencies/simbody/Simbody/src/RigidBodyNode_LoneParticle.cpp:410:19: note: declared here
  410 |     Mat<2,3,Vec3> H = Mat<2,3,Vec3>::getAs(&pc.storageForH[2*uIndex]);
```

The API design for `RigidBodyNode` returns a `const SpatialVec&`, but that is incompatible with computing the `SpatialVec` on-the-fly (locally). To get around that, I modified the API to return a `SpatialVec` value. This is "more expensive" than just returning a reference (i.e. returning 1 integer vs. 6 floats) but, in practice, that kind of overhead rarely matters (because downstream users of the result are likely to want to immediately load the reference into registers to copy it elsewhere or use it in a calculation).

One other concern might be that changing an API from using a const-reference to a value may cause code like the following to be undefined:

```c++
const SpatialVec& v = node.getHCol(...);   // uh-oh: reference to a now-value-based temporary?
```

But that kind of downstream code will still be well-defined due to reference lifetime extension:

- https://en.cppreference.com/w/cpp/language/reference_initialization#Lifetime_of_a_temporary

However, code that (e.g.) takes references to subobjects of the `SpatialVec`, or passes the reference via other function calls, will be broken by this change. Whether this matters (because the top-level API appears to return `SpatialVec` values, and the original UB was specifically isolated to `LoneParticle`) - no idea

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/774)
<!-- Reviewable:end -->
