### PR TITLE
Add the method `calcForces` to `GeneralForceSubsystem`

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -126,7 +126,7 @@ jobs:
   ubuntu:
     name: Ubuntu
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
@@ -185,7 +185,7 @@ jobs:
   style:
     name: Style
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/Simbody/include/simbody/internal/Force.h
+++ b/Simbody/include/simbody/internal/Force.h
@@ -124,7 +124,9 @@ public:
         hint here. 
     @note This method must zero out the passed in arrays, and in most cases
     almost all returned entries will be zero, so this is \e not the most
-    efficent way to calculate forces; use it sparingly. **/
+    efficent way to calculate forces; use it sparingly. For a more efficent way
+    to calculate force contributions from multiple force elements, see
+    GeneralForceSubsystem::calcForces(). **/
     void calcForceContribution(const State&          state,
                                Vector_<SpatialVec>&  bodyForces,
                                Vector_<Vec3>&        particleForces,

--- a/Simbody/include/simbody/internal/Force.h
+++ b/Simbody/include/simbody/internal/Force.h
@@ -126,7 +126,7 @@ public:
     almost all returned entries will be zero, so this is \e not the most
     efficent way to calculate forces; use it sparingly. For a more efficent way
     to calculate force contributions from multiple force elements, see
-    GeneralForceSubsystem::calcForces(). **/
+    GeneralForceSubsystem::calcForceContributionsSum(). **/
     void calcForceContribution(const State&          state,
                                Vector_<SpatialVec>&  bodyForces,
                                Vector_<Vec3>&        particleForces,

--- a/Simbody/include/simbody/internal/GeneralForceSubsystem.h
+++ b/Simbody/include/simbody/internal/GeneralForceSubsystem.h
@@ -107,8 +107,8 @@ public:
     if the given \a state were realized to Dynamics stage. This sizes the given
     arrays if necessary, zeroes them, and then calls each force element's
     calcForce() method which adds its force contributions if any to the
-    appropriate array elements for bodies and mobilities. Note that in general 
-    we have no idea what elements of the system are affected by a force element, 
+    appropriate array elements for bodies and mobilities. Note that in general
+    we have no idea what elements of the system are affected by a force element,
     and in fact that can change based on state and time (consider contact 
     forces, for example). A disabled force element will return all zeroes 
     without invoking calcForce(), since that method may depend on earlier 
@@ -139,7 +139,7 @@ public:
         hint here.  **/
     void calcForceContributionsSum(
         const State& s, const Array_<ForceIndex>& forceIndexes, 
-        Vector_<SpatialVec>& rigidBodyForces, Vector& mobilityForces) const;
+        Vector_<SpatialVec>& bodyForces, Vector& mobilityForces) const;
 
     /** Every Subsystem is owned by a System; a GeneralForceSubsystem expects
     to be owned by a MultibodySystem. This method returns a const reference

--- a/Simbody/include/simbody/internal/GeneralForceSubsystem.h
+++ b/Simbody/include/simbody/internal/GeneralForceSubsystem.h
@@ -102,6 +102,44 @@ public:
     @return Maximum number of threads GeneralForceSubsystem can use for force
     computations**/
     int getNumberOfThreads() const;
+    
+    /** Calculate the sum of forces that would be applied by the force elements 
+    if the given \a state were realized to Dynamics stage. This sizes the given
+    arrays if necessary, zeroes them, and then calls each force element's
+    calcForce() method which adds its force contributions if any to the
+    appropriate array elements for bodies and mobilities. Note that in general 
+    we have no idea what elements of the system are affected by a force element, 
+    and in fact that can change based on state and time (consider contact 
+    forces, for example). A disabled force element will return all zeroes 
+    without invoking calcForce(), since that method may depend on earlier 
+    computations which may not have been performed in that case.
+    @param[in]      state
+        The State containing information to be used by the force elements to
+        calculate the current sum of forces. This must have already been 
+        realized to a high enough stage for each force element to get what it 
+        needs; if you don't know then realize it to Stage::Velocity.
+    @param[in]      forceIndexes
+        This is an array of ForceIndex values, one for each force element whose
+        forces are to be calculated. The order of the force indexes is arbitrary
+        and has no effect on the results.
+    @param[out]     bodyForces
+        This is a Vector of spatial forces, one per mobilized body in the 
+        matter subsystem associated with the force elements. This Vector is
+        indexed by MobilizedBodyIndex so it has a 0th entry corresponding
+        to Ground. A spatial force contains two Vec3's; index with [0] to get
+        the moment vector, with [1] to get the force vector. This argument is
+        resized if necessary to match the number of mobilized bodies and any
+        unused entry will be set to zero on return.
+    @param[out]     mobilityForces
+        This is a Vector of scalar generalized forces, one per mobility in 
+        the matter subsystem associated with the force elements. This is the
+        same as the number of generalized speeds u that collectively represent
+        all the mobilities of the mobilizers. To determine the per-mobilizer
+        correspondence, you must call methods of MobilizedBody; there is no
+        hint here.  **/
+    void calcForces(
+        const State& s, const Array_<ForceIndex>& forceIndexes, 
+        Vector_<SpatialVec>& rigidBodyForces, Vector& mobilityForces) const;
 
     /** Every Subsystem is owned by a System; a GeneralForceSubsystem expects
     to be owned by a MultibodySystem. This method returns a const reference

--- a/Simbody/include/simbody/internal/GeneralForceSubsystem.h
+++ b/Simbody/include/simbody/internal/GeneralForceSubsystem.h
@@ -137,7 +137,7 @@ public:
         all the mobilities of the mobilizers. To determine the per-mobilizer
         correspondence, you must call methods of MobilizedBody; there is no
         hint here.  **/
-    void calcForces(
+    void calcForceContributionsSum(
         const State& s, const Array_<ForceIndex>& forceIndexes, 
         Vector_<SpatialVec>& rigidBodyForces, Vector& mobilityForces) const;
 

--- a/Simbody/src/GeneralForceSubsystem.cpp
+++ b/Simbody/src/GeneralForceSubsystem.cpp
@@ -599,7 +599,8 @@ public:
       return calcForcesExecutor->getMaxThreads();
     }
 
-    void calcForces(const State& s, const Array_<ForceIndex>& forceIndexes,
+    void calcForceContributionsSum(const State& s, 
+        const Array_<ForceIndex>& forceIndexes, 
         Vector_<SpatialVec>& rigidBodyForces, Vector& mobilityForces) const 
     {
         const SimbodyMatterSubsystem& matter = 
@@ -1035,11 +1036,11 @@ void GeneralForceSubsystem::setNumberOfThreads(unsigned numThreads)
 int GeneralForceSubsystem::getNumberOfThreads() const
 {   return getRep().getNumberOfThreads(); }
 
-void GeneralForceSubsystem::calcForces(
+void GeneralForceSubsystem::calcForceContributionsSum(
     const State& s, const Array_<ForceIndex>& forceIndexes, 
     Vector_<SpatialVec>& rigidBodyForces, Vector& mobilityForces) const 
 {
-    getRep().calcForces(
+    getRep().calcForceContributionsSum(
         s, forceIndexes, rigidBodyForces, mobilityForces);
 }
 

--- a/Simbody/src/GeneralForceSubsystem.cpp
+++ b/Simbody/src/GeneralForceSubsystem.cpp
@@ -599,6 +599,29 @@ public:
       return calcForcesExecutor->getMaxThreads();
     }
 
+    void calcForces(const State& s, const Array_<ForceIndex>& forceIndexes,
+        Vector_<SpatialVec>& rigidBodyForces, Vector& mobilityForces) const 
+    {
+        const SimbodyMatterSubsystem& matter = 
+                getMultibodySystem().getMatterSubsystem();
+
+        // Resize if necessary.
+        rigidBodyForces.resize(matter.getNumBodies());
+        mobilityForces.resize(matter.getNumMobilities());
+
+        // Set all forces to zero.
+        rigidBodyForces.setToZero();
+        mobilityForces.setToZero();
+        
+        Vector_<Vec3> particleForces; // unused
+        for (const auto& index : forceIndexes) {
+            if (!isForceDisabled(s, index)) {
+                forces[index]->getImpl().calcForce(
+                    s, rigidBodyForces, particleForces, mobilityForces);
+            }
+        }
+    }
+
     // These override default implementations of virtual methods in the
     // Subsystem::Guts class.
 
@@ -1011,6 +1034,14 @@ void GeneralForceSubsystem::setNumberOfThreads(unsigned numThreads)
 
 int GeneralForceSubsystem::getNumberOfThreads() const
 {   return getRep().getNumberOfThreads(); }
+
+void GeneralForceSubsystem::calcForces(
+    const State& s, const Array_<ForceIndex>& forceIndexes, 
+    Vector_<SpatialVec>& rigidBodyForces, Vector& mobilityForces) const 
+{
+    getRep().calcForces(
+        s, forceIndexes, rigidBodyForces, mobilityForces);
+}
 
 const MultibodySystem& GeneralForceSubsystem::getMultibodySystem() const
 {   return MultibodySystem::downcast(getSystem()); }

--- a/Simbody/src/GeneralForceSubsystem.cpp
+++ b/Simbody/src/GeneralForceSubsystem.cpp
@@ -601,24 +601,24 @@ public:
 
     void calcForceContributionsSum(const State& s, 
         const Array_<ForceIndex>& forceIndexes, 
-        Vector_<SpatialVec>& rigidBodyForces, Vector& mobilityForces) const 
+        Vector_<SpatialVec>& bodyForces, Vector& mobilityForces) const 
     {
         const SimbodyMatterSubsystem& matter = 
                 getMultibodySystem().getMatterSubsystem();
 
         // Resize if necessary.
-        rigidBodyForces.resize(matter.getNumBodies());
+        bodyForces.resize(matter.getNumBodies());
         mobilityForces.resize(matter.getNumMobilities());
 
         // Set all forces to zero.
-        rigidBodyForces.setToZero();
+        bodyForces.setToZero();
         mobilityForces.setToZero();
         
         Vector_<Vec3> particleForces; // unused
         for (const auto& index : forceIndexes) {
             if (!isForceDisabled(s, index)) {
                 forces[index]->getImpl().calcForce(
-                    s, rigidBodyForces, particleForces, mobilityForces);
+                    s, bodyForces, particleForces, mobilityForces);
             }
         }
     }
@@ -1038,10 +1038,10 @@ int GeneralForceSubsystem::getNumberOfThreads() const
 
 void GeneralForceSubsystem::calcForceContributionsSum(
     const State& s, const Array_<ForceIndex>& forceIndexes, 
-    Vector_<SpatialVec>& rigidBodyForces, Vector& mobilityForces) const 
+    Vector_<SpatialVec>& bodyForces, Vector& mobilityForces) const 
 {
     getRep().calcForceContributionsSum(
-        s, forceIndexes, rigidBodyForces, mobilityForces);
+        s, forceIndexes, bodyForces, mobilityForces);
 }
 
 const MultibodySystem& GeneralForceSubsystem::getMultibodySystem() const

