### PR TITLE
Add methods for computing the Jacobian `PV = [P; V]` to SimbodyMatterSubsystem

### DIFF
--- a/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
+++ b/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
@@ -1917,9 +1917,9 @@ calcBodyAccelerationFromUDot() for more information (converting from
 generalized speeds to velocities is just multiplying by the System Jacobian).
 The method calcBiasForMultiplyByPV() is used to determine the state-dependent
 term of the constraint error equations. Then a second call is made to
-evaluate the bias terms paerr(t,q,u;0)=-bp(t,q,u) and vaerr(t,q,u;0)=-bv(t,q,u).
-We then calculate PVulike = [Pulike; Vulike] in O(mp+mv) time, where
-Pulike = paerr(t,q,u;ulike)-paerr(t,q,u;0) and
+evaluate the bias terms paerr(t,q,u;0)=-b_p(t,q,u) and
+vaerr(t,q,u;0)=-b_v(t,q,u). We then calculate PVulike = [Pulike; Vulike] in
+O(mp+mv) time, where Pulike = paerr(t,q,u;ulike)-paerr(t,q,u;0) and
 Vulike = vaerr(t,q,u;ulike)-vaerr(t,q,u;0).
 
 @see calcBiasForMultiplyByPV() **/
@@ -1958,8 +1958,8 @@ functions with zero input to determine the bias term for use in
 multiplyByPV(). Body quantities and generalized quantities are supplied to each
 of the m active constraints' (constant time) error methods to calculate
 <pre>
-   pverr(t,q,u;ulike)=P*ulike - c(t,q)     (holonomic)
-or vaerr(t,q,u;ulike)=V*ulike - b(t,q,u)   (non-holonomic)
+   pverr(t,q,u;ulike)=P*ulike - c(t,q)      (holonomic)
+or vaerr(t,q,u;ulike)=V*ulike - b_v(t,q,u)  (non-holonomic)
 </pre>
 with ulike=0, giving the bias term in O(mp+mv) time.
 

