### PR TITLE
XML String Precision

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -195,9 +195,9 @@ operator<<() available for type T; a *runtime* error is thrown if neither is
 available.
 @param t %Value to be converted to a %String.
 @param precision Optional argument specifying the number of significant
-figures with which t will be represented. The default is given by the constant
-String::DefaultOuputPrecision. Any precision above SimTK::LosslessNumDigitsReal
-is capped at SimTK::LosslessNumDigitsReal. **/
+figures with which t will be represented. The default number is given by the
+constant String::DefaultOutputPrecision. Any precision above
+SimTK::LosslessNumDigitsReal is capped at SimTK::LosslessNumDigitsReal. **/
 template <class T> inline explicit
 String(const T& t, int precision = String::DefaultOutputPrecision);
 

--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -169,13 +169,13 @@ explicit String(bool b) : std::string(b?"true":"false") { }
 // Developer Notes Re: String::DefaultOutputPrecision
 // - This constant was added February 2024 mainly so that numerical values
 //   could be written to XML files with varying significant figures.
-// - It could be altered to be any integer without causing an error, but
-//   some care should be taken before making a change.
+// - This constant could be altered to be any integer without causing an error,
+//   but some care should be taken before making a change.
 //   * Simbody users (e.g., OpenSim developers) may have written software
 //     around a default output precision of 6 (e.g., model files, GUI
 //     displays).
-//   * A default output precision less than 1 or greater than
-//     SimTK::LosslessNumDigitsReal doesn't make sense.
+//   * The default output precision should be great than or equal to 1 and
+//     less than or equal to SimTK::LosslessNumDigitsReal.
 // - Because this constant is used only to supply the default value of an
 //   optional 'precision' argument in the following templatized methods,
 //   no API adjustments are required in code that calls these methods. 

--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -168,8 +168,12 @@ explicit String(bool b) : std::string(b?"true":"false") { }
 /** For any type T for which there is no matching constructor, this templatized
 constructor will format an object of type T into a %String provided that there
 is either an available specialization or (as a last resort) a stream insertion
-operator<<() available for type T. **/
-template <class T> inline explicit String(const T& t); // see below
+operator<<() available for type T; a *runtime* error is thrown if neither is
+available.
+@param t %Value to be converted to a %String.
+@param precision Optional parameter specifying the number of significant
+figures with which t will be represented. **/
+template <class T> inline explicit String(const T& t, int precision = 6);
 
 /** Constructing a %String from a negated value converts to the underlying
 native type and then uses one of the native-type constructors. **/
@@ -358,17 +362,11 @@ auto stringStreamExtractHelper(std::istringstream& is, T& t, int)
 
 /** @endcond **/
 
-/** Generic templatized %String constructor uses stream insertion
-`operator<<(T)` to generate the %String when no specialization of this
-constructor is available. The generated String will have a sufficient number
-of significant digits (i.e., up to ~20) to represent each converted
-SimTK::Real without loss. A *runtime* error is thrown if this method is
-invoked and neither a specialization nor stream insertion operator is
-available. **/
+// Implementation of the generic templatized String constructor.
 template <class T> inline
