### PR TITLE
Fixed LoneParticle bugs in getHCol() and getH_FMCol()

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,54 @@
+# -*- yaml -*-
+
+# This file determines clang-format's style settings; for details, refer to
+# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+BasedOnStyle:  Google
+IndentWidth: 4
+
+Language: Cpp
+
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# Compress functions onto a single line (when they fit) iff they are defined
+# inline (inside a of class) or are empty.
+AllowShortFunctionsOnASingleLine: Inline
+
+# Compress lambdas onto a single line iff they are empty.
+AllowShortLambdasOnASingleLine: Empty
+
+# Specify the #include statement order.  This implements the order mandated by
+# the Google C++ Style Guide: related header, C headers, C++ headers, library
+# headers, and finally the project headers.
+#
+# To obtain updated lists of system headers used in the below expressions, see:
+# http://stackoverflow.com/questions/2027991/list-of-standard-header-files-in-c-and-c/2029106#2029106.
+IncludeCategories:
+  # Spacers used by drake/tools/formatter.py.
+  - Regex:    '^<clang-format-priority-15>$'
+    Priority: 15
+  - Regex:    '^<clang-format-priority-25>$'
+    Priority: 25
+  - Regex:    '^<clang-format-priority-35>$'
+    Priority: 35
+  - Regex:    '^<clang-format-priority-45>$'
+    Priority: 45
+  # C system headers.  The header_dependency_test.py contains a copy of this
+  # list; be sure to update that test anytime this list changes.
+  - Regex:    '^[<"](aio|arpa/inet|assert|complex|cpio|ctype|curses|dirent|dlfcn|errno|fcntl|fenv|float|fmtmsg|fnmatch|ftw|glob|grp|iconv|inttypes|iso646|langinfo|libgen|limits|locale|math|monetary|mqueue|ndbm|netdb|net/if|netinet/in|netinet/tcp|nl_types|poll|pthread|pwd|regex|sched|search|semaphore|setjmp|signal|spawn|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|strings|stropts|sys/ipc|syslog|sys/mman|sys/msg|sys/resource|sys/select|sys/sem|sys/shm|sys/socket|sys/stat|sys/statvfs|sys/time|sys/times|sys/types|sys/uio|sys/un|sys/utsname|sys/wait|tar|term|termios|tgmath|threads|time|trace|uchar|ulimit|uncntrl|unistd|utime|utmpx|wchar|wctype|wordexp)\.h[">]$'
+    Priority: 20
+  # C++ system headers (as of C++23).  The header_dependency_test.py contains a
+  # copy of this list; be sure to update that test anytime this list changes.
+  - Regex:    '^[<"](algorithm|any|array|atomic|barrier|bit|bitset|cassert|ccomplex|cctype|cerrno|cfenv|cfloat|charconv|chrono|cinttypes|ciso646|climits|clocale|cmath|codecvt|compare|complex|concepts|condition_variable|coroutine|csetjmp|csignal|cstdalign|cstdarg|cstdbool|cstddef|cstdint|cstdio|cstdlib|cstring|ctgmath|ctime|cuchar|cwchar|cwctype|deque|exception|execution|expected|filesystem|flat_map|flat_set|format|forward_list|fstream|functional|future|generator|initializer_list|iomanip|ios|iosfwd|iostream|istream|iterator|latch|limits|list|locale|map|mdspan|memory|memory_resource|mutex|new|numbers|numeric|optional|ostream|print|queue|random|ranges|ratio|regex|scoped_allocator|semaphore|set|shared_mutex|source_location|span|spanstream|sstream|stack|stacktrace|stdexcept|stdfloat|stop_token|streambuf|string|string_view|strstream|syncstream|system_error|thread|tuple|type_traits|typeindex|typeinfo|unordered_map|unordered_set|utility|valarray|variant|vector|version)[">]$'
+    Priority: 30
+  # Other libraries' h files (with angles).
+  - Regex:    '^<'
+    Priority: 40
+  # Your project's h files.
+  - Regex:    '^"drake'
+    Priority: 50
+  # Other libraries' h files (with quotes).
+  - Regex:    '^"'
+    Priority: 40

