### PR TITLE
XML String Precision Bug Fix

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -165,26 +165,14 @@ explicit String(std::complex<double> r, const char* fmt="%.17g")
 or "0" cast the bool to an int first. **/
 explicit String(bool b) : std::string(b?"true":"false") { }
 
-// ------------
-// Developer Notes Re: String::DefaultOutputPrecision
-// - This constant was added February 2024 to provide a consistent default
-//   value of the precision argument in the following methods:
-//   * String::String(const T& t, int precision = DefaultOutputPrecision)
-//   * Xml::Element::Element(const String& tagWord, const T& value,
-//         int precision = String::DefaultOutputPrecision)
-//   * Xml::Element::setValueAs(const T& value,
-//         int precision = String::DefaultOutputPrecision)
-// - It could be altered to be any integer without causing an error, but some
-//   care should be taken before making a change.
-//   * Simbody users (e.g., OpenSim devs) may have written software around a
-//     default output precision of 6 (e.g., model files, GUI displays).
-//   * The default output precision should be greater than or equal to 1 and
-//     less than or equal to SimTK::LosslessNumDigitsReal.
-// ------------
-/** The default output precision of the templatized string constructor is 6,
-which corresponds to the default output precision of std::ostream objects.
-See String::String(const T& t, int precision). */
-static const int DefaultOutputPrecision{6};
+/** For any type T for which there is no matching constructor, this templatized
+constructor will format an object of type T into a %String provided that there
+is either an available specialization or (as a last resort) a stream insertion
+operator<<() available for type T; a *runtime* error is thrown if neither is
+available.
+@param t %Value to be converted to a %String. **/
+template <class T> inline explicit
+String(const T& t);
 
 /** For any type T for which there is no matching constructor, this templatized
 constructor will format an object of type T into a %String provided that there
@@ -192,12 +180,11 @@ is either an available specialization or (as a last resort) a stream insertion
 operator<<() available for type T; a *runtime* error is thrown if neither is
 available.
 @param t %Value to be converted to a %String.
-@param precision Optional argument specifying the number of significant
-figures with which t will be represented. The default number is given by the
-constant String::DefaultOutputPrecision. Any precision above
-SimTK::LosslessNumDigitsReal is capped at SimTK::LosslessNumDigitsReal. **/
+@param precision Number of significant figures with which t will be represented.
+Any precision above SimTK::LosslessNumDigitsReal is capped at
+SimTK::LosslessNumDigitsReal. **/
 template <class T> inline explicit
-String(const T& t, int precision = String::DefaultOutputPrecision);
+String(const T& t, int precision);
 
 /** Constructing a %String from a negated value converts to the underlying
 native type and then uses one of the native-type constructors. **/
@@ -387,6 +374,14 @@ auto stringStreamExtractHelper(std::istringstream& is, T& t, int)
 /** @endcond **/
 
 // Implementation of the generic templatized String constructor.