-String::String(const T& t) {
+String::String(const T& t, int precision) {
     std::ostringstream os;
-    os << std::setprecision(LosslessNumDigitsReal);
+    os << std::setprecision(precision);
     *this = stringStreamInsertHelper(os, t, true).str();
 }
 

--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -167,21 +167,19 @@ explicit String(bool b) : std::string(b?"true":"false") { }
 
 // ------------
 // Developer Notes Re: String::DefaultOutputPrecision
-// - This constant was added February 2024 mainly so that numerical values
-//   could be written to XML files with varying significant figures.
-// - This constant could be altered to be any integer without causing an error,
-//   but some care should be taken before making a change.
-//   * Simbody users (e.g., OpenSim developers) may have written software
-//     around a default output precision of 6 (e.g., model files, GUI
-//     displays).
-//   * The default output precision should be great than or equal to 1 and
+// - This constant was added February 2024 to provide a consistent default
+//   value of the precision argument in the following methods:
+//   * String::String(const T& t, int precision = DefaultOutputPrecision)
+//   * Xml::Element::Element(const String& tagWord, const T& value,
+//         int precision = String::DefaultOutputPrecision)
+//   * Xml::Element::setValueAs(const T& value,
+//         int precision = String::DefaultOutputPrecision)
+// - It could be altered to be any integer without causing an error, but some
+//   care should be taken before making a change.
+//   * Simbody users (e.g., OpenSim devs) may have written software around a
+//     default output precision of 6 (e.g., model files, GUI displays).
+//   * The default output precision should be greater than or equal to 1 and
 //     less than or equal to SimTK::LosslessNumDigitsReal.
-// - Because this constant is used only to supply the default value of an
-//   optional 'precision' argument in the following templatized methods,
-//   no API adjustments are required in code that calls these methods. 
-//   * String::String()
-//   * Xml::Element::Element()
-//   * Xml::Element::setValueAs()
 // ------------
 /** The default output precision of the templatized string constructor is 6,
 which corresponds to the default output precision of std::ostream objects.

--- a/SimTKcommon/include/SimTKcommon/internal/Xml.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Xml.h
@@ -1074,8 +1074,9 @@ allowed (generally any type for which a stream insertion operator<<()
 exists).
 @see getValueAs<T>(), setValueAs<T>()**/
 template <class T>
-Element(const String& tagWord, const T& value)
-{   new(this) Element(tagWord, String(value)); }
+Element(const String& tagWord, const T& value,
+    int precision = String::DefaultOutputPrecision)
+{   new(this) Element(tagWord, String(value, precision)); }
 
 /** The clone() method makes a deep copy of this Element and its children and
 returns a new orphan Element with the same contents; ordinary assignment and
@@ -1162,10 +1163,16 @@ void setValue(const String& value);
 
 /** Set the value of this value element to the text equivalent of any type T
 for which a conversion construction String(T) is allowed (generally any
-type for which a stream insertion operator<<() exists). **/
+type for which a stream insertion operator<<() exists).
+@param value %Value to be converted to a %String.
+@param precision Optional argument specifying the number of significant
+figures with which the value will be repr-esented. The default is 6. Any
+precision below 1 is set to 1, and any precision above
+SimTK::LosslessNumDigitsReal is set to SimTK::LosslessNumDigitsReal. **/
 template <class T>