--- a/Simbody/include/simbody/internal/MobilizedBody.h
+++ b/Simbody/include/simbody/internal/MobilizedBody.h
@@ -648,7 +648,7 @@ void setUToFitLinearVelocity(State& state, const Vec3& v_FM) const;
 of this mobilizer's mobilities (actually a column of H_PB_G; what Jain calls H* 
 and Schwieters calls H^T). This is the matrix that maps generalized speeds u to 
 the cross-body relative spatial velocity V_PB_G via V_PB_G=H*u. Note that 
-although H relates child body B to parent body B, it is expressed in the ground 
+although H relates child body B to parent body P, it is expressed in the ground
 frame G so the resulting cross-body velocity of B in P is also expressed in G. 
 The supplied state must have been realized through Position stage because H 
 varies with this mobilizer's generalized coordinates q.

--- a/Simbody/src/RigidBodyNodeSpec.h
+++ b/Simbody/src/RigidBodyNodeSpec.h
@@ -671,9 +671,9 @@ HType&       updH_FM(SBTreePositionCache& pc) const
 // matrix relating parent and body frames, but expressed in Ground.
 // CAUTION: our H definition is transposed from Jain and Schwieters.
 const HType& getH(const SBTreePositionCache& pc) const
-{   return HType::getAs(&pc.storageForH[2*uIndex]); }
+{   return HType::getAs(&pc.storageForH_PB_G[2*uIndex]); }
 HType&       updH(SBTreePositionCache& pc) const
-{   return HType::updAs(&pc.storageForH[2*uIndex]); }
+{   return HType::updAs(&pc.storageForH_PB_G[2*uIndex]); }
 
     // Velocity
 

--- a/Simbody/src/SimbodyTreeState.h
+++ b/Simbody/src/SimbodyTreeState.h
@@ -671,8 +671,10 @@ public:
     // CAUTION: our definition of the H matrix is transposed from those used
     // by Jain and by Schwieters. Jain would call these H* and Schwieters
     // would call them H^T, but we call them H.
-    Array_<Vec3> storageForH_FM; // 2 x ndof (H_FM)
-    Array_<Vec3> storageForH;    // 2 x ndof (H_PB_G)
+    // TODO(sherm1) Since each dof gets a SpatialVec, consider making each
+    //  entry a SpatialVec instead to get rid of the 2x in the index.
+    Array_<Vec3> storageForH_FM;   // 2 x ndof (H_FM)
+    Array_<Vec3> storageForH_PB_G; // 2 x ndof (H_PB_G)
 
     Array_<Transform,MobilizedBodyIndex>    bodyJointInParentJointFrame;  // nb (X_FM)
     Array_<Transform,MobilizedBodyIndex>    bodyConfigInParent;           // nb (X_PB)
@@ -715,7 +717,7 @@ public:
         mobilizerQCache.resize(model.totalNQPoolInUse);
 
         storageForH_FM.resize(2*nDofs);
-        storageForH.resize(2*nDofs);
+        storageForH_PB_G.resize(2*nDofs);
 
         bodyJointInParentJointFrame.resize(nBodies); 
         bodyJointInParentJointFrame[GroundIndex].setToZero();

--- a/Simbody/tests/TestLoneParticle.cpp
+++ b/Simbody/tests/TestLoneParticle.cpp
@@ -21,34 +21,34 @@
  * limitations under the License.                                             *
  * -------------------------------------------------------------------------- */
 
-#include "SimTKsimbody.h"
-#include "SimTKcommon/Testing.h"
-
-#include <vector>
 #include <map>
+#include <vector>
+
+#include "SimTKcommon/Testing.h"
+#include "SimTKsimbody.h"
 
 using namespace SimTK;
 using namespace std;
 
 const Real TOL = 1e-10;
 