--- a/Simbody/tests/TestForces.cpp
+++ b/Simbody/tests/TestForces.cpp
@@ -365,8 +365,10 @@ void testCalcForceContributionsSum() {
     GeneralForceSubsystem forces(system);
     Body::Rigid body(MassProperties(1.0, Vec3(0), Inertia(1)));
     for (int i = 0; i < NUM_BODIES; ++i) {
-        MobilizedBody& parent = matter.updMobilizedBody(MobilizedBodyIndex(matter.getNumBodies()-1));
-        MobilizedBody::Gimbal b(parent, Transform(Vec3(0)), body, Transform(Vec3(BOND_LENGTH, 0, 0)));
+        MobilizedBody& parent = matter.updMobilizedBody(
+            MobilizedBodyIndex(matter.getNumBodies()-1));
+        MobilizedBody::Gimbal b(parent, Transform(Vec3(0)), body, 
+            Transform(Vec3(BOND_LENGTH, 0, 0)));
     }
     
     // Add a set of forces.
@@ -377,7 +379,8 @@ void testCalcForceContributionsSum() {
     Force::ConstantTorque constantTorque(forces, body1, Vec3(1, 2, 3));
     Force::GlobalDamper globalDamper(forces, matter, 2.0);
     Force::MobilityConstantForce mobilityConstantForce(forces, body1, 1, 2.0);
-    Force::TwoPointConstantForce twoPointConstantForce(forces, body1, Vec3(0), body9, Vec3(0), 2.0);
+    Force::TwoPointConstantForce twoPointConstantForce(forces, body1, Vec3(0), 
+        body9, Vec3(0), 2.0);
 
     // Make sure we get the correct summed forces when one is disabled
     
@@ -398,7 +401,6 @@ void testCalcForceContributionsSum() {
     // Calculate the sum of the force components and see if it is correct.
     
     Vector_<SpatialVec> bodyForces(matter.getNumBodies(), SpatialVec(0));
-    Vector_<Vec3> particleForces(0);
     Vector mobilityForces(state.getNU(), Real(0));
     Array_<ForceIndex> forceIndexes;
     forceIndexes.reserve(5);
@@ -413,7 +415,7 @@ void testCalcForceContributionsSum() {
     bodyForces[1][0] += Vec3(1, 2, 3);
     forceIndexes.push_back(constantTorque.getForceIndex());
     
-    // The GlobalDamper is disable and should not contribute any forces
+    // The GlobalDamper is disabled and should not contribute any forces
 
     forceIndexes.push_back(globalDamper.getForceIndex());
     


### PR DESCRIPTION
Addresses #787.

## Summary

This changes adds the method `calcForces` to `GeneralForceSubsystem`, which accepts an array of `ForceIndex` values and calculates the sum of each `Force`'s contribution to the system body and mobility forces. `calcForces` provides similar functionality as `Force::calcForceContribution()`, but only requires zeroing the input force vectors once before calculating the contributions from multiple forces, which should be more efficient when repeated calls are necessary.

## Looking for feedback on

1. Method naming. As drafted, I'm using the generic `calcForces`, but something like `calcForceContributions` or `calcSummedForceContributions`  might be more descriptive.
2. A safe and proper way to skip the resizing/zeroing steps if possible, since the intent here is for speed. Resizing is implicitly skipped if the vectors are the correct size, but not zeroing (I think). A flag to the method would be one option, but stylistically avoiding that would probably be preferred. If no solution is optimal then that's also fine since this is already an improvement for my application.
3. Should I leverage `CalcForcesTask` somehow? This would open up the possibility for parallelization, but I don't quite fully understand everything related to caching forces in there yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/788)
<!-- Reviewable:end -->