-void setValueAs(const T& value)
-{   setValue(String(value)); }
+void setValueAs(const T& value,
+    int precision = String::DefaultOutputPrecision)
+{   setValue(String(value, precision)); }
 
 /** Assuming this is a "value element", convert its text value to the type
 of the template argument T. It is an error if the text can not be converted,

--- a/SimTKcommon/include/SimTKcommon/internal/Xml.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Xml.h
@@ -1072,6 +1072,12 @@ explicit Element(const String& tagWord, const String& value="");
 equivalent of any type T for which a conversion construction String(T) is
 allowed (generally any type for which a stream insertion operator<<()
 exists).
+@param tagWord Tag word used to identify the %Element.
+@param value %Value given to the %Element to be converted to a %String.
+@param precision Optional argument specifying the number of significant
+figures with which the value will be represented. The default number is
+given by the constant String::DefaultOutputPrecision. Any precision above
+SimTK::LosslessNumDigitsReal is set to SimTK::LosslessNumDigitsReal.
 @see getValueAs<T>(), setValueAs<T>()**/
 template <class T>
 Element(const String& tagWord, const T& value,
@@ -1166,8 +1172,8 @@ for which a conversion construction String(T) is allowed (generally any
 type for which a stream insertion operator<<() exists).
 @param value %Value to be converted to a %String.
 @param precision Optional argument specifying the number of significant
-figures with which the value will be repr-esented. The default is 6. Any
-precision below 1 is set to 1, and any precision above
+figures with which the value will be represented. The default number is
+given by the constant String::DefaultOutputPrecision. Any precision above
 SimTK::LosslessNumDigitsReal is set to SimTK::LosslessNumDigitsReal. **/
 template <class T>
 void setValueAs(const T& value,

--- a/SimTKcommon/tests/TestXml.cpp
+++ b/SimTKcommon/tests/TestXml.cpp
@@ -324,6 +324,194 @@ void testStringConvert() {
 
 }
 
+// February 2024
+// The ability to specify output precision was added to three methods
+// in the SimTK API. In particular, an optional precision argument was added
+// to the following methods:
+// 
+// 1) String::String(const T& t, int precision)
+// 2) Element::Element(const String& tagWord, const T& value, int precision)
+// 3) Element::setValueAs(const T& value, int precision)
+// 
+// The following subtest verifies correct execution of these methods.  
+void testOutputPrecision() {
+
+    // Input value -----
+    // 24 digits are used to initialize the variable 'input' below.
+    // Since the maximum number of available digits for a double is 19
+    // (see std::numeric_limits<long double>::max()), this initialization
+    // will result in a consistent value that utilizes all available digits
+    // whether the type of 'input' is float or double.
+    // A Vec<1> is used so that the templatized String constructor is evoked.
+    SimTK::Vec<1> input(0.123456789012345678901234);
+
+    // Expected conversions to String for a range of precsions -----
+    // The index of the 'expected' array below is the precision.
+    // Precisions past a value of 7 are not currently tested so that tests
+    // will execute properly when SimTK::Real is set to float or to double.
+    // Though not tested past p = 7, the following rounding behavior is what
+    // is observed for a double.
+    const int n{24};
+    SimTK::String expected[n];
+    expected[0] = "~[0.1]";
+    expected[1] = "~[0.1]";
+    expected[2] = "~[0.12]";
+    expected[3] = "~[0.123]";
+    expected[4] = "~[0.1235]"; // Rounded up
+    expected[5] = "~[0.12346]"; // Rounded up
+    expected[6] = "~[0.123457]"; // Rounded up
+    expected[7] = "~[0.1234568]"; // Rounded up
+    expected[8] = "~[0.12345679]"; // Rounded up
+    expected[9] = "~[0.123456789]";
+    expected[10] = "~[0.123456789]";
+    expected[11] = "~[0.12345678901]";
+    expected[12] = "~[0.123456789012]";
+    expected[13] = "~[0.1234567890123]";
+    expected[14] = "~[0.12345678901235]"; // Rounded up
+    expected[15] = "~[0.123456789012346]"; // Rounded up
+    expected[16] = "~[0.1234567890123457]"; // Rounded up
+    expected[17] = "~[0.12345678901234568]"; // Rounded up
+    expected[18] = "~[0.123456789012345677]"; // Rounded up
+    expected[19] = "~[0.1234567890123456774]";
+    expected[20] = "~[0.12345678901234567737]";
+    expected[21] = "~[0.12345678901234567737]"; // No long changes because
+    expected[22] = "~[0.12345678901234567737]"; // precision is capped at
+    expected[23] = "~[0.12345678901234567737]"; // LosslessNumDigitsReal
+
+    // Store the precision of a local std::ostringstream object before any
+    // calls to String::String. This is done to verify that changes made to
+    // the precision inside String::String do not affect the precision of
+    // other ostringstream instances.
+    std::ostringstream osLocal;
+    const auto starting_precision{osLocal.precision()};
+
+    // ================
+    // String::String()
+    // ================
+    int p;
+    for(p=0; p <= 7; ++p) {
+        // Specify the precision.
+        String output(input, p);
+        SimTK_TEST(output == expected[p]);
+
+        // Verify that the precision of osLocal is unchanged.
+        SimTK_TEST(osLocal.precision() == starting_precision);
+
+        // Omit the precision argument, thereby testing the default argument.
+        // Make sure that String::DefaultOutputPrecision < n so that we don't
+        // step out of bounds on the 'expected' array.
+        if (String::DefaultOutputPrecision < n) {
+            String outputDefault(input);
+            SimTK_TEST(outputDefault ==
+                expected[String::DefaultOutputPrecision]);
+        }
+    }
+
+    // Note that nothing bad happens when p is neg or 0.
+    // String::String() does not check for p < 0 or p == 0; it just
+    // relies on std::ostream to handle such values.
+    // If the following tests fail, it may be because the implementation
+    // of std::ostream varies across operating systems or has changed
+    // since these tests were first put in place.
+    // -----
+    // p < 0: ostream does not accept and falls back on its starting precision.
+    // 'starting_precision' (see above) is used to get the default output
+    // value (see below) to handle a situation in which
+    // String::DefaultOuputPrecision differs from ostream.precision()
+    String outputDefault(input, (int)starting_precision);
+    String outputNeg(input,-2);
+    SimTK_TEST(outputNeg == outputDefault);
+    // -----
+    // p = 0: ostream takes the min p that applies (p = 1)
+    String outputOne(input, 1);
+    String outputZero(input, 0); 
+    SimTK_TEST(outputZero == outputOne);
+
+    //std::ostringstream os;
+    //String outputDefault =
+    //    stringStreamInsertHelper<Vec<1>>(os, input, true).str();
+
+    // Test when pecision is greater than LosslessNumDigits.
+    // In String::String(), p is capped at LosslessNumDigits.
+    String outputLossless(input, SimTK::LosslessNumDigitsReal);
+    String outputLosslessPlus1(input, SimTK::LosslessNumDigitsReal+1);
+    SimTK_TEST(outputLosslessPlus1 == outputLossless);
+
+    // =======================
+    // Test Element::Element()
+    // =======================
+    // Element::Element() is just passing the arguments through to a
+    // String::String() call. So, just going to verify a few notable cases.
+    //------ use the default precision by not passing p
+    Xml::Element defaultSigFigs("default", input);
+    SimTK_TEST(defaultSigFigs.getValue() ==
+        expected[String::DefaultOutputPrecision]);
+    //------ a precision of 0 should get lower bounded to 1
+    p = 0;
+    Xml::Element zeroSigFigs("zero", input, p);
+    SimTK_TEST(zeroSigFigs.getValue() == expected[1]);
+    //------ will not round
+    p = 3;
+    Xml::Element threeSigFigs("three", input, p);
+    SimTK_TEST(threeSigFigs.getValue() == expected[p]);
+    //------ will round
+    p = 7;
+    Xml::Element sevenSigFigs("seven", input, p);
+    SimTK_TEST(sevenSigFigs.getValue() == expected[p]);
+    //------ above the max that makes sense
+    p = SimTK::LosslessNumDigitsReal;
+    Xml::Element losslessSigFigs("lossless", input, p);
+    p = SimTK::LosslessNumDigitsReal + 1;
+    Xml::Element losslessPlusOneSigFigs("losslessPlusOne", input, p);
+    SimTK_TEST(losslessPlusOneSigFigs.getValue() ==
+        losslessSigFigs.getValue());
+
+    // ==========================
+    // Test Element::setValueAs()
+    // ==========================
+    // Element::setValueAs() is just passing the arguments through to a
+    // String::String() call. So, just going to verify a few notable cases.
+    // These tests use the previously constructed element nodes but first set
+    // all of their values to 0.0 as way of clearing the previous value.
+    //------ first set the value of existing elements to 0.0
+    Vec<1> zeroValue(0.0);
+    defaultSigFigs.setValueAs<Vec<1>>(zeroValue);
+    zeroSigFigs.setValueAs<Vec<1>>(zeroValue);
+    threeSigFigs.setValueAs<Vec<1>>(zeroValue);
+    sevenSigFigs.setValueAs<Vec<1>>(zeroValue);
+    losslessSigFigs.setValueAs<Vec<1>>(zeroValue);
+    losslessPlusOneSigFigs.setValueAs<Vec<1>>(zeroValue);
+    SimTK_TEST(defaultSigFigs.getValue() == "~[0]")
+    SimTK_TEST(zeroSigFigs.getValue() == "~[0]")
+    SimTK_TEST(threeSigFigs.getValue() == "~[0]")
+    SimTK_TEST(sevenSigFigs.getValue() == "~[0]")
+    SimTK_TEST(losslessSigFigs.getValue() == "~[0]")
+    SimTK_TEST(losslessPlusOneSigFigs.getValue() == "~[0]")
+    //------ use the default precision by not passing p
+    defaultSigFigs.setValueAs<Vec<1>>(input);
+    SimTK_TEST(defaultSigFigs.getValue() ==
+        expected[String::DefaultOutputPrecision]);
+    //------ a precision of 0 should get lower bounded to 1
+    p = 0;
+    zeroSigFigs.setValueAs<Vec<1>>(input, p);
+    SimTK_TEST(zeroSigFigs.getValue() == expected[1]);
+    //------ will not round
+    p = 3;
+    threeSigFigs.setValueAs<Vec<1>>(input, p);
+    SimTK_TEST(threeSigFigs.getValue() == expected[p]);
+    //------ will round
+    p = 7;
+    sevenSigFigs.setValueAs<Vec<1>>(input, p);
+    SimTK_TEST(sevenSigFigs.getValue() == expected[p]);
+    //------ above the max that makes sense
+    p = SimTK::LosslessNumDigitsReal;
+    losslessSigFigs.setValueAs<Vec<1>>(input, p);
+    p = SimTK::LosslessNumDigitsReal + 1;
+    losslessPlusOneSigFigs.setValueAs<Vec<1>>(input, p);
+    SimTK_TEST(losslessPlusOneSigFigs.getValue() ==
+        losslessSigFigs.getValue());
+}
+
 int main() {
     cout << "Path of this executable: '" << Pathname::getThisExecutablePath() << "'\n";
     cout << "Executable directory: '" << Pathname::getThisExecutableDirectory() << "'\n";
@@ -331,6 +519,7 @@ int main() {
 
     SimTK_START_TEST("TestXml");
 
+        SimTK_SUBTEST(testOutputPrecision);
         SimTK_SUBTEST(testStringConvert);
         SimTK_SUBTEST(testXmlFromString);
         SimTK_SUBTEST(testXmlFromScratch);

--- a/SimTKcommon/tests/TestXml.cpp
+++ b/SimTKcommon/tests/TestXml.cpp
@@ -342,17 +342,17 @@ void testOutputPrecision() {
     // (see std::numeric_limits<long double>::max()), this initialization
     // will result in a consistent value that utilizes all available digits
     // whether the type of 'input' is float or double.
-    // A Vec<1> is used so that the templatized String constructor is evoked.
+    // A Vec<1> is used so that the templatized String constructor is invoked.
     SimTK::Vec<1> input(0.123456789012345678901234);
 
-    // Expected conversions to String for a range of precsions -----
+    // Expected conversions to String for a range of precisions -----
     // The index of the 'expected' array below is the precision.
     // Precisions past a value of 7 are not currently tested so that tests
     // will execute properly when SimTK::Real is set to float or to double.
     // Though not tested past p = 7, the following rounding behavior is what
     // is observed for a double.
-    const int n{24};
-    SimTK::String expected[n];
+    const int num_precisions{24};
+    SimTK::String expected[num_precisions];
     expected[0] = "~[0.1]";
     expected[1] = "~[0.1]";
     expected[2] = "~[0.12]";
@@ -398,9 +398,9 @@ void testOutputPrecision() {
         SimTK_TEST(osLocal.precision() == starting_precision);
 
         // Omit the precision argument, thereby testing the default argument.
-        // Make sure that String::DefaultOutputPrecision < n so that we don't
-        // step out of bounds on the 'expected' array.
-        if (String::DefaultOutputPrecision < n) {
+        // Make sure that String::DefaultOutputPrecision < num_precisions so
+        // that we don't step out of bounds on the 'expected' array.
+        if (String::DefaultOutputPrecision < num_precisions) {
             String outputDefault(input);
             SimTK_TEST(outputDefault ==
                 expected[String::DefaultOutputPrecision]);
@@ -427,11 +427,7 @@ void testOutputPrecision() {
     String outputZero(input, 0); 
     SimTK_TEST(outputZero == outputOne);
 
-    //std::ostringstream os;
-    //String outputDefault =
-    //    stringStreamInsertHelper<Vec<1>>(os, input, true).str();
-
-    // Test when pecision is greater than LosslessNumDigits.
+    // Test when precision is greater than LosslessNumDigits.
     // In String::String(), p is capped at LosslessNumDigits.
     String outputLossless(input, SimTK::LosslessNumDigitsReal);
     String outputLosslessPlus1(input, SimTK::LosslessNumDigitsReal+1);


### PR DESCRIPTION
While there are various constructors available in class ```SimTK::String``` that allowed for specification of output format, the templatized constructor for class ```String``` (i.e., ```String::String(const T& t)```) was fixed at the output precision set by ```std::ostream```. As a consequence, any ```String``` conversion for a type ```T``` for which there exists no matching constructor was fixed to an output precision of ```6```.

So that output precision (i.e., the number of significant figures used to represent a value) can be specified for such types, this commit adds an optional ```precision``` argument to the templatized ```String``` constructor and to the methods in class ```SimTK::Xml``` that call this templatized ```String``` constructor. In particular, the following methods now include the optional ```precision``` argument:
```
SimTK::String::String<T>(const T& t, int precision = String::DefaultOutputPrecision)

SimTK::Xml::Element::Element<T>(const String& tagWord, const T& value, int precision = String::DefaultOutputPrecision)

SimTK::Xml::Element::setValueAs<T>(const T& value, int precision = String::DefaultOutputPrecision)
```
Because the ```precision``` argument is optional, no API adjustments are needed in existing code that calls the above methods.

The static constant ```String::DefaultOutputPrecision``` was added to support this new functionality. Its value is chosen to be ```6``` to be consistent with the default precision of class ```std::ostream``` and so that previous behavior would be maintained.

The primary benefit of this commit is that a broad range of numerical value types in SimTK (e.g., ```Vec3```, ```Vec4```, etc.) can be serialized via class ```SimTK::Xml``` with a specified number of significant figures.  The changes revert default output precision to what it was prior to #762 but also make it possible to serialize ```SimTK::State```, among other quantities, in lossless fashion.

User facing Doxygen comments were updated and a subunit test (```testOutputPrecision```) was added to ```testXml.cpp```.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/776)
<!-- Reviewable:end -->