-#define ASSERT(cond) {SimTK_ASSERT_ALWAYS(cond, "Assertion failed");}
+#define ASSERT(cond) \
+    { SimTK_ASSERT_ALWAYS(cond, "Assertion failed"); }
 
 template <class T>
 void assertEqual(T val1, T val2) {
-    ASSERT(abs(val1-val2) < TOL);
+    ASSERT(abs(val1 - val2) < TOL);
 }
 
 template <int N>
 void assertEqual(Vec<N> val1, Vec<N> val2) {
-    for (int i = 0; i < N; ++i)
-        ASSERT(abs(val1[i]-val2[i]) < TOL);
+    for (int i = 0; i < N; ++i) ASSERT(abs(val1[i] - val2[i]) < TOL);
 }
 
 static void compareToTranslate(bool prescribe, Motion::Level level) {
-    // Create a system of pairs of identical bodies, where half will be implemented with RBNodeLoneParticle
-    // and half with RBNodeTranslate.
-    
+    // Create a system of pairs of identical bodies, where half will be
+    // implemented with RBNodeLoneParticle and half with RBNodeTranslate.
+
     MultibodySystem system;
     SimbodyMatterSubsystem matter(system);
     GeneralForceSubsystem force(system);
@@ -57,46 +57,53 @@ static void compareToTranslate(bool prescribe, Motion::Level level) {
     Random::Gaussian random(0.0, 3.0);
     const int numBodies = 10;
     for (int i = 0; i < numBodies; i++) {
+        // This is a lone particle mobilizer since all defaults are 0/identity.
         MobilizedBody::Translation body1(matter.updGround(), body);
-        MobilizedBody::Translation body2(matter.updGround(), Vec3(0), body, Vec3(1e-100));
+        // This is a regular translation mobilizer because of the offset.
+        MobilizedBody::Translation body2(matter.updGround(), Vec3(0), body,
+                                         Vec3(1e-100));
         Vec3 station1(random.getValue(), random.getValue(), random.getValue());
         Vec3 station2(random.getValue(), random.getValue(), random.getValue());
         Real length = random.getValue();
-        Force::TwoPointLinearSpring(force, matter.updGround(), station1, body1, station2, 1.0, length);
-        Force::TwoPointLinearSpring(force, matter.updGround(), station1, body2, station2, 1.0, length);
+        Force::TwoPointLinearSpring(force, matter.updGround(), station1, body1,
+                                    station2, 1.0, length);
+        Force::TwoPointLinearSpring(force, matter.updGround(), station1, body2,
+                                    station2, 1.0, length);
         if (prescribe) {
             Real phase = random.getValue();
             Motion::Sinusoid(body1, level, 1.5, 1.1, phase);
             Motion::Sinusoid(body2, level, 1.5, 1.1, phase);
         }
     }
-    
+
     // Initialize the state.
-    
+
     State state = system.realizeTopology();
     for (int i = 0; i < numBodies; i++) {
         Vec3 pos(random.getValue(), random.getValue(), random.getValue());
         Vec3 vel(random.getValue(), random.getValue(), random.getValue());
-        const MobilizedBody& body1 = matter.getMobilizedBody(MobilizedBodyIndex(2*i+1));
-        const MobilizedBody& body2 = matter.getMobilizedBody(MobilizedBodyIndex(2*i+2));
+        const MobilizedBody& body1 =
+            matter.getMobilizedBody(MobilizedBodyIndex(2 * i + 1));
+        const MobilizedBody& body2 =
+            matter.getMobilizedBody(MobilizedBodyIndex(2 * i + 2));
         body1.setQToFitTranslation(state, pos);
         body2.setQToFitTranslation(state, pos);
         body1.setUToFitLinearVelocity(state, vel);
         body2.setUToFitLinearVelocity(state, vel);
     }
-    
+
     // Calculate lots of quantities from the MobilizedBodies.
-    
+
     system.realize(state, Stage::Acceleration);
     Vector_<SpatialVec> reactionForces;
     matter.calcMobilizerReactionForces(state, reactionForces);
     Vector_<SpatialVec> reactionForcesFreebody;
-    matter.calcMobilizerReactionForcesUsingFreebodyMethod(state, reactionForcesFreebody);
+    matter.calcMobilizerReactionForcesUsingFreebodyMethod(
+        state, reactionForcesFreebody);
 
     // Both methods should produce the same results.
     SimTK_TEST_EQ(reactionForces, reactionForcesFreebody);
-    
-    
+
     Vector mv, minvv;
     matter.multiplyByM(state, state.getU(), mv);
     matter.multiplyByMInv(state, state.getU(), minvv);
@@ -104,42 +111,60 @@ static void compareToTranslate(bool prescribe, Motion::Level level) {
     Vector_<SpatialVec> appliedBodyForces(matter.getNumBodies());
     for (int i = 0; i < numBodies; i++) {
         Vec3 mobilityForce;
-        random.fillArray((Real*) &mobilityForce, 3);
-        Vec3::updAs(&appliedMobilityForces[6*i]) = mobilityForce;
-        Vec3::updAs(&appliedMobilityForces[6*i+3]) = mobilityForce;
+        random.fillArray((Real*)&mobilityForce, 3);
+        Vec3::updAs(&appliedMobilityForces[6 * i]) = mobilityForce;
+        Vec3::updAs(&appliedMobilityForces[6 * i + 3]) = mobilityForce;
         SpatialVec bodyForce;
-        random.fillArray((Real*) &bodyForce, 6);
-        appliedBodyForces[2*i+1] = bodyForce;
-        appliedBodyForces[2*i+2] = bodyForce;
+        random.fillArray((Real*)&bodyForce, 6);
+        appliedBodyForces[2 * i + 1] = bodyForce;
+        appliedBodyForces[2 * i + 2] = bodyForce;
     }
     Vector knownUdot, residualMobilityForces;
-    matter.calcResidualForceIgnoringConstraints(state, appliedMobilityForces, appliedBodyForces, knownUdot, residualMobilityForces);
+    matter.calcResidualForceIgnoringConstraints(state, appliedMobilityForces,
+                                                appliedBodyForces, knownUdot,
+                                                residualMobilityForces);
     Vector dEdQ;
     matter.multiplyBySystemJacobianTranspose(state, appliedBodyForces, dEdQ);
-    Array_<SpatialInertia,MobilizedBodyIndex> compositeInertias;
+    Array_<SpatialInertia, MobilizedBodyIndex> compositeInertias;
     matter.calcCompositeBodyInertias(state, compositeInertias);
-    
-    // See whether the RBNodeLoneParticles and the RBNodeTranslates produced identical results.
-    
+
+    // See whether the RBNodeLoneParticles and the RBNodeTranslates produced
+    // identical results.
+
     for (int i = 0; i < numBodies; i++) {
-        MobilizedBodyIndex index1(2*i+1);
-        MobilizedBodyIndex index2(2*i+2);
+        MobilizedBodyIndex index1(2 * i + 1);
+        MobilizedBodyIndex index2(2 * i + 2);
         const MobilizedBody& body1 = matter.getMobilizedBody(index1);
         const MobilizedBody& body2 = matter.getMobilizedBody(index2);
-        assertEqual(body1.getBodyOriginLocation(state), body2.getBodyOriginLocation(state));
-        assertEqual(body1.getBodyOriginVelocity(state), body2.getBodyOriginVelocity(state));
-        assertEqual(body1.getBodyOriginAcceleration(state), body2.getBodyOriginAcceleration(state));
+        assertEqual(body1.getBodyOriginLocation(state),
+                    body2.getBodyOriginLocation(state));
+        assertEqual(body1.getBodyOriginVelocity(state),
+                    body2.getBodyOriginVelocity(state));
+        assertEqual(body1.getBodyOriginAcceleration(state),
+                    body2.getBodyOriginAcceleration(state));
         assertEqual(reactionForces[index1][0], reactionForces[index2][0]);
         assertEqual(reactionForces[index1][1], reactionForces[index2][1]);
-        assertEqual(Vec3::getAs(&mv[6*i]), Vec3::getAs(&mv[6*i+3]));
+        assertEqual(Vec3::getAs(&mv[6 * i]), Vec3::getAs(&mv[6 * i + 3]));
         if (!prescribe)
-            assertEqual(Vec3::getAs(&minvv[6*i]), Vec3::getAs(&minvv[6*i+3]));
-        assertEqual(Vec3::getAs(&residualMobilityForces[6*i]), Vec3::getAs(&residualMobilityForces[6*i+3]));
-        assertEqual(Vec3::getAs(&dEdQ[6*i]), Vec3::getAs(&dEdQ[6*i+3]));
-        assertEqual(compositeInertias[index1].getMass(), compositeInertias[index2].getMass());
-        assertEqual(compositeInertias[index1].getMassCenter(), compositeInertias[index2].getMassCenter());
-        assertEqual(compositeInertias[index1].getUnitInertia().getMoments(), compositeInertias[index2].getUnitInertia().getMoments());
-        assertEqual(compositeInertias[index1].getUnitInertia().getProducts(), compositeInertias[index2].getUnitInertia().getProducts());
+            assertEqual(Vec3::getAs(&minvv[6 * i]),
+                        Vec3::getAs(&minvv[6 * i + 3]));
+        assertEqual(Vec3::getAs(&residualMobilityForces[6 * i]),
+                    Vec3::getAs(&residualMobilityForces[6 * i + 3]));
+        assertEqual(Vec3::getAs(&dEdQ[6 * i]), Vec3::getAs(&dEdQ[6 * i + 3]));
+        assertEqual(compositeInertias[index1].getMass(),
+                    compositeInertias[index2].getMass());
+        assertEqual(compositeInertias[index1].getMassCenter(),
+                    compositeInertias[index2].getMassCenter());
+        assertEqual(compositeInertias[index1].getUnitInertia().getMoments(),
+                    compositeInertias[index2].getUnitInertia().getMoments());
+        assertEqual(compositeInertias[index1].getUnitInertia().getProducts(),
+                    compositeInertias[index2].getUnitInertia().getProducts());
+
+        for (MobilizerUIndex j(0); j < 3; ++j) {
+            SimTK_TEST_EQ(body1.getHCol(state, j), body2.getHCol(state, j));
+            SimTK_TEST_EQ(body1.getH_FMCol(state, j),
+                          body2.getH_FMCol(state, j));
+        }
     }
 }
 
@@ -161,9 +186,9 @@ static void testPrescribeAcceleration() {
 
 int main() {
     SimTK_START_TEST("TestLoneParticle");
-        SimTK_SUBTEST(testFree);
-        SimTK_SUBTEST(testPrescribePosition);
-        SimTK_SUBTEST(testPrescribeVelocity);
-        SimTK_SUBTEST(testPrescribeAcceleration);
+    SimTK_SUBTEST(testFree);
+    SimTK_SUBTEST(testPrescribePosition);
+    SimTK_SUBTEST(testPrescribeVelocity);
+    SimTK_SUBTEST(testPrescribeAcceleration);
     SimTK_END_TEST();
 }


### PR DESCRIPTION
The LoneParticle mobilizer implementation was incorrectly returning references to expired local variables when asked for columns of H_PB_G or H_FM. 

Since these matrices never change for a LoneParticle (F=P=G and M=B by construction) this PR instead precalculates H_PB_G and H_FM in the position cache (in realizeInstance()) and then just returns the right column when asked. I added a missing test case to TestLoneParticle.cpp that failed with the original implementation and works now.

There is some minor cleanup here also:
- I renamed storageForH to storageForH_PB_G to be more precise.
- I wrapped some long lines in TestLoneParticle.cpp to meet the 80 character standard
- Added a few short comments
- Added a .clang-format configuration file that matches Simbody's style

This replaces PR #774.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/786)
<!-- Reviewable:end -->
