### PR TITLE
Xml String Precision Bug Fix 2

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -1,4 +1,4 @@
-#ifndef SimTK_SimTKCOMMON_STRING_H_
+﻿#ifndef SimTK_SimTKCOMMON_STRING_H_
 #define SimTK_SimTKCOMMON_STRING_H_
 
 /* -------------------------------------------------------------------------- *
@@ -181,8 +181,8 @@ operator<<() available for type T; a *runtime* error is thrown if neither is
 available.
 @param t %Value to be converted to a %String.
 @param precision Number of significant figures with which t will be represented.
-Any precision above SimTK::LosslessNumDigitsReal is capped at
-SimTK::LosslessNumDigitsReal. **/
+Bounds are enforced so that ```1 ≤ precision ≤ SimTK::LosslessNumDigitsReal```.
+*/
 template <class T> inline explicit
 String(const T& t, int precision);
 
@@ -382,10 +382,15 @@ String::String(const T& t) {
 
 // Implementation of the generic templatized String constructor
 // with precision.
+// To ensure consistent behavior of ostream::setprecision() across operating
+// systems and whether a build is debug or release, precision is bounded:
+// 1 <= precision <= SimTK::LosslessNumDigitsReal
 template <class T> inline
 String::String(const T& t, int precision) {
     std::ostringstream os;
-    if(precision > SimTK::LosslessNumDigitsReal)
+    if(precision < 1)
+        precision = 1;
+    else if(precision > SimTK::LosslessNumDigitsReal)
         precision = SimTK::LosslessNumDigitsReal;
     os << std::setprecision(precision);
     *this = stringStreamInsertHelper(os, t, true).str();

--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -181,7 +181,7 @@ operator<<() available for type T; a *runtime* error is thrown if neither is
 available.
 @param t %Value to be converted to a %String.
 @param precision Number of significant figures with which t will be represented.
-Bounds are enforced so that ```1 ≤ precision ≤ SimTK::LosslessNumDigitsReal```.
+Bounds are enforced so that `1 ≤ precision ≤ SimTK::LosslessNumDigitsReal`.
 */
 template <class T> inline explicit
 String(const T& t, int precision);

--- a/SimTKcommon/include/SimTKcommon/internal/String.h
+++ b/SimTKcommon/include/SimTKcommon/internal/String.h
@@ -165,26 +165,14 @@ explicit String(std::complex<double> r, const char* fmt="%.17g")
 or "0" cast the bool to an int first. **/
 explicit String(bool b) : std::string(b?"true":"false") { }
 
-// ------------
-// Developer Notes Re: String::DefaultOutputPrecision
-// - This constant was added February 2024 to provide a consistent default
-//   value of the precision argument in the following methods:
-//   * String::String(const T& t, int precision = DefaultOutputPrecision)
-//   * Xml::Element::Element(const String& tagWord, const T& value,
-//         int precision = String::DefaultOutputPrecision)
-//   * Xml::Element::setValueAs(const T& value,
-//         int precision = String::DefaultOutputPrecision)
-// - It could be altered to be any integer without causing an error, but some
-//   care should be taken before making a change.
-//   * Simbody users (e.g., OpenSim devs) may have written software around a
-//     default output precision of 6 (e.g., model files, GUI displays).
-//   * The default output precision should be greater than or equal to 1 and
-//     less than or equal to SimTK::LosslessNumDigitsReal.
-// ------------
-/** The default output precision of the templatized string constructor is 6,
-which corresponds to the default output precision of std::ostream objects.
-See String::String(const T& t, int precision). */
-static const int DefaultOutputPrecision{6};
+/** For any type T for which there is no matching constructor, this templatized
+constructor will format an object of type T into a %String provided that there
+is either an available specialization or (as a last resort) a stream insertion
+operator<<() available for type T; a *runtime* error is thrown if neither is
+available.
+@param t %Value to be converted to a %String. **/
+template <class T> inline explicit
+String(const T& t);
 
 /** For any type T for which there is no matching constructor, this templatized
 constructor will format an object of type T into a %String provided that there
@@ -192,12 +180,11 @@ is either an available specialization or (as a last resort) a stream insertion
 operator<<() available for type T; a *runtime* error is thrown if neither is
 available.
 @param t %Value to be converted to a %String.
-@param precision Optional argument specifying the number of significant
-figures with which t will be represented. The default number is given by the
-constant String::DefaultOutputPrecision. Any precision above
-SimTK::LosslessNumDigitsReal is capped at SimTK::LosslessNumDigitsReal. **/
+@param precision Number of significant figures with which t will be represented.
+Any precision above SimTK::LosslessNumDigitsReal is capped at
+SimTK::LosslessNumDigitsReal. **/
 template <class T> inline explicit
-String(const T& t, int precision = String::DefaultOutputPrecision);
+String(const T& t, int precision);
 
 /** Constructing a %String from a negated value converts to the underlying
 native type and then uses one of the native-type constructors. **/
@@ -387,6 +374,14 @@ auto stringStreamExtractHelper(std::istringstream& is, T& t, int)
 /** @endcond **/
 
 // Implementation of the generic templatized String constructor.
+template <class T> inline
+String::String(const T& t) {
+    std::ostringstream os;
+    *this = stringStreamInsertHelper(os, t, true).str();
+}
+
+// Implementation of the generic templatized String constructor
+// with precision.
 template <class T> inline
 String::String(const T& t, int precision) {
     std::ostringstream os;

--- a/SimTKcommon/include/SimTKcommon/internal/Xml.h
+++ b/SimTKcommon/include/SimTKcommon/internal/Xml.h
@@ -1074,15 +1074,24 @@ allowed (generally any type for which a stream insertion operator<<()
 exists).
 @param tagWord Tag word used to identify the %Element.
 @param value %Value given to the %Element to be converted to a %String.
-@param precision Optional argument specifying the number of significant
-figures with which the value will be represented. The default number is
-given by the constant String::DefaultOutputPrecision. Any precision above
-SimTK::LosslessNumDigitsReal is set to SimTK::LosslessNumDigitsReal.
-@see getValueAs<T>(), setValueAs<T>()**/
+@see getValueAs<T>(), setValueAs<T>() **/
 template <class T>
-Element(const String& tagWord, const T& value,
-    int precision = String::DefaultOutputPrecision)
-{   new(this) Element(tagWord, String(value, precision)); }
+Element(const String& tagWord, const T& value) :
+    Element(tagWord, String(value)) { }
+
+/** Create a new value element and set its initial value to the text
+equivalent of any type T for which a conversion construction String(T) is
+allowed (generally any type for which a stream insertion operator<<()
+exists).
+@param tagWord Tag word used to identify the %Element.
+@param value %Value given to the %Element to be converted to a %String.
+@param precision Number of significant figures with which the value will be
+represented. Any precision above SimTK::LosslessNumDigitsReal is capped at
+SimTK::LosslessNumDigitsReal.
+@see getValueAs<T>(), setValueAs<T>() **/
+template <class T>
+Element(const String& tagWord, const T& value, int precision) :
+    Element(tagWord, String(value, precision)) { }
 
 /** The clone() method makes a deep copy of this Element and its children and
 returns a new orphan Element with the same contents; ordinary assignment and
@@ -1170,15 +1179,24 @@ void setValue(const String& value);
 /** Set the value of this value element to the text equivalent of any type T
 for which a conversion construction String(T) is allowed (generally any
 type for which a stream insertion operator<<() exists).
-@param value %Value to be converted to a %String.
-@param precision Optional argument specifying the number of significant
-figures with which the value will be represented. The default number is
-given by the constant String::DefaultOutputPrecision. Any precision above
-SimTK::LosslessNumDigitsReal is set to SimTK::LosslessNumDigitsReal. **/
+@param value %Value to be converted to a %String. **/
 template <class T>
-void setValueAs(const T& value,
-    int precision = String::DefaultOutputPrecision)
-{   setValue(String(value, precision)); }
+void setValueAs(const T& value) {
+    setValue(String(value));
+}
+
+/** Set the value of this value element to the text equivalent of any type T
+for which a conversion construction String(T) is allowed (generally any
+type for which a stream insertion operator<<() exists).
+@param value %Value to be converted to a %String.
+@param precision Number of significant figures with which the value will be
+represented. Any precision above SimTK::LosslessNumDigitsReal is capped at
+SimTK::LosslessNumDigitsReal. **/
+template <class T>
+void setValueAs(const T& value, int precision) {
+    // precision will be capped in the String constructor if needed.
+    setValue(String(value, precision));
+}
 
 /** Assuming this is a "value element", convert its text value to the type
 of the template argument T. It is an error if the text can not be converted,

--- a/SimTKcommon/tests/TestXml.cpp
+++ b/SimTKcommon/tests/TestXml.cpp
@@ -407,28 +407,19 @@ void testOutputPrecision() {
         }
     }
 
-    // Note that nothing bad happens when p is neg or 0.
-    // String::String() does not check for p < 0 or p == 0; it just
-    // relies on std::ostream to handle such values.
-    // If the following tests fail, it may be because the implementation
-    // of std::ostream varies across operating systems or has changed
-    // since these tests were first put in place.
-    // -----
-    // p < 0: ostream does not accept and falls back on its starting precision.
-    // 'starting_precision' (see above) is used to get the default output
-    // value (see below) to handle a situation in which
-    // String::DefaultOuputPrecision differs from ostream.precision()
-    String outputDefault(input, (int)starting_precision);
+    // Test when precision is less than 1.
+    // Implementations of std::ostreatm::setprecision() may differ.
+    // To ensure uniform behavior std libraries, precision is bounded.
+    // In String::String(const T& t, int p), if p <= 1, p is set to 1.
+    // p < 0: 
     String outputNeg(input,-2);
-    SimTK_TEST(outputNeg == outputDefault);
-    // -----
-    // p = 0: ostream takes the min p that applies (p = 1)
-    String outputOne(input, 1);
+    SimTK_TEST(outputNeg == expected[1]);
+    // p = 0:
     String outputZero(input, 0); 
-    SimTK_TEST(outputZero == outputOne);
+    SimTK_TEST(outputZero == expected[1]);
 
     // Test when precision is greater than LosslessNumDigits.
-    // In String::String(), p is capped at LosslessNumDigits.
+    // In String::String(const T& t, int p), p is capped at LosslessNumDigits.
     String outputLossless(input, SimTK::LosslessNumDigitsReal);
     String outputLosslessPlus1(input, SimTK::LosslessNumDigitsReal+1);
     SimTK_TEST(outputLosslessPlus1 == outputLossless);

--- a/SimTKcommon/tests/TestXml.cpp
+++ b/SimTKcommon/tests/TestXml.cpp
@@ -324,7 +324,7 @@ void testStringConvert() {
 
 }
 
-// February 2024
+// March 2024
 // The ability to specify output precision was added by adding three new
 // methods to the SimTK API. In particular, a precision argument was added
 // to the following methods:

--- a/SimTKcommon/tests/TestXml.cpp
+++ b/SimTKcommon/tests/TestXml.cpp
@@ -408,9 +408,9 @@ void testOutputPrecision() {
     }
 
     // Test when precision is less than 1.
-    // Implementations of std::ostreatm::setprecision() may differ.
-    // To ensure uniform behavior std libraries, precision is bounded.
-    // In String::String(const T& t, int p), if p <= 1, p is set to 1.
+    // Implementations of std::ostream::setprecision() may differ.
+    // To ensure uniform behavior from std libraries, precision is bounded.
+    // In String::String(const T& t, int p), if p < 1, p is set to 1.
     // p < 0: 
     String outputNeg(input,-2);
     SimTK_TEST(outputNeg == expected[1]);


### PR DESCRIPTION
It was discovered that implementations of ```std::ostream::setprecision()``` in the C++ Standard Library may differ. See Issue https://github.com/simbody/simbody/issues/780.

To ensure consistent behavior of ```std::ostream::setprecision()``` across operating systems and whether a build is debug or release, ```precision``` is now bounded in ```SimTK::String::String(const T& t, int precision)``` so that 

```
1 <= precision <= SimTK::LosslessNumDigitsReal
```
before the call to ```std::ostream::setprecision()``` is made.

Documentation and tests in TestXML.cpp have been updated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/781)
<!-- Reviewable:end -->