+template <class T> inline
+String::String(const T& t) {
+    std::ostringstream os;
+    *this = stringStreamInsertHelper(os, t, true).str();
+}
+
+// Implementation of the generic templatized String constructor
+// with precision.
 template <class T> inline
 String::String(const T& t, int precision) {
     std::ostringstream os;

--- a/SimTKcommon/include/SimTKcommon/internal/Xml.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Xml.h
@@ -1074,15 +1074,24 @@ allowed (generally any type for which a stream insertion operator<<()
 exists).
 @param tagWord Tag word used to identify the %Element.
 @param value %Value given to the %Element to be converted to a %String.
-@param precision Optional argument specifying the number of significant
-figures with which the value will be represented. The default number is
-given by the constant String::DefaultOutputPrecision. Any precision above
-SimTK::LosslessNumDigitsReal is set to SimTK::LosslessNumDigitsReal.
-@see getValueAs<T>(), setValueAs<T>()**/
+@see getValueAs<T>(), setValueAs<T>() **/
 template <class T>
-Element(const String& tagWord, const T& value,
-    int precision = String::DefaultOutputPrecision)
-{   new(this) Element(tagWord, String(value, precision)); }
+Element(const String& tagWord, const T& value) :
+    Element(tagWord, String(value)) { }
+
+/** Create a new value element and set its initial value to the text
+equivalent of any type T for which a conversion construction String(T) is
+allowed (generally any type for which a stream insertion operator<<()
+exists).
+@param tagWord Tag word used to identify the %Element.
+@param value %Value given to the %Element to be converted to a %String.
+@param precision Number of significant figures with which the value will be
+represented. Any precision above SimTK::LosslessNumDigitsReal is capped at
+SimTK::LosslessNumDigitsReal.
+@see getValueAs<T>(), setValueAs<T>() **/
+template <class T>
+Element(const String& tagWord, const T& value, int precision) :
+    Element(tagWord, String(value, precision)) { }
 
 /** The clone() method makes a deep copy of this Element and its children and
 returns a new orphan Element with the same contents; ordinary assignment and
@@ -1170,15 +1179,24 @@ void setValue(const String& value);
 /** Set the value of this value element to the text equivalent of any type T
 for which a conversion construction String(T) is allowed (generally any
 type for which a stream insertion operator<<() exists).
-@param value %Value to be converted to a %String.
-@param precision Optional argument specifying the number of significant
-figures with which the value will be represented. The default number is
-given by the constant String::DefaultOutputPrecision. Any precision above
-SimTK::LosslessNumDigitsReal is set to SimTK::LosslessNumDigitsReal. **/
+@param value %Value to be converted to a %String. **/
 template <class T>
-void setValueAs(const T& value,
-    int precision = String::DefaultOutputPrecision)
-{   setValue(String(value, precision)); }
+void setValueAs(const T& value) {
+    setValue(String(value));
+}
+
+/** Set the value of this value element to the text equivalent of any type T
+for which a conversion construction String(T) is allowed (generally any
+type for which a stream insertion operator<<() exists).
+@param value %Value to be converted to a %String.
+@param precision Number of significant figures with which the value will be
+represented. Any precision above SimTK::LosslessNumDigitsReal is capped at
+SimTK::LosslessNumDigitsReal. **/
+template <class T>
+void setValueAs(const T& value, int precision) {
+    // precision will be capped in the String constructor if needed.
+    setValue(String(value, precision));
+}
 
 /** Assuming this is a "value element", convert its text value to the type
 of the template argument T. It is an error if the text can not be converted,


### PR DESCRIPTION
This PR fixes issue #778.  The fix is to remove ```precision``` as an optional argument in the following methods, returning their signatures to their form prior to #776, and to add three new methods with ```precision``` as a non-optional argument.

---- Methods in #776
```
String::String(const T& t, int precision = String::DefaultOutputPrecision)
Xml::Element(const String& tagWord, const T& value, int precision = String::DefaultOutputPrecision)
Xml::setValueAs(const T& value, int precision = String::DefaultOutputPrecision)
```
---- Methods prior to #776 (original signatures)
```
String::String(const T& t)
Xml::Element(const String& tagWord, const T& value)
Xml::setValueAs(const T& value)
```

---- New methods (non-optional precision argument)
```
String::String(const T& t, int precision)
Xml::Element(const String& tagWord, const T& value, int precision)
Xml::setValueAs(const T& value, int precision)
```

With this approach, variables of type ```bool``` are handled properly.  When a demand for a number of significant figures other than the default ```std::ostream``` value (i.e., 6) arise, users should simply call one of the new added methods with the desired precision. An added benefit of this approach is that the constant ```String::DefaultOutputPrecision```, which was added in #776, could be (and was) removed.

The subunit test, ```Xml.cpp::TestXml::testOutputPrecision``` has been updated to account for the above changes. In particular, all references to ```String::DefaultOuputPrecision``` were removed, and ```SimTK_TEST()``` calls for variables of type bool were added.

User-facing documentation was also updated.