--- a/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
+++ b/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
@@ -1934,7 +1934,7 @@ void multiplyByPV(const State&  state,
 /** Multiply PVulike=PV*ulike where PV = [P;V] using the supplied precalculated
 bias vector to improve performance (approximately 2X) over the other signature.
 @see calcBiasForMultiplyByPV() **/
-void multiplyByPV(const State&  state,
+void multiplyByPV(const State&   state,
                   const Vector&  ulike,
                   const Vector&  biaspv,
                   Vector&        PVulike) const;
@@ -2022,15 +2022,15 @@ void multiplyByPVTranspose(const State&  state,
                            const Vector& lambdapv,
                            Vector&       fpv) const;
 
-/** This O(n(mp+mv)) operator explicitly calculates the n X (mp+mv) transpose of
-PV = [P;V], a submatrix of the acceleration-level constraint Jacobian G, which
-appears in the system equations of motion. This method generates ~PV columnwise
-using the constraint force generating methods which map constraint multipliers
-to constraint forces. To within numerical error, this should be identical to the
-transpose of the matrix returned by calcPV() which uses a different method.
-Consider using the multiplyByPVTranspose() method instead of this one, which
-forms the matrix-vector product ~PV*v in O(n) time without explicitly forming
-~PV.
+/** This O(n*(mp+mv)) operator explicitly calculates the n X (mp+mv) transpose
+of PV = [P;V], a submatrix of the acceleration-level constraint Jacobian G,
+which appears in the system equations of motion. This method generates ~PV
+columnwise using the constraint force generating methods which map constraint
+multipliers to constraint forces. To within numerical error, this should be
+identical to the transpose of the matrix returned by calcPV() which uses a
+different method. Consider using the multiplyByPVTranspose() method instead of
+this one, which forms the matrix-vector product ~PV*v in O(n) time without
+explicitly forming ~PV.
 @par Required stage
   \c Stage::Velocity
 @see calcPV(), multiplyByPVTranspose() **/

--- a/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
+++ b/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
@@ -1972,11 +1972,11 @@ void calcBiasForMultiplyByPV(const State& state,
 acceleration-level constraint matrix PV = [P;A] (a submatrix of the full
 constraint Jacobian G) which appears in the system equations of motion. Consider
 using the multiplyByPV() method instead of this one, which forms the matrix-
-vector product PV*v in O(mp+mv+n) time without explicitly forming PV.
+vector product PV*u in O(mp+mv+n) time without explicitly forming PV.
 
 @par Implementation
 This method generates PV columnwise using repeated calls to multiplyByPV(),
-which makes use of the constraint error methods to perform a PV*v product
+which makes use of the constraint error methods to perform a PV*u product
 in O(mp+mv+n) time. To within numerical error, for non-working constraints
 this should be identical to the transpose of the matrix returned by calcPVt()
 which uses the constraint force methods instead.

--- a/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
+++ b/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
@@ -1535,10 +1535,10 @@ functions with zero input to determine the bias term for use in
 multiplyByG(). Body quantities and generalized quantities are supplied to each 
 of the m active constraints' (constant time) error methods to calculate
 <pre>
-   pverr(t,q,u;ulike)=G*ulike - c(t,q)    (holonomic)
+   pverr(t,q,u;ulike)=G*ulike - c(t,q)    (holonomic) 
 or aerr(t,q,u;ulike)=G*ulike - b(t,q,u)   (nonholonomic or acceleration-only)
 </pre>
-with ulike=0, giving the bias term in O(m) time.
+with ulike=0, giving the bias term in O(m) time. 
 
 If you want the acceleration-level bias terms b for all the constraints, even
 if they are holonomic, use calcBiasForAccelerationConstraints(). **/
@@ -1679,7 +1679,7 @@ void multiplyByGTranspose(const State&  state,
     
 /** This O(nm) operator explicitly calculates the n X m transpose of the 
 acceleration-level constraint Jacobian G = [P;V;A] which appears in the system 
-equations of motion. This method generates ~G columnwise using the constraint
+equations of motion. This method generates ~G columnwise using the constraint 
 force generating methods which map constraint multipliers to constraint forces.
 To within numerical error, this should be identical to the transpose of
 the matrix returned by calcG() which uses a different method. Consider using 

--- a/Simbody/src/SimbodyMatterSubsystem.cpp
+++ b/Simbody/src/SimbodyMatterSubsystem.cpp
@@ -646,7 +646,7 @@ multiplyByPVTranspose(const State&  s,
     const int mHolo    = ic.totalNHolonomicConstraintEquationsInUse;
     const int mNonholo = ic.totalNNonholonomicConstraintEquationsInUse;
     const int mpv  = mHolo+mNonholo;
-    const int nu = rep.getNU(s);
+    const int nu   = rep.getNU(s);
 
     SimTK_ERRCHK2_ALWAYS(lambdapv.size() == mpv,
         "SimbodyMatterSubsystem::multiplyByPVTranspose()",
@@ -999,7 +999,7 @@ multiplyByPV(const State&  s,
     const int mHolo    = ic.totalNHolonomicConstraintEquationsInUse;
     const int mNonholo = ic.totalNNonholonomicConstraintEquationsInUse;
     const int mpv  = mHolo+mNonholo;
-    const int nu = rep.getNU(s);
+    const int nu   = rep.getNU(s);
 
     SimTK_ERRCHK2_ALWAYS(ulike.size() == nu,
         "SimbodyMatterSubsystem::multiplyByPV()",

--- a/Simbody/src/SimbodyMatterSubsystem.cpp
+++ b/Simbody/src/SimbodyMatterSubsystem.cpp
@@ -645,8 +645,8 @@ multiplyByPVTranspose(const State&  s,
     // Global problem dimensions.
     const int mHolo    = ic.totalNHolonomicConstraintEquationsInUse;
     const int mNonholo = ic.totalNNonholonomicConstraintEquationsInUse;
-    const int mpv  = mHolo+mNonholo;
-    const int nu   = rep.getNU(s);
+    const int mpv = mHolo+mNonholo;
+    const int nu  = rep.getNU(s);
 
     SimTK_ERRCHK2_ALWAYS(lambdapv.size() == mpv,
         "SimbodyMatterSubsystem::multiplyByPVTranspose()",
@@ -887,7 +887,7 @@ calcConstraintAccelerationErrors(const State&               state,
 //==============================================================================
 //                            MULTIPLY BY Pq
 //==============================================================================
-// Check arguments, copy in/out of contiguous Vectors if necssary, call the
+// Check arguments, copy in/out of contiguous Vectors if necessary, call the
 // implementation method.
 void SimbodyMatterSubsystem::
 multiplyByPq(const State&   s,
@@ -988,9 +988,9 @@ calcBiasForMultiplyByPq(const State& state,
 // implementation method.
 void SimbodyMatterSubsystem::
 multiplyByPV(const State&  s,
-            const Vector& ulike,
-            const Vector& biaspv,
-            Vector&       PVulike) const
+             const Vector& ulike,
+             const Vector& biaspv,
+             Vector&       PVulike) const
 {
     const SimbodyMatterSubsystemRep& rep = getRep();
     const SBInstanceCache& ic = rep.getInstanceCache(s);
@@ -998,8 +998,8 @@ multiplyByPV(const State&  s,
     // Global problem dimensions.
     const int mHolo    = ic.totalNHolonomicConstraintEquationsInUse;
     const int mNonholo = ic.totalNNonholonomicConstraintEquationsInUse;
-    const int mpv  = mHolo+mNonholo;
-    const int nu   = rep.getNU(s);
+    const int mpv = mHolo+mNonholo;
+    const int nu  = rep.getNU(s);
 
     SimTK_ERRCHK2_ALWAYS(ulike.size() == nu,
         "SimbodyMatterSubsystem::multiplyByPV()",

--- a/Simbody/src/SimbodyMatterSubsystemRep.h
+++ b/Simbody/src/SimbodyMatterSubsystemRep.h
@@ -812,8 +812,9 @@ public:
     // Form the product 
     //    fu = [ ~P ~V ~A ] * lambda
     // with all or a subset of P,V,A included. The multiplier-like vector
-    // must have length equal to the total number of kinematic constraints for
-    // the included submatrices; the maximum length is m=mp+mv+ma.
+    // must have length equal to the total number of active kinematic
+    // constraints for the included submatrices; the maximum length is
+    // m=mp+mv+ma.
     // This is an O(n+m) method.
     void multiplyByPVATranspose(const State&     state,
                                 bool             includeP,

--- a/Simbody/src/SimbodyMatterSubsystemRep.h
+++ b/Simbody/src/SimbodyMatterSubsystemRep.h
@@ -811,8 +811,10 @@ public:
 
     // Form the product 
     //    fu = [ ~P ~V ~A ] * lambda
-    // with all or a subset of P,V,A included. The multiplier-like vector 
-    // must have length m=mp+mv+ma always. This is an O(n+m) method.
+    // with all or a subset of P,V,A included. The multiplier-like vector
+    // 'lambda' must have length equal to the number of kinematic constraints
+    // associated with the selected submatrices; the maximum length is
+    // m=mp+mv+ma. This is an O(n+m) method.
     void multiplyByPVATranspose(const State&     state,
                                 bool             includeP,
                                 bool             includeV,

--- a/Simbody/src/SimbodyMatterSubsystemRep.h
+++ b/Simbody/src/SimbodyMatterSubsystemRep.h
@@ -812,9 +812,9 @@ public:
     // Form the product 
     //    fu = [ ~P ~V ~A ] * lambda
     // with all or a subset of P,V,A included. The multiplier-like vector
-    // 'lambda' must have length equal to the number of kinematic constraints
-    // associated with the selected submatrices; the maximum length is
-    // m=mp+mv+ma. This is an O(n+m) method.
+    // must have length equal to the total number of kinematic constraints for
+    // the included submatrices; the maximum length is m=mp+mv+ma.
+    // This is an O(n+m) method.
     void multiplyByPVATranspose(const State&     state,
                                 bool             includeP,
                                 bool             includeV,


### PR DESCRIPTION
Fixes #782.

This PR adds the desired method `multiplyByPVTranspose()` to `SimbodyMatterSubsystem`. It seemed logical to add the additional methods `multiplyByPV()` (both signatures), `calcBiasForMultiplyByPV()`, `calcPV()`, and `calcPVTranspose()` similar to the methods for `Pq` and `G`. I've added relevant tests to `TestConstraints.cpp`. 

Minor: I fixed a couple of typos in comment strings and also updated the comment for `multiplyByPVATranspose()` to more clearly describe the size requirement for the input argument `lambda`.

I'll leave a comment or two in the changes below with some other questions I add.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/783)
<!-- Reviewable:end -->
