### PR TITLE
Scholz2015 wrapping algorithm

### DIFF
--- a/Simbody/include/SimTKsimbody.h
+++ b/Simbody/include/SimTKsimbody.h
@@ -78,6 +78,7 @@ will include this one). **/
 #include "simbody/internal/CableTrackerSubsystem.h"
 #include "simbody/internal/CablePath.h"
 #include "simbody/internal/CableSpring.h"
+#include "simbody/internal/CableSpan.h"
 #include "simbody/internal/Visualizer.h"
 #include "simbody/internal/Visualizer_InputListener.h"
 #include "simbody/internal/Visualizer_Reporter.h"

--- a/Simbody/include/simbody/internal/CableSpan.h
+++ b/Simbody/include/simbody/internal/CableSpan.h
@@ -1,0 +1,553 @@
+#ifndef SimTK_SIMBODY_CABLE_SPAN_H_
+#define SimTK_SIMBODY_CABLE_SPAN_H_
+
+/*-----------------------------------------------------------------------------
+                               Simbody(tm)
+-------------------------------------------------------------------------------
+ Copyright (c) 2024 Authors.
+ Authors: Pepijn van den Bos
+ Contributors:
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may
+ not use this file except in compliance with the License. You may obtain a
+ copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ----------------------------------------------------------------------------*/
+
+#include "simbody/internal/MobilizedBody.h"
+#include "simbody/internal/common.h"
+
+namespace SimTK
+{
+
+/** @class SimTK::CableSpanObstacleIndex
+This is a unique integer type for identifying obstacles comprising a particular
+CableSpan. These begin at zero for each CableSpan. **/
+SimTK_DEFINE_UNIQUE_INDEX_TYPE(CableSpanObstacleIndex);
+
+/** @class SimTK::CableSpanIndex
+This is a unique integer type for quickly identifying specific cables for fast
+lookup purposes. These begin at zero for each CableSubsystem. **/
+SimTK_DEFINE_UNIQUE_INDEX_TYPE(CableSpanIndex);
+
+class MultibodySystem;
+class CableSubsystem;
+class CableSubsystemTestHelper;
+
+//==============================================================================
+/** This class represents the path of a frictionless cable from an origin point
+fixed to a body, over geometric obstacles fixed to other bodies, to a final
+termination point.
+
+The CableSpan's path can be seen as consisting of straight line segments and
+curved line segments: A curved segment over each obstacle, and straight segments
+connecting them to each other and to the end points. Each curved segment is
+computed as a geodesic to give (in some sense) a shortest path over the surface.
+During a simulation the cable can slide freely over the obstacle surfaces. It
+can lose contact with a surface and miss that obstacle in a straight line.
+Similarly the cable can touchdown on the obstacle if the surface obstructs the
+straight line segment again.
+
+The path is computed as an optimization problem using the previous optimal path
+as the warm start. This is done by computing natural geodesic corrections for
+each curve segment to compute the locally shortest path, as described in the
+following publication:
+
+    Scholz, A., Sherman, M., Stavness, I. et al (2015). A fast multi-obstacle
+    muscle wrapping method using natural geodesic variations. Multibody System
+    Dynamics 36, 195–219.
+
+The overall path is locally the shortest, allowing winding over an obstacle
+multiple times, without flipping to the other side.
+
+During initialization the path is assumed to be in contact with each obstacle at
+the user defined contact-point-hint. At each contact point a
+zero-length-geodesic is computed with the tangent estimated as pointing from the
+previous path point to the next path point. From this configuration, the solver
+is started, and the geodesics will be corrected until the entire path is smooth.
+
+Important to note is that the cable's interaction with the obstacles is ordered
+based on the order in which they were added. That is, if three obstacles are
+added to a cable, then, the cable can wrap over the first, then the second, and
+then the third. If the first obstacle spatially collides with the path twice it
+will not actually wrap over it twice. Use CablePath if this is not the desired
+behavior.
+
+Note that a CableSpan is a geometric object, not a force or constraint element.
+That is, a CableSpan alone will not influence the behavior of a simulation.
+However, forces and constraint elements can be constructed that make use of a
+CableSpan to generate forces.
+
+A CableSpan must be registered with a CableSubsystem which manages their
+runtime evaluation. **/
+class SimTK_SIMBODY_EXPORT CableSpan final {
+public:
+    /** Construct a new cable that can be configured later. **/
+    CableSpan();
+    /** Delete the cable if this handle was the last reference to it. **/
+    ~CableSpan() noexcept = default;
+    /** Copy constructor is shallow and reference counted. **/
+    CableSpan(const CableSpan&) = default;
+    /** Copy assignment is shallow and reference counted. **/
+    CableSpan& operator=(const CableSpan& source) = default;
+    CableSpan(CableSpan&&) noexcept               = default;
+    CableSpan& operator=(CableSpan&&) noexcept    = default;
+
+    /** @name Cable construction */
+    ///@{
+
+    /** Create a straight-line cable spanning between a point fixed on one body
+    to one fixed on another body. You can add obstacles and move the end points
+    later.
+    @param subsystem The subsystem that this cable is adopted by.
+    @param originBody The mobilized body that the origin point is rigidly
+    attached to.
+    @param originStation The origin point of the cable defined in body fixed
+    coordinates.
+    @param terminationBody The mobilized body that the termination point is
+    rigidly attached to.
+    @param terminationStation The termination point of the cable defined in
+    body fixed coordinates. **/
+    CableSpan(
+        CableSubsystem& subsystem,
+        MobilizedBodyIndex originBody,
+        const Vec3& originStation,
+        MobilizedBodyIndex terminationBody,
+        const Vec3& terminationStation);
+
+    /** Add an obstacle to the cable's path that must be wrapped over.
+    @param obstacleBody The body that the contact geometry is rigidly attached
+    to.
+    @param X_BS Transform specifying the location and orientation of the
+    contact geometry's origin frame with respect to the mobilized body.
+    @param obstacleGeometry The geometry of the obstacle's surface.
+    @return The index of the added obstacle in this cable. **/
+    CableSpanObstacleIndex addObstacle(
+        MobilizedBodyIndex obstacleBody,
+        const Transform& X_BS,
+        std::shared_ptr<const ContactGeometry> obstacleGeometry);
+
+    /** Add an obstacle to the cable's path that must be wrapped over.
+    @param obstacleBody The body that the contact geometry is rigidly attached
+    to.
+    @param X_BS Transform specifying the location and orientation of the
+    contact geometry's origin frame with respect to the mobilized body.
+    @param obstacleGeometry The geometry of the obstacle's surface.
+    @param contactPointHint_S A guess for the cable's initial contact point on
+    the obstacle, in local surface frame coordinates. The point will be used as
+    a starting point when computing the initial cable path. As such, it does
+    not have to lie on the contact geometry's surface, nor does it have to
+    belong to a valid cable path.
+    @return The index of the added obstacle in this cable. **/
+    CableSpanObstacleIndex addObstacle(
+        MobilizedBodyIndex obstacleBody,
+        const Transform& X_BS,
+        std::shared_ptr<const ContactGeometry> obstacleGeometry,
+        const Vec3& contactPointHint_S);
+
+    /** Get the number of obstacles added to the path. **/
+    int getNumObstacles() const;
+
+    ///@}
+
+    /** @name End points configuration */
+    ///@{
+
+    /** Get the index of the mobilized body that the cable's origin point is
+    attached to. **/
+    MobilizedBodyIndex getOriginBodyIndex() const;
+
+    /** Set the index of the mobilized body that the cable's origin point is
+    attached to. **/
+    void setOriginBodyIndex(MobilizedBodyIndex originBody);
+
+    /** Get the index of the mobilized body that the cable's termination point
+    is attached to. **/
+    MobilizedBodyIndex getTerminationBodyIndex() const;
+
+    /** Set the index of the mobilized body that the cable's termination point
+    is attached to. **/
+    void setTerminationBodyIndex(MobilizedBodyIndex terminationBody);
+
+    /** Get the cable's origin point defined in body fixed coordinates. **/
+    Vec3 getOriginStation() const;
+
+    /** Set the cable's origin point defined in body fixed coordinates. **/
+    void setOriginStation(const Vec3& originStation);
+
+    /** Get the cable's termination point defined in body fixed coordinates.
+    **/
+    Vec3 getTerminationStation() const;
+
+    /** Set the cable's termination point defined in body fixed coordinates.
+    **/
+    void setTerminationStation(const Vec3& terminationStation);
+
+    ///@}
+
+    /** @name Obstacle configuration */
+    ///@{
+
+    /** Get the index of the mobilized body that the obstacle is attached to.
+    @param ix The index of the obstacle in this CableSpan.
+    @return The index of the mobilized body that the obstacle is attached
+    to. **/
+    const MobilizedBodyIndex& getObstacleMobilizedBodyIndex(
+        CableSpanObstacleIndex ix) const;
+
+    /** Set the index of the mobilized body that the obstacle is attached to.
+    @param ix The index of the obstacle in this CableSpan.
+    @param body The index of the mobilized body that the obstacle is attached
+    to. **/
+    void setObstacleMobilizedBodyIndex(
+        CableSpanObstacleIndex ix,
+        MobilizedBodyIndex body);
+
+    /** Get the orientation and position of the obstacle's surface with respect
+    to its mobilized body.
+    @param ix The index of the obstacle in this CableSpan.
+    @return The orientation and position of the obstacle's surface with respect
+    to it's mobilized body. **/
+    const Transform& getObstacleTransformSurfaceToBody(
+        CableSpanObstacleIndex ix) const;
+
+    /** Set the orientation and position of the obstacle's surface with respect
+    to its mobilized body.
+    @param ix The index of the obstacle in this CableSpan.
+    @param X_BS The orientation and position of the obstacle's surface with
+    respect to it's mobilized body. **/
+    void setObstacleTransformSurfaceToBody(
+        CableSpanObstacleIndex ix,
+        const Transform& X_BS);
+
+    /** Get the obstacle's ContactGeometry.
+    @param ix The index of the obstacle in this CableSpan.
+    @return The obstacle's surface geometry. **/
+    const ContactGeometry& getObstacleContactGeometry(
+        CableSpanObstacleIndex ix) const;
+
+    /** Set the obstacle's ContactGeometry.
+    @param ix The index of the obstacle in this CableSpan.
+    @param obstacleGeometry The obstacle's surface geometry. **/
+    void setObstacleContactGeometry(
+        CableSpanObstacleIndex ix,
+        std::shared_ptr<const ContactGeometry> obstacleGeometry);
+
+    /** Get the point on the obstacle used to compute the initial path.
+    @param ix The index of the obstacle in this CableSpan.
+    @return The point in the obstacle's local surface coordinates. **/
+    Vec3 getObstacleContactPointHint(CableSpanObstacleIndex ix) const;
+
+    /** Set the point on the obstacle used to compute the initial path.
+    @param ix The index of the obstacle in this CableSpan.
+    @param contactPointHint_S A guess for the cable's initial contact point on
+    the obstacle, in local surface frame coordinates. The point will be used as
+    a starting point when computing the initial cable path. As such, it does
+    not have to lie on the contact geometry's surface, nor does it have to
+    belong to the optimal cable path. **/
+    void setObstacleContactPointHint(
+        CableSpanObstacleIndex ix,
+        Vec3 contactPointHint_S);
+
+    ///@}
+
+    /** @name Solver configuration */
+    ///@{
+
+    /** Get the accuracy used by the numerical integrator when computing a
+    geodesic over an obstacle.
+    Note: This does not affect the integrator that is used to propagate the
+    multibody system over time, that is a different integrator. **/
+    Real getCurveSegmentAccuracy() const;
+
+    /** Set the accuracy used by the numerical integrator when computing a
+    geodesic over an obstacle.
+    Note: This does not affect the integrator that is used to propagate the
+    multibody system over time, that is a different integrator. **/
+    void setCurveSegmentAccuracy(Real accuracy);
+
+    /** Get the maximum number of solver iterations for finding the optimal
+    path. **/
+    int getSolverMaxIterations() const;
+
+    /** Set the maximum number of solver iterations for finding the optimal
+    path. **/
+    void setSolverMaxIterations(int maxIterations);
+
+    /** Number of solver iterations used to compute the current cable's path.
+    State must be realized to Stage::Position.
+    @param state System State.
+    @return Number of solver iterations used. **/
+    int getNumSolverIterations(const State& state) const;
+
+    /** Get the smoothness tolerance used to compute the optimal path.
+    The (non) smoothness is defined as the angular discontinuity at the points
+    where straight- and curved-line segments meet, measured in radians. When
+    computing the optimal path this smoothness is optimized, and the solver
+    stops when reaching given tolerance.
+    **/
+    Real getSmoothnessTolerance() const;
+
+    /** Set the smoothness tolerance used to compute the optimal path.
+    See CableSpan::getSmoothnessTolerance.
+    **/
+    void setSmoothnessTolerance(Real tolerance);
+
+    /** The smoothness of the current cable's path.
+    See CableSpan::getSmoothnessTolerance.
+    State must be realized to Stage::Position. **/
+    Real getSmoothness(const State& state) const;
+
+    ///@}
+
+    /** @name Path computations */
+    ///@{
+
+    /** Get the total cable length.
+    State must be realized to Stage::Position.
+    @param state State of the system.
+    @return The total cable length. **/
+    Real calcLength(const State& state) const;
+
+    /** Get the derivative of the total cable length.
+    State must be realized to Stage::Velocity.
+    @param state State of the system.
+    @return The time derivative of the total cable length. **/
+    Real calcLengthDot(const State& state) const;
+
+    /** Given a tension > 0 acting uniformly along this cable, compute the
+    resulting forces applied to the bodies it touches.
+    The body forces are added into the appropriate slots in the supplied Array
+    which has one entry per body in the same format as is supplied to the
+    calcForce() method of force elements. If the supplied tension is <= 0,
+    signifying a slack cable, this method does nothing. **/
+    void applyBodyForces(
+        const State& state,
+        Real tension,
+        Vector_<SpatialVec>& bodyForcesInG) const;
+
+    /** Compute the cable power.
+    State must be realized to Stage::Position.
+    @param state State of the system.
+    @param tension The tension force in the cable.
+    @return The cable power. **/
+    Real calcCablePower(const State& state, Real tension) const;
+
+    /** Compute points on the path spanned by this cable suitable for
+    visualization purposes.
+    State must be realized to Stage::Position.
+    @param state System State.
+    @param sink Where the path points (in ground frame) will be written to. **/
+    void calcDecorativePathPoints(
+        const State& state,
+        const std::function<void(Vec3 point_G)>& sink) const;
+
+    ///@}
+
+    /** @name Curve segment computations */
+    ///@{
+
+    /** Returns true when the cable is in contact with the obstacle.
+    State must be realized to Stage::Position.
+    @param state State of the system.
+    @param ix The index of the obstacle in this CableSpan. **/
+    bool isInContactWithObstacle(const State& state, CableSpanObstacleIndex ix)
+        const;
+
+    /** Compute the Frenet frame associated with the obstacle's curve segment at
+    the initial contact point on that obstacle.
+    If the path is not in contact with the obstacle's surface the frame will
+    contain invalid data (NaNs). The Frenet frame is measured relative to
+    ground, with the tangent along the X axis, the surface normal along the Y
+    axis and the binormal along the Z axis.
+    State must be realized to Stage::Position.
+    @param state State of the system.
+    @param ix The index of the obstacle in this CableSpan.
+    @return The Frenet frame at the obstacle's initial contact point. **/
+    Transform calcCurveSegmentInitialFrenetFrame(
+        const State& state,
+        CableSpanObstacleIndex ix) const;
+
+    /** Compute the Frenet frame associated with the obstacle's curve segment at
+    the final contact point on that obstacle.
+    If the path is not in contact with the obstacle's surface the frame will
+    contain invalid data (NaNs). The Frenet frame is measured relative to
+    ground, with the tangent along the X axis, the surface normal along the Y
+    axis and the binormal along the Z axis.
+    State must be realized to Stage::Position.
+    @param state State of the system.
+    @param ix The index of the obstacle in this CableSpan.
+    @return The Frenet frame at the obstacle's final contact point. **/
+    Transform calcCurveSegmentFinalFrenetFrame(
+        const State& state,
+        CableSpanObstacleIndex ix) const;
+
+    /** Get the arc length of the obstacle's curve segment.
+    Returns NaN if the obstacle is not in contact with the path.
+    State must be realized to Stage::Position.
+    @param state State of the system.
+    @param ix The index of the obstacle in this CableSpan.
+    @return The arc length. **/
+    Real calcCurveSegmentArcLength(
+        const State& state,
+        CableSpanObstacleIndex ix) const;
+
+    /** Compute points along the obstacle's curve segment at equal length
+    intervals.
+
+    The first and last contact point of the curve segment are always included.
+    Therefore the minimum allowed number of samples is 2.
+
+    For analytic surfaces the resampled points are computed analytically.
+    Otherwise, the points are computed from the internally stored geodesic
+    using Hermite interpolation, generally resulting in a good approximation of
+    the point at the requested arc lengths.
+
+    This function throws an exception if the obstacle is not in contact with
+    the cable. Check isInContactWithObstacle() before calling this function.
+
+    @param state State of the system.
+    @param ix The index of the obstacle in this CableSpan.
+    @param numSamples The number of resampling points (minimum is 2).
+    @param sink Where the resampled points (in ground frame) will be written
+    to. **/
+    void calcCurveSegmentResampledPoints(
+        const State& state,
+        CableSpanObstacleIndex ix,
+        int numSamples,
+        const std::function<void(Vec3 point_G)>& sink) const;
+
+    ///@}
+
+    /** @cond **/ // Hide from Doxygen.
+    class Impl;
+
+private:
+    const Impl& getImpl() const
+    {
+        return *m_impl;
+    }
+
+    Impl& updImpl()
+    {
+        return *m_impl;
+    }
+
+    std::shared_ptr<Impl> m_impl;
+
+    friend CableSubsystem;
+
+    // Befriend the helper class for testing the implementation.
+    friend CableSubsystemTestHelper;
+    /** @endcond **/
+};
+
+//==============================================================================
+/** This subsystem manages cables spanning between two points in a system.
+Each cable is represented by a CableSpan. Obstacles can be added to the cable,
+and must be wrapped over. The calculated path will consist of a series of
+straight line segments between obstacles, and curved segments (geodesics) over
+the obstacles. Force elements defined elsewhere may make use of the cables to
+apply forces to the system.
+
+See CableSpan. **/
+class SimTK_SIMBODY_EXPORT CableSubsystem : public Subsystem {
+public:
+    explicit CableSubsystem(MultibodySystem&);
+
+    const MultibodySystem& getMultibodySystem() const;
+
+    /** Get the number of cables being managed by this subsystem.
+    These are identified by CableSpanIndex values from 0 to getNumCables()-1.
+    This is available after realizeTopology() and does not change subsequently.
+    **/
+    int getNumCables() const;
+
+    /** Get const access to a particular cable. **/
+    const CableSpan& getCable(CableSpanIndex ix) const;
+
+    /** Get writeable access to a particular cable. **/
+    CableSpan& updCable(CableSpanIndex ix);
+
+    /** @cond **/ // Hide from Doxygen.
+    SimTK_PIMPL_DOWNCAST(CableSubsystem, Subsystem);
+
+    class Impl;
+    Impl& updImpl();
+    const Impl& getImpl() const;
+
+    // Befriend the helper class for testing the implementation.
+    friend CableSubsystemTestHelper;
+    /** @endcond **/
+};
+
+/** @cond **/ // Hide from Doxygen.
+//==============================================================================
+/** Helper class for testing correctness of all currently computed paths in a
+CableSubsystem.
+
+For each CableSpan's computed path it is checked that:
+1. Any curve segment over an obstacle is a correct geodesic.
+2. The path error Jacobian matches a perturbation test.
+
+The geodesics and Jacobians are internal to the CableSpan's implementation, we
+refer to the following publication to understand their role:
+
+    Scholz, A., Sherman, M., Stavness, I. et al (2015). A fast multi-obstacle
+    muscle wrapping method using natural geodesic variations. Multibody System
+    Dynamics 36, 195–219.
+
+Consider a bug in the code, then this test is designed to have
+high sensitivity (and lower specificity). That is, if you pass, you can rest
+assured that all curve segments are indeed geodesics, and that the Jacobian
+correctly predicts the local effect of the NaturalGeodesicCorrection on the
+path error vector. It is possible to fail this test in the absence of any bugs
+by using incompatible configuration parameters; e.g. by setting a very poor
+integrator accuracy for the CableSpan, and using a very small perturbation value
+in the Jacobian perturbation test. For use in a unit test a high sensitivity
+works just fine: If you pass it normally, you should pass it after a code
+refactor as well.
+
+Testing each computed path in your simulation is possible, but will criple your
+simulation speed.
+
+State must be realized to Stage::Position before testing. **/
+class SimTK_SIMBODY_EXPORT CableSubsystemTestHelper {
+public:
+    /** Construct a CableSubsystemTestHelper that can be used to test a
+    CableSubsystem. **/
+    CableSubsystemTestHelper();
+    ~CableSubsystemTestHelper() noexcept;
+    CableSubsystemTestHelper(const CableSubsystemTestHelper&);
+    CableSubsystemTestHelper& operator=(const CableSubsystemTestHelper&);
+    CableSubsystemTestHelper(CableSubsystemTestHelper&&) noexcept = default;
+    CableSubsystemTestHelper& operator=(CableSubsystemTestHelper&&) noexcept =
+        default;
+
+    /** Test the paths of all CableSpan registered in a CableSubsystem.
+    State must be realized to Stage::Position.
+    An exception is thrown when the test fails.
+    @param state State of the system.
+    @param subsystem CableSubsystem containing all paths to be tested.
+    @param testReport Interesting test results will be written to this stream.
+    **/
+    void testCurrentPath(
+        const State& state,
+        const CableSubsystem& subsystem,
+        std::ostream& testReport) const;
+
+    class Impl;
+
+private:
+    std::unique_ptr<Impl> m_impl;
+};
+/** @endcond **/
+
+} // namespace SimTK
+
+#endif

--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -1,0 +1,3559 @@
+/*-----------------------------------------------------------------------------
+                               Simbody(tm)
+-------------------------------------------------------------------------------
+ Copyright (c) 2024 Authors.
+ Authors: Pepijn van den Bos
+ Contributors:
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may
+ not use this file except in compliance with the License. You may obtain a
+ copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ----------------------------------------------------------------------------*/
+
+#include "CableSpan_SubsystemTestHelper_Impl.h"
+
+#include "simbody/internal/CableSpan.h"
+#include "simbody/internal/MultibodySystem.h"
+#include "simbody/internal/SimbodyMatterSubsystem.h"
+
+#include "SimTKcommon/internal/State.h"
+
+using namespace SimTK;
+
+// For convenience.
+using ObstacleIndex = CableSpanObstacleIndex;
+
+//==============================================================================
+//                            Data Structures
+//==============================================================================
+/* The following section contains the data structures used to compute the cable
+path. */
+namespace
+{
+
+//------------------------------------------------------------------------------
+//  Geodesic Degrees of Freedom
+//------------------------------------------------------------------------------
+/* Number of degrees of freedom of a general geodesic.
+There are four: see NaturalGeodesicCorrections below. */
+constexpr int c_GeodesicDOF = 4;
+
+//------------------------------------------------------------------------------
+//  Natural Geodesic Corrections
+//------------------------------------------------------------------------------
+/* Natural geodesic corrections represent the coordinates along which we can
+change a geodesic. The elements, in order, are (see Scholz2015):
+- Tangential correction of initial contact point.
+- Binormal correction of initial contact point.
+- Directional correction of tangent at the initial contact point.
+- Lengthening correction of geodesic. */
+using NaturalGeodesicCorrection = Vec<c_GeodesicDOF>;
+
+//------------------------------------------------------------------------------
+//  Struct Line Segment
+//------------------------------------------------------------------------------
+/* Representation of a cable segment that does not lie on a surface: A straight
+line. */
+struct LineSegment final {
+    LineSegment() = default;
+
+    // Construct a new LineSegment connecting pointA and pointB.
+    LineSegment(const Vec3& pointA, const Vec3& pointB) :
+        length((pointB - pointA).norm()), direction((pointB - pointA) / length)
+    {}
+
+    Real length = NaN;
+    UnitVec3 direction{NaN, NaN, NaN};
+};
+
+//------------------------------------------------------------------------------
+//  Wrapping Status
+//------------------------------------------------------------------------------
+/* This enum gives the wrapping status of an obstacle in a CableSpan's path. */
+enum class ObstacleWrappingStatus {
+    // InitialGuess: The curve segment must be initialized from the initial
+    // contact point parameter. This will be used as the starting point for
+    // computing the optimal cable path.
+    InitialGuess,
+    // InContactWithSurface: The cable comes into contact with the obstacle.
+    InContactWithSurface,
+    // LiftedFromSurface: The cable does not come into contact with the
+    // obstacle.
+    LiftedFromSurface,
+    // Disabled: The obstacle was manually disabled, preventing any interaction
+    // with the cable. TODO no longer used?
+    Disabled,
+};
+
+//------------------------------------------------------------------------------
+//  Frenet Frame
+//------------------------------------------------------------------------------
+/* The Frenet frame plays an important role in defining the state of a geodesic.
+In the end it is simply a Transform, which is why we define it as an alias.
+
+The position of the Frenet frame is defined to lie on the geodesic, but for
+the orientation of the frame different conventions are used.
+Here we define it as (see Scholz2015):
+- X axis: tangent to geodesic
+- Y axis: normal to surface
+- Z axis: binormal to geodesic (tangent cross normal) */
+using FrenetFrame                        = Transform;
+static const CoordinateAxis TangentAxis  = XAxis;
+static const CoordinateAxis NormalAxis   = YAxis;
+static const CoordinateAxis BinormalAxis = ZAxis;
+
+//------------------------------------------------------------------------------
+//  Struct MatrixWorkspace
+//------------------------------------------------------------------------------
+/* This is a helper struct that is used by a CableSpan to compute the
+Stage::Position level data, i.e. the spanned path.
+Computing the path involves a Newton type iteration, for which several
+matrices need to be computed. This struct provides the required matrices with
+appropriate dimensions. After computing the path this data is no longer needed
+by the CableSpan. */
+struct MatrixWorkspace {
+    // Number of path error constraints per curve segment.
+    static constexpr int c_NumPathErrorConstraints = 4;
+    // Total number of constraints per curve segment.
+    static constexpr int c_NumConstraints = c_NumPathErrorConstraints + 1;
+
+    // Given the number of CurveSegments that are in contact with their
+    // respective obstacle's surface, contruct a MatrixWorkspace of correct
+    // dimensions.
+    explicit MatrixWorkspace(int problemSize) : nObstaclesInContact(problemSize)
+    {
+        static constexpr int Q = c_GeodesicDOF;
+        static constexpr int C = c_NumConstraints;
+        const int n            = problemSize;
+
+        lineSegments.resize(n + 1);
+        pathErrorJacobian = Matrix(C * n, Q * n, 0.);
+        pathCorrection    = Vector(Q * n, 0.);
+        pathError         = Vector(C * n, 0.);
+    }
+
+    // Return the NaturalGeodesicCorrection for the curve segment at the
+    // "active" curve index, where "active" means counting those that are in
+    // contact with the obstacle.
+    NaturalGeodesicCorrection getCurveCorrection(int activeCurveIx) const
+    {
+        SimTK_ASSERT(
+            activeCurveIx < nObstaclesInContact,
+            "Index of curve (counting active only) exceeds number of segments in contact with obstacles");
+        SimTK_ASSERT(
+            pathCorrection.size() == nObstaclesInContact * c_GeodesicDOF,
+            "Invalid size of pathCorrection vector.");
+        const int eltIx = activeCurveIx * c_GeodesicDOF;
+        return {
+            pathCorrection[eltIx],
+            pathCorrection[eltIx + 1],
+            pathCorrection[eltIx + 2],
+            pathCorrection[eltIx + 3]};
+    }
+
+    /* All straight line segments in the current path. */
+    std::vector<LineSegment> lineSegments;
+    /* The path error vector captures the misalignment of the straight line and
+    curved segments at the contact points, as well as the penalty for taking a
+    large optimization step. The computation of the path is then done by
+    driving this path error to zero (up to tolerance), such that all segments
+    are smoothly connected, and the optimization step size converges to zero.
+
+    To derive the path errors, consider a single active obstacle (active being
+    those that are in contact with the cable), and define:
+    - Let the subscripts P and Q denote the initial and final contact point on
+      the obstacle respectively.
+    - The direction of the straight line segment connected to the obstacle at
+      the contact points: e_P, e_Q
+    - The direction of the surface normal at contact points: n_P, n_Q
+    - The direction of the geodesic binormal at contact points: b_P, b_Q
+
+    For each active obstacle four path error elements are then computed:
+    1. dot(e_P, n_P)
+    2. dot(e_P, b_P)
+    3. dot(e_Q, n_Q)
+    4. dot(e_Q, b_Q)
+
+    Stacking all four path error elements, of all active obstacles, gives the
+    first elements of the path error vector.
+
+    Additionally, for each active obstacle, one element is added to the path
+    error vector that constrains the length of the geodesic to remain the same.
+    This helps regulate the search for the path in case the Jacobian of the path
+    error loses rank. The value of these elements is simply zero. */
+    Vector pathError;
+    /* The Jacobian of the path error vector to the natural geodesic
+    corrections of all active obstacles. */
+    Matrix pathErrorJacobian;
+    /* The factorization for solving the pathErrorJacobian in least squares
+    sense. */
+    FactorQTZ factor;
+    /* The path correction vector contains the NaturalGeodesicCorrection
+    vector of each active obstacle stacked as a vector. This vector is
+    computed at each solver iteration, and applying these corrections
+    attempts to drive the path error vector to zero. */
+    Vector pathCorrection;
+    /* The infinity norm of the path error vector. */
+    Real maxPathError = NaN;
+    /* The number of active obstacles. */
+    int nObstaclesInContact = -1;
+};
+
+//------------------------------------------------------------------------------
+//  CableSpanData
+//------------------------------------------------------------------------------
+/* CableSpanData is a data structure used by class CableSpan::Impl to store
+relevant quantities in the State's cache.
+
+The struct has three members Instance, Position and Velocity that correspond to
+the stages (Stage::Instance, Stage::Position and Stage::Velocity) at which they
+can be computed.
+
+Member variables with a "_G" suffix are expressed in the Ground frame. */
+struct CableSpanData {
+    /* Cache entry for holding MatrixWorkspaces of different dimensions.
+    This acts as a scratchpad when computing Stage::Position level data, during
+    which the path is essentially computed. During that computation the
+    dimension of the matrices changes as the cable touches down- or lifts off
+    from obstacle surfaces. This means that MatrixWorkspaces of different
+    dimensions are used when compting the optimal path. After having completed
+    the Stage::Position level data, the data in the MatrixWorkspaces is no
+    longer used. */
+    class Instance {
+    public:
+        Instance() = default;
+
+        // Get mutable access to a MatrixWorkspace of appropriate dimension.
+        // Constructs requested MatrixWorkspace if not done previously.
+        MatrixWorkspace& updOrInsert(int nActive)
+        {
+            SimTK_ASSERT1(
+                nActive >= 0,
+                "CableSpanData::updOrInsert()"
+                "Number of obstacles in contact must be nonnegative (got %d)",
+                nActive);
+
+            // Construct all MatrixWorkspaces for up to and including the
+            // requested dimension.
+            for (size_t i = matrixWorkspaces.size();
+                 i <= static_cast<size_t>(nActive);
+                 ++i) {
+                matrixWorkspaces.emplace_back(static_cast<int>(i));
+            }
+
+            // Return MatrixWorkspace of requested dimension.
+            return matrixWorkspaces.at(nActive);
+        }
+
+    private:
+        // MatrixWorkspaces of suitable dimensions for solving the cable path
+        // given a number of obstacles in contact with the cable. The ith
+        // element in the vector is used for solving a path with i-active
+        // obstacles.
+        std::vector<MatrixWorkspace> matrixWorkspaces;
+    };
+    struct Position final {
+        // Position of the cable origin point in the ground frame.
+        Vec3 originPoint_G{NaN, NaN, NaN};
+        // Position of the cable termination point in the ground frame.
+        Vec3 terminationPoint_G{NaN, NaN, NaN};
+        // Tangent vector to the cable at the origin point, in the ground frame.
+        UnitVec3 originTangent_G{NaN, NaN, NaN};
+        // Tangent vector to the cable at the termination point, in the ground
+        // frame.
+        UnitVec3 terminationTangent_G{NaN, NaN, NaN};
+        // The total cable length.
+        Real cableLength = NaN;
+        // The path smoothness, computed as the maximum angular misalignment at
+        // the points where the straight- and curved-line segments meet,
+        // measured in radians.
+        Real smoothness = NaN;
+        // Number of iterations the solver used to compute the cable's path.
+        int loopIter = -1;
+    };
+    struct Velocity final {
+        // Time derivative of the total cable length.
+        Real lengthDot = NaN;
+    };
+};
+
+//------------------------------------------------------------------------------
+//  CurveSegmentData
+//------------------------------------------------------------------------------
+/* CurveSegmentData is a data structure used by class CurveSegment to store
+relevent quantities in the State's cache.
+
+The struct has two member structs Instance and Position that correspond to the
+stages (Stage::Instance and Stage::Position) at which they can be computed.
+
+Following Scholz2015 the following subscripts are used:
+
+Member variables with a "_P" suffix indicate the start of the geodesic.
+Member variables with a "_Q" suffix indicate the end of the geodesic.
+Member variables with a "_S" suffix are expressed in the Surface frame.
+Member variables with a "_G" suffix are expressed in the Ground frame.
+
+For example: point_SP would indicate the initial contact point represented and
+measured from the surface's origin frame. */
+struct CurveSegmentData {
+    struct Instance final {
+        // Frenet frame at the initial contact point w.r.t. the surface frame.
+        FrenetFrame X_SP{Rotation().setRotationToNaN(), Vec3(NaN)};
+        // Frenet frame at the final contact point w.r.t. the surface frame.
+        FrenetFrame X_SQ{Rotation().setRotationToNaN(), Vec3(NaN)};
+        // Length of this curve segment.
+        Real arcLength = NaN;
+        // Curvatures at the contact points, with the tangential and binormal
+        // direction as the first and last element respectively.
+        Vec2 curvatures_P{NaN}; // initial contact point.
+        Vec2 curvatures_Q{NaN}; // final contact point.
+        // Geodesic torsion at the initial and final contact points.
+        Real torsion_P = NaN;
+        Real torsion_Q = NaN;
+        // Jacobi scalars at the final contact point. Contains the
+        // translational and rotational direction as the first and last
+        // element (see Scholz2015).
+        Vec2 jacobi_Q{NaN};
+        Vec2 jacobiDot_Q{NaN};
+        // Samples recorded from shooting the geodesic over the surface.
+        // For an analytic contact geometry this container will be empty.
+        // Otherwise, the first and last sample will contain X_SP and X_SQ
+        // defined above.
+        std::vector<ContactGeometry::GeodesicKnotPoint> geodesicKnotPoints;
+        // The initial integrator stepsize to try next time when shooting a
+        // geodesic. This step size estimate will improve each time after
+        // shooting a new geodesic.
+        // The default value is a bit arbitrary: Taking it too large will
+        // simply cause it to be rejected. Taking it too small will cause it to
+        // rapidly increase. We take it too small, to be on the safe side.
+        Real integratorInitialStepSize = 1e-10;
+        // Given the line spanned by the point before and after this curve
+        // segment, the tracking point lies on that line and is nearest to the
+        // surface. This point is used to find the touchdown location when the
+        // curve is not in contact with the obstacles's surface.
+        Vec3 trackingPointOnLine_S{NaN, NaN, NaN};
+        // This is a flag to indicate whether the cable comes into contact with
+        // the obstacle at all. If the cable is not in contact with the
+        // surface, only trackingPointOnLine_S will contain valid data. If the
+        // cable is in contact with the surface, trackingPointOnLine_S will not
+        // contain valid data.
+        ObstacleWrappingStatus wrappingStatus =
+            ObstacleWrappingStatus::InitialGuess;
+    };
+    struct Position final {
+        // Position and orientation of contact geometry w.r.t. ground.
+        Transform X_GS;
+        // Frenet frame at the initial contact point w.r.t. ground.
+        FrenetFrame X_GP;
+        // Frenet frame at the final contact point w.r.t. ground.
+        FrenetFrame X_GQ;
+    };
+};
+
+} // namespace
+
+//==============================================================================
+//                          Configuration Parameters
+//==============================================================================
+/* The following section contains structs that collect relevant configuration
+parameters. */
+namespace
+{
+
+//------------------------------------------------------------------------------
+//  Integrator Tolerances
+//------------------------------------------------------------------------------
+/* These are all the parameters needed to configure the GeodesicIntegrator
+when computing a new geodesic over the obstacle's surface. */
+struct IntegratorTolerances {
+    // The accuracy used to control the stepsize of the variable step geodesic
+    // integrator.
+    Real geodesicIntegratorAccuracy = 1e-9;
+    // The tolerance used when projecting the geodesic's state to the surface
+    // during integration.
+    // TODO the surface projection tolerance should be linked to the geodesic
+    // integrator accuracy.
+    Real constraintProjectionTolerance = 1e-9;
+    // TODO this is not connected to anything yet.
+    int constraintProjectionMaxIterations = 50;
+};
+
+//------------------------------------------------------------------------------
+//  Cable Span Parameters
+//------------------------------------------------------------------------------
+/* These are all the parameters for configuring the solver steps in the
+CableSpan. */
+struct CableSpanParameters final : IntegratorTolerances {
+    // The path's smoothness tolerance is defined as the angular misalignment
+    // at the points where the straight- and curved-line segments meet,
+    // measured in radians. When computing the optimal path this quantity is
+    // minimized, and the solver stops when reaching this tolerance.
+    Real smoothnessTolerance = 0.1 / 180. * Pi; // Default = 0.1 degrees.
+    // The solver's max allowed number of iterations used to compute the
+    // optimal path.
+    int solverMaxIterations = 50; // TODO a bit high?
+    // The solver's max allowed stepsize measured in radians. This is converted
+    // to a max allowed linear stepsize using the local radius of curvature
+    // evaluated at each obstacle.
+    Real solverMaxStepSize = 10. / 180. * Pi;
+};
+
+} // namespace
+
+//==============================================================================
+//                Contact Geometry Related Helper Functions
+//==============================================================================
+/* This section contains some helper functions for handling FrenetFrames and
+flipping some signs in ContactGeometry. */
+namespace
+{
+
+// Helper for grabbing the tangent axis.
+const UnitVec3& getTangent(const FrenetFrame& X)
+{
+    return X.R().getAxisUnitVec(TangentAxis);
+}
+
+// Helper for grabbing the normal axis.
+const UnitVec3& getNormal(const FrenetFrame& X)
+{
+    return X.R().getAxisUnitVec(NormalAxis);
+}
+
+// Helper for grabbing the binormal axis.
+const UnitVec3& getBinormal(const FrenetFrame& X)
+{
+    return X.R().getAxisUnitVec(BinormalAxis);
+}
+
+// Compute the Frenet frame at a knot point of a geodesic.
+FrenetFrame calcFrenetFrameFromGeodesicState(
+    const ContactGeometry& geometry,
+    const ContactGeometry::GeodesicKnotPoint& q)
+{
+    FrenetFrame X;
+    X.updP() = q.point;
+    X.updR().setRotationFromTwoAxes(
+        geometry.calcSurfaceUnitNormal(q.point),
+        NormalAxis,
+        q.tangent,
+        TangentAxis);
+    return X;
+}
+
+// Compute the surface curvature such that tangentDot = curvature * normal
+// (This flips the sign).
+Real calcSurfaceCurvature(
+    const ContactGeometry& geometry,
+    const FrenetFrame& X_S,
+    CoordinateAxis direction)
+{
+    return -geometry.calcSurfaceCurvatureInDirection(
+        X_S.p(),
+        X_S.R().getAxisUnitVec(direction));
+}
+
+// Evaluate whether a point lies below the given surface.
+bool isPointBelowSurface(const ContactGeometry& geometry, const Vec3& point_S)
+{
+    // We are not below the surface if the surface is not defined at the point.
+    if (!geometry.isSurfaceDefined(point_S)) {
+        return false;
+    }
+    // NOTE surface value is negative above surface.
+    return geometry.calcSurfaceValue(point_S) > 0.;
+}
+
+} // namespace
+
+//==============================================================================
+//                      Class CableSubsystem::Impl
+//==============================================================================
+// Implementation class of the CableSubsystem.
+class CableSubsystem::Impl : public Subsystem::Guts {
+public:
+    //--------------------------------------------------------------------------
+    //  Interface Translation Functions
+    //--------------------------------------------------------------------------
+    CableSpanIndex adoptCable(CableSpan& cable)
+    {
+        invalidateSubsystemTopologyCache();
+
+        CableSpanIndex cableIx(cables.size());
+        cables.emplace_back(cable);
+        return cableIx;
+    }
+
+    int getNumCables() const
+    {
+        return cables.size();
+    }
+
+    const CableSpan& getCable(CableSpanIndex index) const;
+
+    CableSpan& updCable(CableSpanIndex index);
+
+    const CableSpan::Impl& getCableImpl(CableSpanIndex index) const;
+
+    const MultibodySystem& getMultibodySystem() const
+    {
+        return MultibodySystem::downcast(getSystem());
+    }
+
+    SimTK_DOWNCAST(Impl, Subsystem::Guts);
+
+private:
+    //--------------------------------------------------------------------------
+    //  Subsystem::Guts Virtual Interface
+    //--------------------------------------------------------------------------
+    Impl* cloneImpl() const override
+    {
+        return new Impl(*this);
+    }
+
+    int realizeSubsystemTopologyImpl(State& state) const override;
+
+    int calcDecorativeGeometryAndAppendImpl(
+        const State& state,
+        Stage stage,
+        Array_<DecorativeGeometry>& decorations) const override;
+
+    //--------------------------------------------------------------------------
+    //  Data
+    //--------------------------------------------------------------------------
+
+    // All cables in this subsystem.
+    Array_<CableSpan, CableSpanIndex> cables;
+
+    //--------------------------------------------------------------------------
+    friend CableSubsystemTestHelper;
+};
+
+//==============================================================================
+//                          Struct Curve Segment
+//==============================================================================
+/* The CableSpan's path consists of straight line segments between the
+obstacles, and curved segments over the obstacles. This struct represents the
+curve segment related to an obstacle in the path. It manages the cached data
+related to that obstacle such as the WrappingStatus, the geodesic in local
+coordinates, and the contact points in Ground frame coordinates. */
+class CurveSegment final {
+public:
+    //--------------------------------------------------------------------------
+    // Constructors.
+    //--------------------------------------------------------------------------
+
+    CurveSegment() = default;
+
+    CurveSegment(
+        CableSubsystem* subsystem,
+        CableSpanIndex cableIndex,
+        ObstacleIndex obstacleIndex,
+        MobilizedBodyIndex obstacleBody,
+        Transform X_BS,
+        std::shared_ptr<const ContactGeometry> obstacleGeometry,
+        const Vec3& contactPointHint_S) :
+        m_subsystem(subsystem),
+        m_cableIndex(cableIndex), m_obstacleIndex(obstacleIndex),
+        m_body(obstacleBody), m_X_BS(std::move(X_BS)),
+        m_geometry(std::move(obstacleGeometry)),
+        m_contactPointHint_S(contactPointHint_S)
+    {}
+
+    //--------------------------------------------------------------------------
+    // Realizing and cache access.
+    //--------------------------------------------------------------------------
+
+    // Allocate state variables and cache entries.
+    void realizeTopology(State& state)
+    {
+        CurveSegmentData::Instance dataInst;
+        // Initialize the contact point if a hint is available.
+        if (isContactPointHintAvailable()) {
+            const Vec3 initContactPoint =
+                getContactGeometry().projectDownhillToNearestPoint(
+                    getContactPointHint());
+            dataInst.X_SP.updP()    = initContactPoint;
+            dataInst.X_SQ.updP()    = initContactPoint;
+            dataInst.wrappingStatus = ObstacleWrappingStatus::InitialGuess;
+        } else {
+            // Otherwise assume no contact.
+            dataInst.trackingPointOnLine_S = Vec3{0.};
+            dataInst.wrappingStatus = ObstacleWrappingStatus::LiftedFromSurface;
+        }
+        // Use auto-update discrete variable to retain the previous path as a
+        // warmstart.
+        m_indexDataInst = updSubsystem().allocateAutoUpdateDiscreteVariable(
+            state,
+            Stage::Position,
+            new Value<CurveSegmentData::Instance>(dataInst),
+            Stage::Instance);
+
+        m_indexDataPos = updSubsystem().allocateCacheEntry(
+            state,
+            Stage::Position,
+            Stage::Infinity,
+            new Value<CurveSegmentData::Position>());
+    }
+
+    void invalidatePosEntry(const State& state) const
+    {
+        getSubsystem().markCacheValueNotRealized(state, m_indexDataPos);
+    }
+
+    const CurveSegmentData::Instance& getDataInst(const State& state) const
+    {
+        const CableSubsystem& subsystem = getSubsystem();
+        if (!subsystem.isDiscreteVarUpdateValueRealized(
+                state,
+                m_indexDataInst)) {
+            updDataInst(state) = getPrevDataInst(state);
+            subsystem.markDiscreteVarUpdateValueRealized(
+                state,
+                m_indexDataInst);
+        }
+        return Value<CurveSegmentData::Instance>::downcast(
+            subsystem.getDiscreteVarUpdateValue(state, m_indexDataInst));
+    }
+
+    const CurveSegmentData::Position& getDataPos(const State& state) const
+    {
+        return Value<CurveSegmentData::Position>::downcast(
+            getSubsystem().getCacheEntry(state, m_indexDataPos));
+    }
+
+    //------------------------------------------------------------------------------
+    // Model configuration accessors.
+    //------------------------------------------------------------------------------
+
+    // Set the user defined point that controls the initial wrapping path.
+    // Point is in surface coordinates.
+    void setContactPointHint(Vec3 contactPointHint_S)
+    {
+        m_contactPointHint_S = contactPointHint_S;
+    }
+
+    // Get the user defined point that controls the initial wrapping path.
+    // Point is in surface coordinates.
+    Vec3 getContactPointHint() const
+    {
+        return m_contactPointHint_S;
+    }
+
+    bool isContactPointHintAvailable() const
+    {
+        return !(
+            isNaN(m_contactPointHint_S[0]) && isNaN(m_contactPointHint_S[1]) &&
+            isNaN(m_contactPointHint_S[2]));
+    }
+
+    const ContactGeometry& getContactGeometry() const
+    {
+        return *m_geometry;
+    }
+
+    void setContactGeometry(std::shared_ptr<const ContactGeometry> geometry)
+    {
+        m_geometry = std::move(geometry);
+    }
+
+    const MobilizedBody& getMobilizedBody() const
+    {
+        return getSubsystem()
+            .getMultibodySystem()
+            .getMatterSubsystem()
+            .getMobilizedBody(m_body);
+    }
+
+    const MobilizedBodyIndex& getMobilizedBodyIndex() const
+    {
+        return m_body;
+    }
+
+    void setMobilizedBodyIndex(MobilizedBodyIndex body)
+    {
+        m_body = body;
+    }
+
+    const Transform& getTransformSurfaceToBody() const
+    {
+        return m_X_BS;
+    }
+
+    void setTransformSurfaceToBody(const Transform& X_BS)
+    {
+        m_X_BS = X_BS;
+    }
+
+    const CableSubsystem& getSubsystem() const
+    {
+        if (!m_subsystem) {
+            SimTK_ERRCHK_ALWAYS(
+                m_subsystem,
+                "CurveSegment::getSubsystem()",
+                "CableSpan not yet adopted by any CableSubsystem");
+        }
+        return *m_subsystem;
+    }
+
+    CableSubsystem& updSubsystem()
+    {
+        if (!m_subsystem) {
+            SimTK_ERRCHK_ALWAYS(
+                m_subsystem,
+                "CurveSegment::updSubsystem()",
+                "CableSpan not yet adopted by any CableSubsystem");
+        }
+        return *m_subsystem;
+    }
+
+    void setSubsystem(CableSubsystem& subsystem)
+    {
+        m_subsystem = &subsystem;
+    }
+
+    const CableSpan::Impl& getCable() const
+    {
+        return getSubsystem().getImpl().getCableImpl(m_cableIndex);
+    }
+    const IntegratorTolerances& getIntegratorTolerances() const;
+
+    //------------------------------------------------------------------------------
+    // Utility functions.
+    //------------------------------------------------------------------------------
+
+    Transform calcSurfaceFrameInGround(const State& state) const
+    {
+        return getMobilizedBody().getBodyTransform(state).compose(m_X_BS);
+    }
+
+    Vec3 calcInitialContactPoint_G(const State& state) const
+    {
+        return calcSurfaceFrameInGround(state).shiftFrameStationToBase(
+            getDataInst(state).X_SP.p());
+    }
+
+    Vec3 calcFinalContactPoint_G(const State& state) const
+    {
+        return calcSurfaceFrameInGround(state).shiftFrameStationToBase(
+            getDataInst(state).X_SQ.p());
+    }
+
+    bool isInContactWithSurface(const State& state) const
+    {
+        const CurveSegmentData::Instance& dataInst = getDataInst(state);
+        return dataInst.wrappingStatus ==
+                   ObstacleWrappingStatus::InContactWithSurface ||
+               dataInst.wrappingStatus == ObstacleWrappingStatus::InitialGuess;
+    }
+
+    //------------------------------------------------------------------------------
+    //  Helper Functions: Finding next and previous CurveSegments
+    //------------------------------------------------------------------------------
+    // The functions below essentially filter any obstacles that are not in
+    // contact with the cable.
+
+    // Find the first obstacle before this segment that is in contact with the
+    // cable. Returns an invalid index if there is none.
+    ObstacleIndex findPrevObstacleInContactWithCable(const State& state) const;
+    // Similarly find the first obstacle after this segment that is in contact.
+    ObstacleIndex findNextObstacleInContactWithCable(const State& state) const;
+
+    // Find the last path point before this segment, in ground frame
+    // coordinates.
+    Vec3 findPrevPathPoint_G(const State& state) const;
+    // Find the first path point after this segment, in ground frame
+    // coordinates.
+    Vec3 findNextPathPoint_G(const State& state) const;
+
+    // Find the path point before this segment, in surface frame coordinates.
+    Vec3 findPrevPathPoint_S(const State& state) const
+    {
+        const Vec3 prevPoint_S =
+            calcSurfaceFrameInGround(state).shiftBaseStationToFrame(
+                findPrevPathPoint_G(state));
+        SimTK_ERRCHK_ALWAYS(
+            !isPointBelowSurface(getContactGeometry(), prevPoint_S),
+            "CurveSegment::Impl::assertSurfaceBounds",
+            "Preceding point lies inside the surface");
+        return prevPoint_S;
+    }
+    // Find the path point after this segment, in surface frame coordinates.
+    Vec3 findNextPathPoint_S(const State& state) const
+    {
+        const Vec3 nextPoint_S =
+            calcSurfaceFrameInGround(state).shiftBaseStationToFrame(
+                findNextPathPoint_G(state));
+        SimTK_ERRCHK_ALWAYS(
+            !isPointBelowSurface(getContactGeometry(), nextPoint_S),
+            "CurveSegment::Impl::assertSurfaceBounds",
+            "Next point lies inside the surface");
+        return nextPoint_S;
+    }
+
+    //------------------------------------------------------------------------------
+    //  Updating CurveSegmentData::Instance Helpers
+    //------------------------------------------------------------------------------
+
+    // Compute a new geodesic from provided initial conditions.
+    void shootNewGeodesic(
+        const Vec3& point_S,
+        const Vec3& tangent_S,
+        Real length,
+        Real initIntegratorStepSize,
+        CurveSegmentData::Instance& dataInst) const
+    {
+        // Shoot a new geodesic over the surface, and compute the geodesic state
+        // at the first and last contact point of the surface.
+        std::array<ContactGeometry::GeodesicKnotPoint, 2>
+            geodesicBoundaryStates;
+
+        // First determine if this geometry has an analytic form.
+        const ContactGeometry& geometry = getContactGeometry();
+        const bool useAnalyticGeodesic  = geometry.isAnalyticFormAvailable();
+
+        if (useAnalyticGeodesic) {
+            // For analytic surfaces we can compute the inital and final Frenet
+            // frames without computing any intermediate knot points.
+            int numberOfKnotPoints = 2;
+            int knotIx             = 0;
+            geometry.shootGeodesicInDirectionAnalytically(
+                point_S,
+                tangent_S,
+                length,
+                numberOfKnotPoints,
+                // Copy the state at the boundary frames.
+                [&](const ContactGeometry::GeodesicKnotPoint& q)
+                {
+                    geodesicBoundaryStates.at(knotIx) = q;
+                    ++knotIx;
+                });
+        } else {
+            // For implicit surfaces we must use a numerical integrator to
+            // compute the initial and final frames. Because this is relatively
+            // costly, we will cache this geodesic.
+            dataInst.geodesicKnotPoints.clear();
+            const IntegratorTolerances& tols = getIntegratorTolerances();
+            geometry.shootGeodesicInDirectionImplicitly(
+                point_S,
+                tangent_S,
+                length,
+                initIntegratorStepSize,
+                tols.geodesicIntegratorAccuracy,
+                tols.constraintProjectionTolerance,
+                tols.constraintProjectionMaxIterations,
+                [&](const ContactGeometry::GeodesicKnotPoint& q)
+                {
+                    // Store the knot points in the cache.
+                    dataInst.geodesicKnotPoints.push_back(q);
+                });
+
+            // Copy the state at the boundary frames.
+            SimTK_ASSERT(
+                dataInst.geodesicKnotPoints.size() > 0,
+                "CurveSegment: Failed to shoot a new geodesic: buffer empty");
+            geodesicBoundaryStates = {
+                dataInst.geodesicKnotPoints.front(),
+                dataInst.geodesicKnotPoints.back(),
+            };
+        }
+
+        // Use the geodesic state at the boundary frames to compute the fields
+        // in CurveSegmentData::Instance.
+
+        // Compute the Frenet frames at the boundary frames.
+        dataInst.X_SP = calcFrenetFrameFromGeodesicState(
+            geometry,
+            geodesicBoundaryStates.front());
+        dataInst.X_SQ = calcFrenetFrameFromGeodesicState(
+            geometry,
+            geodesicBoundaryStates.back());
+
+        // Compute the jacobi field scalars at the final frame.
+        dataInst.jacobi_Q = {
+            geodesicBoundaryStates.back().jacobiTrans,
+            geodesicBoundaryStates.back().jacobiRot,
+        };
+        dataInst.jacobiDot_Q = {
+            geodesicBoundaryStates.back().jacobiTransDot,
+            geodesicBoundaryStates.back().jacobiRotDot,
+        };
+
+        // Compute the curvatures at the boundary frames.
+        dataInst.curvatures_P = {
+            calcSurfaceCurvature(geometry, dataInst.X_SP, TangentAxis),
+            calcSurfaceCurvature(geometry, dataInst.X_SP, BinormalAxis),
+        };
+        dataInst.curvatures_Q = {
+            calcSurfaceCurvature(geometry, dataInst.X_SQ, TangentAxis),
+            calcSurfaceCurvature(geometry, dataInst.X_SQ, BinormalAxis),
+        };
+
+        // Compute the geodesic torsion at the boundary frames.
+        dataInst.torsion_P = geometry.calcSurfaceTorsionInDirection(
+            dataInst.X_SP.p(),
+            getTangent(dataInst.X_SP));
+        dataInst.torsion_Q = geometry.calcSurfaceTorsionInDirection(
+            dataInst.X_SQ.p(),
+            getTangent(dataInst.X_SQ));
+
+        // Store the arc length.
+        dataInst.arcLength = length;
+
+        // Update the initial integrator step size:
+        if (!useAnalyticGeodesic) { // does not apply to analytic surfaces.
+
+            // We want to know if we should attempt a larger initial step size
+            // next time, or a smaller one. If the initIntegratorStepSize was
+            // rejected, it makes little sense to start with the exact same step
+            // size next time, only to find it rejected again.
+
+            const int numStepsTaken =
+                static_cast<int>(dataInst.geodesicKnotPoints.size()) - 1;
+
+            // If the integrator took a single step or none: The final arc
+            // length is shorter than the initial step size attempted. The step
+            // was atleast not rejected, but we do not know if we can make it
+            // larger. So we do not update it.
+            if (numStepsTaken <= 1) {
+                // Try the same step next time:
+                dataInst.integratorInitialStepSize = initIntegratorStepSize;
+            }
+
+            // If the integrator took two or more steps, we might want to update
+            // the next step size to try,
+            if (numStepsTaken >= 2) {
+                // The acual initial step size taken by the integrator cannot
+                // have been larger than initIntegratorStepSize, but it might be
+                // smaller if it was rejected. If rejected, we will reduce the
+                // init step size for next time.
+                const Real actualFirstStepSize =
+                    dataInst.geodesicKnotPoints.at(1).arcLength -
+                    dataInst.geodesicKnotPoints.front().arcLength;
+                const bool initStepWasRejected =
+                    actualFirstStepSize < initIntegratorStepSize;
+                if (initStepWasRejected) {
+                    // Reduce the init step size for next time, to avoid
+                    // rejecting it again.
+                    dataInst.integratorInitialStepSize = actualFirstStepSize;
+                } else {
+                    // If the initIntegratorStepSize was accepted we might want
+                    // to try a larger step next time. The actualFirstStepSize
+                    // cannot be larger than initIntegratorStepSize: we must
+                    // take a look at the second step size.
+                    const Real actualSecondStepSize =
+                        dataInst.geodesicKnotPoints.at(2).arcLength -
+                        dataInst.geodesicKnotPoints.at(1).arcLength;
+                    // We already established that the initIntegratorStepSize
+                    // was accepted, now we are only looking to increase the
+                    // step size.
+                    dataInst.integratorInitialStepSize =
+                        std::max(initIntegratorStepSize, actualSecondStepSize);
+                }
+            }
+        }
+
+        dataInst.wrappingStatus = ObstacleWrappingStatus::InContactWithSurface;
+    }
+
+    // Lift curve from surface, and start tracking the given point.
+    void liftCurveFromSurface(
+        const Vec3& trackingPoint_S,
+        CurveSegmentData::Instance& dataInst) const
+    {
+        dataInst.wrappingStatus = ObstacleWrappingStatus::LiftedFromSurface;
+        dataInst.arcLength      = NaN;
+        dataInst.trackingPointOnLine_S = trackingPoint_S;
+    }
+
+    // Helper function for initializing the path.
+    void calcInitCurve(const State& state) const
+    {
+        // Check if a valid contact point hint was set.
+        if (!isContactPointHintAvailable()) {
+            // No initial contact point was set: Initialize as lifted from the
+            // surface, and initialize tracking point at origin (for lack of
+            // alternative).
+            liftCurveFromSurface(Vec3(0.), updDataInst(state));
+            return;
+        }
+        // If we do have a contact point hint, initialize the path by shooting a
+        // zero-length geodesic at that location.
+
+        // Shoot a zero length geodesic at the contact point with tangent
+        // directed from prevPoint to nextPoint:
+        const Vec3 prevPoint_S = findPrevPathPoint_S(state);
+        const Vec3 nextPoint_S = findNextPathPoint_S(state);
+        shootNewGeodesic(
+            getContactPointHint(),     // = location
+            nextPoint_S - prevPoint_S, // = tangent
+            0.,                        // = arc length
+            getDataInst(state).integratorInitialStepSize,
+            updDataInst(state));
+    }
+
+    // Helper function for detecting touchdown on the obstacle's surface, and
+    // the location of the touchdown point if so.
+    void calcCurveTouchdownIfNeeded(const State& state) const
+    {
+        // Only attempt touchdown when lifted.
+        const CurveSegmentData::Instance& dataInst = getDataInst(state);
+        if (dataInst.wrappingStatus !=
+            ObstacleWrappingStatus::LiftedFromSurface) {
+            return;
+        }
+
+        // Given the straight line between the point before and after this
+        // segment, touchdown is detected by computing the point on that line
+        // that is nearest to the surface.
+        const Vec3 prevPoint_S = findPrevPathPoint_S(state);
+        const Vec3 nextPoint_S = findNextPathPoint_S(state);
+
+        // Use the cached tracking point as the initial guess.
+        Vec3 pointOnLineNearSurface_S = dataInst.trackingPointOnLine_S;
+
+        // Compute the point on the line nearest the surface.
+        const IntegratorTolerances& tols = getIntegratorTolerances();
+        bool touchdownDetected =
+            getContactGeometry().calcNearestPointOnLineImplicitly(
+                prevPoint_S,
+                nextPoint_S,
+                tols.constraintProjectionMaxIterations,
+                tols.constraintProjectionTolerance,
+                pointOnLineNearSurface_S) ==
+            ContactGeometry::NearestPointOnLineResult::PointFallsBelowSurface;
+
+        // In case of touchdown, shoot a zero-length geodesic at the touchdown
+        // point.
+        if (touchdownDetected) {
+            shootNewGeodesic(
+                pointOnLineNearSurface_S,
+                nextPoint_S - prevPoint_S,
+                0.,
+                dataInst.integratorInitialStepSize,
+                updDataInst(state));
+            return;
+        }
+
+        // Not touchingdown indicates liftoff:
+        liftCurveFromSurface(pointOnLineNearSurface_S, updDataInst(state));
+    }
+
+    // Helper function for detecting liftoff from the obstacle's surface.
+    void calcCurveLiftoffIfNeeded(const State& state) const
+    {
+        // Only attempt liftoff when currently wrapping the surface.
+        const CurveSegmentData::Instance& dataInst = getDataInst(state);
+        if (dataInst.wrappingStatus !=
+            ObstacleWrappingStatus::InContactWithSurface) {
+            return;
+        }
+
+        // The curve length must have shrunk completely before lifting off.
+        if (dataInst.arcLength > 0.) {
+            return;
+        }
+
+        // For a zero-length curve, trigger liftoff when the prev and next
+        // points lie above the surface plane.
+        const Vec3 prevPoint_S = findPrevPathPoint_S(state);
+        const Vec3 nextPoint_S = findNextPathPoint_S(state);
+        if (dot(prevPoint_S - dataInst.X_SP.p(),
+                dataInst.X_SP.R().getAxisUnitVec(NormalAxis)) <= 0. ||
+            dot(nextPoint_S - dataInst.X_SP.p(),
+                dataInst.X_SP.R().getAxisUnitVec(NormalAxis)) <= 0.) {
+            // No liftoff.
+            return;
+        }
+
+        // Liftoff detected, initialize the tracking point from the last contact
+        // point.
+        liftCurveFromSurface(dataInst.X_SP.p(), updDataInst(state));
+    }
+
+    //------------------------------------------------------------------------------
+    //  Computing cached data
+    //------------------------------------------------------------------------------
+
+    // Apply the correction to the initial condition of the geodesic, and
+    // shoot a new geodesic, updating the cache variable.
+    void applyGeodesicCorrection(
+        const State& state,
+        const NaturalGeodesicCorrection& c) const
+    {
+        // Get the previous geodesic.
+        const CurveSegmentData::Instance& dataInst = getDataInst(state);
+
+        // Frenet frame at initial contact point.
+        const FrenetFrame& X_SP = dataInst.X_SP;
+        const UnitVec3& t       = getTangent(X_SP);
+        const UnitVec3& n       = getNormal(X_SP);
+        const UnitVec3& b       = getBinormal(X_SP);
+
+        const Real tau   = dataInst.torsion_P;
+        const Real kappa = dataInst.curvatures_P[0];
+
+        // Get corrected initial conditions.
+        const Vec3 dx               = t * c[0] + b * c[1];
+        const Vec3 correctedPoint_S = X_SP.p() + dx;
+
+        const Vec3 w = (kappa * c[0] - tau * c[1]) * b - c[2] * n;
+        const Vec3 correctedTangent_S = t + cross(w, t);
+
+        // Take the length correction, and add to the current length.
+        const Real dl = c[3]; // Length increment is the last element.
+        const Real correctedLength = std::max(
+            dataInst.arcLength + dl,
+            0.); // Clamp length to be nonnegative.
+
+        // Shoot the new geodesic.
+        shootNewGeodesic(
+            correctedPoint_S,
+            correctedTangent_S,
+            correctedLength,
+            dataInst.integratorInitialStepSize,
+            updDataInst(state));
+
+        getSubsystem().markDiscreteVarUpdateValueRealized(
+            state,
+            m_indexDataInst);
+        invalidatePosEntry(state);
+    }
+
+    const CurveSegmentData::Instance& calcDataInst(const State& state) const
+    {
+        // Update the CurveSegmentData::Instance cache depending on the current
+        // wrapping status.
+        switch (getDataInst(state).wrappingStatus) {
+        case ObstacleWrappingStatus::Disabled:
+            break;
+        case ObstacleWrappingStatus::InitialGuess:
+            // Path needs to be initialized.
+            calcInitCurve(state);
+            break;
+        case ObstacleWrappingStatus::InContactWithSurface:
+            // If in contact with obstacle: detect lifting off.
+            calcCurveLiftoffIfNeeded(state);
+            break;
+        case ObstacleWrappingStatus::LiftedFromSurface:
+            // If not in contact with obstacle: detect touching down.
+            calcCurveTouchdownIfNeeded(state);
+            break;
+        }
+
+        getSubsystem().markDiscreteVarUpdateValueRealized(
+            state,
+            m_indexDataInst);
+        return getDataInst(state);
+    }
+
+    const CurveSegmentData::Position& calcDataPos(const State& state) const
+    {
+        // Make sure the Instance level data is up to date.
+        const CurveSegmentData::Instance& dataInst = calcDataInst(state);
+
+        // Update the Stage::Position level cache.
+        CurveSegmentData::Position& dataPos = updDataPos(state);
+
+        // Store tramsform from local surface frame to ground.
+        dataPos.X_GS = calcSurfaceFrameInGround(state);
+
+        // Check if the obstacle is in contact with the cable.
+        if (isInContactWithSurface(state)) {
+            // Store the geodesic's Frenet frames in ground frame.
+            dataPos.X_GP = dataPos.X_GS.compose(dataInst.X_SP);
+            dataPos.X_GQ = dataPos.X_GS.compose(dataInst.X_SQ);
+        } else {
+            // No contact = no geodesic.
+            dataPos.X_GP.setToNaN();
+            dataPos.X_GQ.setToNaN();
+        }
+
+        getSubsystem().markCacheValueRealized(state, m_indexDataPos);
+
+        return dataPos;
+    }
+
+    //------------------------------------------------------------------------------
+    //  Generating Geodesic Points For Visualization
+    //------------------------------------------------------------------------------
+
+    void calcDecorativePathPoints(
+        const State& state,
+        const std::function<void(Vec3 point_G)>& sink) const
+    {
+        if (!isInContactWithSurface(state)) {
+            return;
+        }
+
+        const CurveSegmentData::Instance& dataInst = getDataInst(state);
+        const Transform& X_GS                      = getDataPos(state).X_GS;
+
+        // Lambda for computing the point in ground from a GeodesicKnotPoint,
+        // and writing it to the sink.
+        auto calcPathPointAndWriteToSink =
+            [&](const ContactGeometry::GeodesicKnotPoint& q)
+        {
+            const Vec3 point_G = X_GS.shiftFrameStationToBase(q.point);
+            sink(point_G);
+        };
+
+        if (getContactGeometry().isAnalyticFormAvailable()) {
+            // NOTE Depending on what is actually desired by the end-user, this
+            // might need revision.
+
+            // For analytic surfaces there is no numerical integrator to give a
+            // natural interspacing of knots. So instead I just assume you
+            // would like some OK granularity. This can be done by interspacing
+            // the knots by a certain "angle" (e.g. 5 degrees is pretty fine),
+            // and using the radius of curvature to convert the angle to a
+            // spatial interspacing of the samples.
+            constexpr Real c_AngularSpacing = 0.087; // ~ 5 degrees
+
+            // To convert the angular spacing to a spatial spacing we need the
+            // curvature. The curvature is generally not constant along a
+            // geodesic, but there are not a lot of analytic surfaces at the
+            // moment (sphere and cylinder?). For these we can just look at the
+            // curvature at the boundary frames to know the curvature along the
+            // entire geodesic.
+            const Real maxCurvature_P = max(abs(dataInst.curvatures_P));
+            const Real maxCurvature_Q = max(abs(dataInst.curvatures_Q));
+            const Real minRadiusOfCurvature =
+                1. / std::max(maxCurvature_P, maxCurvature_Q);
+
+            // Estimate the spatial interspacing from the angular spacing and
+            // the radius of curvature.
+            const Real lengthInterspacing =
+                minRadiusOfCurvature * c_AngularSpacing;
+
+            // Now shoot the geodesic analytically with the desired granularity.
+            const int numberOfKnotPoints =
+                static_cast<int>(dataInst.arcLength / lengthInterspacing);
+            getContactGeometry().shootGeodesicInDirectionAnalytically(
+                dataInst.X_SP.p(),
+                getTangent(dataInst.X_SP),
+                dataInst.arcLength,
+                std::max(numberOfKnotPoints, 2),
+                calcPathPointAndWriteToSink);
+            return;
+        }
+
+        // If the surface did not have an analytic form, we simply forward the
+        // knots from the GeodesicIntegrator.
+        for (const ContactGeometry::GeodesicKnotPoint& q :
+             dataInst.geodesicKnotPoints) {
+            calcPathPointAndWriteToSink(q);
+        }
+    }
+
+    /* Resample the curve segment at equal length intervals using n=numSamples
+    points, and write them to the output sink. */
+    void calcResampledPoints(
+        const State& state,
+        int numSamples,
+        const std::function<void(Vec3 point_G)>& sink) const;
+
+private:
+    //------------------------------------------------------------------------------
+    // Private Cache Access.
+    //------------------------------------------------------------------------------
+
+    CurveSegmentData::Instance& updDataInst(const State& state) const
+    {
+        return Value<CurveSegmentData::Instance>::updDowncast(
+            getSubsystem().updDiscreteVarUpdateValue(state, m_indexDataInst));
+    }
+
+    const CurveSegmentData::Instance& getPrevDataInst(const State& state) const
+    {
+        return Value<CurveSegmentData::Instance>::downcast(
+            getSubsystem().getDiscreteVariable(state, m_indexDataInst));
+    }
+
+    CurveSegmentData::Instance& updPrevDataInst(State& state) const
+    {
+        return Value<CurveSegmentData::Instance>::updDowncast(
+            getSubsystem().updDiscreteVariable(state, m_indexDataInst));
+    }
+
+    CurveSegmentData::Position& updDataPos(const State& state) const
+    {
+        return Value<CurveSegmentData::Position>::updDowncast(
+            getSubsystem().updCacheEntry(state, m_indexDataPos));
+    }
+
+    //------------------------------------------------------------------------------
+    // Data
+    //------------------------------------------------------------------------------
+
+    // Subsystem info.
+    CableSubsystem* m_subsystem = nullptr;
+    // The index of this CurveSegment's cable in the CableSubsystem.
+    CableSpanIndex m_cableIndex = CableSpanIndex::Invalid();
+    // The index of this CurveSegment's obstacle in the cable.
+    ObstacleIndex m_obstacleIndex = ObstacleIndex::Invalid();
+
+    // MobilizedBody that surface is attached to.
+    MobilizedBodyIndex m_body;
+    // Surface to body transform.
+    Transform m_X_BS;
+
+    // Obstacle surface.
+    std::shared_ptr<const ContactGeometry> m_geometry;
+
+    // Topology cache.
+    CacheEntryIndex m_indexDataPos        = CacheEntryIndex::Invalid();
+    DiscreteVariableIndex m_indexDataInst = DiscreteVariableIndex::Invalid();
+
+    // Initial contact point hint used to setup the initial path.
+    Vec3 m_contactPointHint_S{NaN, NaN, NaN};
+
+    //------------------------------------------------------------------------------
+    // Helper class for unit tests.
+    friend CableSubsystemTestHelper;
+};
+
+//==============================================================================
+//                         Class Cablespan::Impl
+//==============================================================================
+/* This is the internal implementation class for CableSpan.
+
+The CableSpan::Impl's main job is to set up the solver for computing the path
+over the surfaces. A list of CurveSegments is stored, and whenever an obstacle
+is added to the CableSpan, this will create a new CurveSegment internally. The
+CurveSegment deals with computing the local geodesic, and detecting contact or
+liftoff, and manages the related cached data. We then collect info on the
+computed geodesics, to evaluate the path smoothness (see
+CableSpanData::Instance::pathError). Depending on the given tolerance, we
+compute the NaturalGeodesicCorrection vector for each CurveSegment to improve
+the smoothness, and try again. */
+class CableSpan::Impl {
+public:
+    //--------------------------------------------------------------------------
+    // Constructors.
+    //--------------------------------------------------------------------------
+
+    Impl() = default;
+
+    // Construct a CableSpan::Impl with valid data fields, but without being
+    // registered at any CableSubsystem.
+    Impl(
+        MobilizedBodyIndex originBody,
+        Vec3 originStation,
+        MobilizedBodyIndex terminationBody,
+        Vec3 terminationStation) :
+        m_originBody(originBody),
+        m_originStation(originStation),
+        m_terminationBody(terminationBody),
+        m_terminationStation(terminationStation)
+    {}
+
+    //--------------------------------------------------------------------------
+    // Realizing and accessing cache.
+    //--------------------------------------------------------------------------
+
+    // Allocate state variables and cache entries.
+    // The cached CableSpanData::Instance is shared among those CableSpan
+    // managed by one CableSubsystem, and accessed by the provided
+    // indexOfDataInstEntry.
+    void realizeTopology(State& state, CacheEntryIndex indexOfDataInstEntry)
+    {
+        m_indexDataInst = indexOfDataInstEntry;
+
+        m_indexDataPos = updSubsystem().allocateCacheEntry(
+            state,
+            Stage::Position,
+            Stage::Infinity,
+            new Value<CableSpanData::Position>());
+
+        m_indexDataVel = updSubsystem().allocateCacheEntry(
+            state,
+            Stage::Velocity,
+            Stage::Infinity,
+            new Value<CableSpanData::Velocity>());
+
+        for (CurveSegment& segment : m_curveSegments) {
+            segment.realizeTopology(state);
+        }
+    }
+
+    void invalidateTopology()
+    {
+        if (m_subsystem) {
+            getSubsystem().invalidateSubsystemTopologyCache();
+        }
+    }
+
+    void realizePosition(const State& state) const
+    {
+        if (getSubsystem().isCacheValueRealized(state, m_indexDataPos)) {
+            return;
+        }
+        calcDataPos(state);
+        getSubsystem().markCacheValueRealized(state, m_indexDataPos);
+    }
+
+    void realizeVelocity(const State& state) const
+    {
+        realizePosition(state);
+        if (getSubsystem().isCacheValueRealized(state, m_indexDataVel)) {
+            return;
+        }
+        calcDataVel(state, updDataVel(state));
+        getSubsystem().markCacheValueRealized(state, m_indexDataVel);
+    }
+
+    const CableSpanData::Position& getDataPos(const State& state) const
+    {
+        realizePosition(state);
+        return Value<CableSpanData::Position>::downcast(
+            getSubsystem().getCacheEntry(state, m_indexDataPos));
+    }
+
+    const CableSpanData::Velocity& getDataVel(const State& state) const
+    {
+        realizeVelocity(state);
+        return Value<CableSpanData::Velocity>::downcast(
+            getSubsystem().getCacheEntry(state, m_indexDataVel));
+    }
+
+    //--------------------------------------------------------------------------
+    // Accessors
+    //--------------------------------------------------------------------------
+
+    const CurveSegment& getObstacleCurveSegment(ObstacleIndex ix) const
+    {
+        return m_curveSegments[ix];
+    }
+
+    CurveSegment& updObstacleCurveSegment(ObstacleIndex ix)
+    {
+        return m_curveSegments[ix];
+    }
+
+    CableSpanParameters& updParameters()
+    {
+        return m_parameters;
+    }
+
+    const CableSpanParameters& getParameters() const
+    {
+        return m_parameters;
+    }
+
+    //--------------------------------------------------------------------------
+    // Helper functions: End-points frame transformations.
+    //--------------------------------------------------------------------------
+
+    // Get body to which this cable's origin point is rigidly attached to.
+    const Mobod& getOriginBody() const
+    {
+        return getSubsystem()
+            .getMultibodySystem()
+            .getMatterSubsystem()
+            .getMobilizedBody(m_originBody);
+    }
+
+    // Get body to which this cable's termination point is rigidly attached to.
+    const Mobod& getTerminationBody() const
+    {
+        return getSubsystem()
+            .getMultibodySystem()
+            .getMatterSubsystem()
+            .getMobilizedBody(m_terminationBody);
+    }
+
+    Vec3 calcOriginPointInGround(const State& state) const
+    {
+        return getOriginBody().getBodyTransform(state).shiftFrameStationToBase(
+            m_originStation);
+    }
+
+    Vec3 calcTerminationPointInGround(const State& state) const
+    {
+        return getTerminationBody()
+            .getBodyTransform(state)
+            .shiftFrameStationToBase(m_terminationStation);
+    }
+
+    //--------------------------------------------------------------------------
+    // Helper function
+    //--------------------------------------------------------------------------
+
+    // Count the number of CurveSegments that are in contact with the obstacle's
+    // surface.
+    int countActive(const State& s) const
+    {
+        int counter = 0;
+        for (const CurveSegment& curve : m_curveSegments) {
+            if (curve.isInContactWithSurface(s)) {
+                ++counter;
+            }
+        }
+        return counter;
+    }
+
+    //--------------------------------------------------------------------------
+    // CableSpan interface translation.
+    //--------------------------------------------------------------------------
+
+    ObstacleIndex addObstacle(
+        MobilizedBodyIndex obstacleBody,
+        const Transform& X_BS,
+        std::shared_ptr<const ContactGeometry> obstacleGeometry,
+        const Vec3& contactPointHint_S)
+    {
+        invalidateTopology();
+
+        ObstacleIndex obstacleIx(m_curveSegments.size());
+
+        m_curveSegments.push_back(CurveSegment(
+            m_subsystem,
+            getIndex(),
+            obstacleIx,
+            obstacleBody,
+            X_BS,
+            std::move(obstacleGeometry),
+            contactPointHint_S));
+
+        return obstacleIx;
+    }
+
+    MobilizedBodyIndex getOriginBodyIndex() const
+    {
+        return m_originBody;
+    }
+
+    void setOriginBodyIndex(MobilizedBodyIndex originBody)
+    {
+        m_originBody = originBody;
+    }
+
+    MobilizedBodyIndex getTerminationBodyIndex() const
+    {
+        return m_terminationBody;
+    }
+
+    void setTerminationBodyIndex(MobilizedBodyIndex terminationBody)
+    {
+        m_terminationBody = terminationBody;
+    }
+
+    const Vec3& getOriginStation() const
+    {
+        return m_originStation;
+    }
+
+    void setOriginStation(const Vec3& originStation)
+    {
+        m_originStation = originStation;
+    }
+
+    const Vec3& getTerminationStation() const
+    {
+        return m_terminationStation;
+    }
+
+    void setTerminationStation(const Vec3& terminationStation)
+    {
+        m_terminationStation = terminationStation;
+    }
+
+    int getNumObstacles() const
+    {
+        return m_curveSegments.size();
+    }
+
+    void applyBodyForces(
+        const State& state,
+        Real tension,
+        Vector_<SpatialVec>& bodyForcesInG) const;
+
+    Real calcCablePower(const State& state, Real tension) const;
+
+    void calcDecorativePathPoints(
+        const State& state,
+        const std::function<void(Vec3 point_G)>& sink) const
+    {
+        // Write the initial path point.
+        const CableSpanData::Position& dataPos = getDataPos(state);
+        sink(dataPos.originPoint_G);
+
+        // Write path points along each of the curves.
+        for (const CurveSegment& curve : m_curveSegments) {
+            curve.calcDecorativePathPoints(state, sink);
+        }
+
+        // Write the path's termination point.
+        sink(dataPos.terminationPoint_G);
+    }
+
+    void calcCurveSegmentResampledPoints(
+        const State& state,
+        CableSpanObstacleIndex ix,
+        int numSamples,
+        const std::function<void(Vec3 point_G)>& sink) const;
+
+    void calcDecorativeGeometryAndAppend(
+        const State& state,
+        Array_<DecorativeGeometry>& decorations) const
+    {
+        // Draw lines between all path points.
+        {
+            const Vec3 c_Color            = Purple;
+            constexpr int c_LineThickness = 3;
+
+            bool isFirstPoint = true;
+            Vec3 prevPoint_G{NaN};
+            // Lambda that draws a line between two path points prevPoint_G &
+            // nextPoint_G and pushes it to the decorations buffer.
+            auto pushDecorativeLineBetweenPathPoints = [&](Vec3 nextPoint_G)
+            {
+                if (!isFirstPoint) {
+                    decorations.push_back(
+                        DecorativeLine(prevPoint_G, nextPoint_G)
+                            .setColor(c_Color)
+                            .setLineThickness(c_LineThickness));
+                }
+                prevPoint_G  = nextPoint_G;
+                isFirstPoint = false;
+            };
+            // Call the lambda for all path points.
+            calcDecorativePathPoints(
+                state,
+                pushDecorativeLineBetweenPathPoints);
+        }
+
+        // For any obstacle that is not in contact with the cable, draw the
+        // tracking point used for touchdown.
+        {
+            const Vec3 c_Color            = Red;
+            constexpr int c_LineThickness = 3;
+
+            // Find those obstacles that are not in contact.
+            for (ObstacleIndex ix(0); ix < getNumObstacles(); ++ix) {
+                const CurveSegment& curve = getObstacleCurveSegment(ix);
+                if (curve.isInContactWithSurface(state)) {
+                    continue;
+                }
+
+                // Draw the tracking point (in ground frame).
+                const Transform X_GS = curve.getDataPos(state).X_GS;
+                const Vec3 trackingPoint_S =
+                    curve.getDataInst(state).trackingPointOnLine_S;
+                const Vec3 trackingPoint_G =
+                    X_GS.shiftFrameStationToBase(trackingPoint_S);
+                decorations.push_back(
+                    DecorativePoint(trackingPoint_G).setColor(c_Color));
+                // Draw line to tracking point from either the surface, or the
+                // obstacle origin. We default to drawing from the origin
+                // because surface projection becomes unstable at larger
+                // distances, which causes the projection to take too much
+                // time. Which was the reason to not use it in the first place.
+                // But it is more illustrative.
+                constexpr bool c_DrawLineFromObstacleOrigin = true;
+                if (c_DrawLineFromObstacleOrigin) {
+                    decorations.push_back(
+                        DecorativeLine(X_GS.p(), trackingPoint_G)
+                            .setColor(c_Color)
+                            .setLineThickness(c_LineThickness));
+                } else {
+                    Vec3 surfacePoint_S(NaN);
+                    try {
+                        surfacePoint_S =
+                            curve.getContactGeometry()
+                                .projectDownhillToNearestPoint(trackingPoint_S);
+                    } catch (...) {
+                        // Yes catching all is bad, but since this plotting
+                        // option is just for debugging, and this
+                        // projection is likely to fail as we get further
+                        // from the surface, we just dont plot it if we
+                        // don't have it.
+                        continue;
+                    }
+                    const Vec3 surfacePoint_G =
+                        X_GS.shiftFrameStationToBase(surfacePoint_S);
+                    decorations.push_back(
+                        DecorativeLine(trackingPoint_G, surfacePoint_G)
+                            .setColor(Orange)
+                            .setLineThickness(c_LineThickness));
+                }
+            }
+        }
+    }
+
+private:
+    //--------------------------------------------------------------------------
+    // Private accessors.
+    //--------------------------------------------------------------------------
+
+    // Get the subsystem this CableSpan is part of.
+    const CableSubsystem& getSubsystem() const
+    {
+        SimTK_ERRCHK_ALWAYS(
+            m_subsystem,
+            "CableSpan::Impl::getSubsystem()",
+            "CableSpan not yet adopted by any CableSubsystem");
+        return *m_subsystem;
+    }
+
+    void setSubsystem(CableSubsystem& subsystem, CableSpanIndex index)
+    {
+        m_subsystem = &subsystem;
+        m_index     = index;
+        for (CurveSegment& curve : m_curveSegments) {
+            curve.setSubsystem(subsystem);
+        }
+    }
+
+    CableSubsystem& updSubsystem()
+    {
+        SimTK_ERRCHK_ALWAYS(
+            m_subsystem,
+            "CableSpan::Impl::updSubsystem()",
+            "CableSpan not yet adopted by any CableSubsystem");
+        return *m_subsystem;
+    }
+
+    // Get the index of this CableSpan in the CableSubsystem.
+    CableSpanIndex getIndex() const
+    {
+        SimTK_ERRCHK1_ALWAYS(
+            m_index.isValid(),
+            "CableSpan::Impl::getIndex()",
+            "Index %d is not valid.",
+            m_index);
+        return m_index;
+    }
+
+    // Mutable CableSpanData::Instance cache access.
+    CableSpanData::Instance& updDataInst(const State& state) const
+    {
+        return Value<CableSpanData::Instance>::updDowncast(
+            getSubsystem().updCacheEntry(state, m_indexDataInst));
+    }
+
+    // Mutable CableSpanData::Position cache access.
+    CableSpanData::Position& updDataPos(const State& state) const
+    {
+        return Value<CableSpanData::Position>::updDowncast(
+            getSubsystem().updCacheEntry(state, m_indexDataPos));
+    }
+
+    // Mutable CableSpanData::Velocity cache access.
+    CableSpanData::Velocity& updDataVel(const State& state) const
+    {
+        return Value<CableSpanData::Velocity>::updDowncast(
+            getSubsystem().updCacheEntry(state, m_indexDataVel));
+    }
+
+    //------------------------------------------------------------------------------
+    //  Computing cached data
+    //------------------------------------------------------------------------------
+
+    const MatrixWorkspace& calcDataInst(const State& state) const;
+
+    const CableSpanData::Position& calcDataPos(const State& s) const
+    {
+        CableSpanData::Position& dataPos = updDataPos(s);
+
+        dataPos.originPoint_G      = calcOriginPointInGround(s);
+        dataPos.terminationPoint_G = calcTerminationPointInGround(s);
+
+        // Helper for computing the total cable length.
+        auto calcTotalCableLength =
+            [&](const std::vector<LineSegment>& lines) -> Real
+        {
+            Real totalCableLength = 0.;
+            // Add length of each line segment.
+            for (const LineSegment& line : lines) {
+                totalCableLength += line.length;
+            }
+            // Add length of each curve segment.
+            for (const CurveSegment& curve : m_curveSegments) {
+                if (curve.isInContactWithSurface(s)) {
+                    totalCableLength += curve.getDataInst(s).arcLength;
+                }
+            }
+            return totalCableLength;
+        };
+
+        // Computing the CableSpan's path is done iteratively by computing
+        // corrections for the CurveSegments until the pathErrorVector is small
+        // enough.
+        for (dataPos.loopIter = 0;
+             dataPos.loopIter < getParameters().solverMaxIterations;
+             ++dataPos.loopIter) {
+            // Compute all data required for updating the
+            // CableSpanData::Position cache.
+            const MatrixWorkspace& data = calcDataInst(s);
+
+            // Stop iterating if:
+            // 1. No obstacles in contact with path: Path is straight line.
+            const bool noneInContact = data.nObstaclesInContact == 0;
+            // 2. Converged: No significant correction.
+            const bool converged = data.pathCorrection.normInf() < Eps;
+            // 3. Not converged: Max iterations has been reached.
+            const bool maxIterationsReached =
+                dataPos.loopIter >= getParameters().solverMaxIterations - 1;
+            if (noneInContact || converged || maxIterationsReached) {
+                // Update cache entry and stop solver.
+                dataPos.smoothness  = data.maxPathError;
+                dataPos.cableLength = calcTotalCableLength(data.lineSegments);
+                dataPos.originTangent_G = data.lineSegments.front().direction;
+                dataPos.terminationTangent_G =
+                    data.lineSegments.back().direction;
+                break;
+            }
+
+            // Apply the corrections to each CurveSegment to reduce the path
+            // error.
+            int activeCurveIx = 0; // Index of curve in all that are in contact.
+            for (const CurveSegment& curve : m_curveSegments) {
+                if (curve.isInContactWithSurface(s)) {
+                    curve.applyGeodesicCorrection(
+                        s,
+                        data.getCurveCorrection(activeCurveIx));
+                    ++activeCurveIx;
+                }
+            }
+
+            // The applied corrections have changed the path: invalidate each
+            // segment's cache.
+            for (const CurveSegment& curve : m_curveSegments) {
+                // Also invalidate non-active segments: They might touchdown
+                // again.
+                curve.invalidatePosEntry(s);
+            }
+        }
+
+        return dataPos;
+    }
+
+    void calcDataVel(const State& s, CableSpanData::Velocity& dataVel) const
+    {
+        const CableSpanData::Position& dataPos = getDataPos(s);
+
+        auto CalcPointVelocityInGround = [&](const MobilizedBody& mobod,
+                                             const Vec3& point_G) -> Vec3
+        {
+            // Not using MobilizedBody::findStationVelocityInGround because the
+            // point is already in ground frame.
+
+            // Get body kinematics in ground frame.
+            const Vec3& x_BG = mobod.getBodyOriginLocation(s);
+            const Vec3& w_BG = mobod.getBodyAngularVelocity(s);
+            const Vec3& v_BG = mobod.getBodyOriginVelocity(s);
+
+            // Compute surface point velocity in ground frame.
+            return v_BG + w_BG % (point_G - x_BG);
+        };
+
+        // Compute the lengthening speed of the total cable.
+        // Consider a point at x_GQ moving with velocity v_GQ, and similarly a
+        // point x_GP moving with velocity v_GP. The line starting at x_GQ and
+        // ending at x_GP will have a lenghtening speed of:
+        // lengthDot = dot( UnitVec(x_GP - x_GQ), v_GP - v_GQ)
+        // The total cable lengthening speed is computed by summing the
+        // lengthening speed of all straight line segments (see Scholz2015).
+        Real& lengthDot = (dataVel.lengthDot = 0.);
+
+        // Starting point and velocity of straight line segment (the cable
+        // origin).
+        Vec3 x_GQ = dataPos.originPoint_G;
+        Vec3 v_GQ =
+            getOriginBody().findStationVelocityInGround(s, m_originStation);
+
+        for (const CurveSegment& curve : m_curveSegments) {
+            if (curve.isInContactWithSurface(s)) {
+                const MobilizedBody& mobod = curve.getMobilizedBody();
+                const CurveSegmentData::Position& curveDataPos =
+                    curve.getDataPos(s);
+
+                // Ending point and velocity of straight line segment.
+                const Vec3 x_GP = curveDataPos.X_GP.p();
+                const Vec3 v_GP =
+                    CalcPointVelocityInGround(mobod, curveDataPos.X_GP.p());
+
+                // Compute the lengthening.
+                lengthDot += dot(UnitVec3(x_GP - x_GQ), v_GP - v_GQ);
+
+                // Set the next straight line starting point and velocity.
+                x_GQ = curveDataPos.X_GQ.p();
+                v_GQ = CalcPointVelocityInGround(mobod, curveDataPos.X_GQ.p());
+            }
+        }
+
+        // Ending point and velocity of straight line segment (the cable
+        // termination).
+        const Vec3 v_GP = getTerminationBody().findStationVelocityInGround(
+            s,
+            m_terminationStation);
+        Vec3 x_GP = dataPos.terminationPoint_G;
+
+        // Compute lengthening.
+        lengthDot += dot(UnitVec3(x_GP - x_GQ), v_GP - v_GQ);
+    }
+
+    //------------------------------------------------------------------------------
+    // Data
+    //------------------------------------------------------------------------------
+
+    // Reference back to the subsystem.
+    CableSubsystem* m_subsystem = nullptr;
+    CableSpanIndex m_index      = CableSpanIndex::Invalid();
+
+    // TOPOLOGY CACHE (set during realizeTopology())
+    CacheEntryIndex m_indexDataInst = CacheEntryIndex::Invalid();
+    CacheEntryIndex m_indexDataPos  = CacheEntryIndex::Invalid();
+    CacheEntryIndex m_indexDataVel  = CacheEntryIndex::Invalid();
+
+    // Path origin attachment point (a body and a station on the body).
+    MobilizedBodyIndex m_originBody = MobilizedBodyIndex::Invalid();
+    Vec3 m_originStation{NaN};
+
+    // Path termination attachment point (a body and a station on the body).
+    MobilizedBodyIndex m_terminationBody = MobilizedBodyIndex::Invalid();
+    Vec3 m_terminationStation{NaN};
+
+    // Path CurveSegments over the obstacles.
+    Array_<CurveSegment, ObstacleIndex> m_curveSegments;
+
+    // All configuration parameters.
+    CableSpanParameters m_parameters{};
+
+    friend CableSpan;
+    friend CableSubsystem;
+    friend CableSubsystemTestHelper;
+};
+
+//==============================================================================
+//          CurveSegment Utility Functions Using CableSpan Handle
+//==============================================================================
+// These helper functions are defined here as they depend on the declarations
+// in CableSpan::Impl.
+
+const IntegratorTolerances& CurveSegment::getIntegratorTolerances() const
+{
+    return getCable().getParameters();
+}
+
+ObstacleIndex CurveSegment::findPrevObstacleInContactWithCable(
+    const State& state) const
+{
+    const CableSpan::Impl& cable = getCable();
+    // Find the first obstacle that makes contact before this CurveSegment.
+    for (ObstacleIndex ix(m_obstacleIndex); ix > 0; --ix) {
+        ObstacleIndex prevIx(ix - 1);
+        if (cable.getObstacleCurveSegment(prevIx).isInContactWithSurface(
+                state)) {
+            return prevIx;
+        }
+    }
+    // No obstacles in contact before this segment.
+    return ObstacleIndex::Invalid();
+}
+
+ObstacleIndex CurveSegment::findNextObstacleInContactWithCable(
+    const State& state) const
+{
+    const CableSpan::Impl& cable = getCable();
+    // Find the first obstacle that makes contact after this CurveSegment.
+    for (ObstacleIndex ix(m_obstacleIndex + 1); ix < cable.getNumObstacles();
+         ++ix) {
+        if (cable.getObstacleCurveSegment(ix).isInContactWithSurface(state)) {
+            return ix;
+        }
+    }
+    // No obstacles in contact after this segment.
+    return ObstacleIndex::Invalid();
+}
+
+Vec3 CurveSegment::findPrevPathPoint_G(const State& state) const
+{
+    // Check if there is a curve segment preceding given obstacle.
+    const ObstacleIndex prevObstacle =
+        findPrevObstacleInContactWithCable(state);
+    if (prevObstacle.isValid()) {
+        // The previous point is the final contact point of the previous curve.
+        return getCable()
+            .getObstacleCurveSegment(prevObstacle)
+            .calcFinalContactPoint_G(state);
+    }
+    // There are no curve segments before given obstacle: the previous point
+    // is the path's origin point.
+    const CableSpan::Impl& cable = getCable();
+    return getCable()
+        .getOriginBody()
+        .getBodyTransform(state)
+        .shiftFrameStationToBase(cable.getOriginStation());
+}
+
+Vec3 CurveSegment::findNextPathPoint_G(const State& state) const
+{
+    // Check if there is a curve segment after given obstacle.
+    const ObstacleIndex nextObstacle =
+        findNextObstacleInContactWithCable(state);
+    if (nextObstacle.isValid()) {
+        // The next point is the initial contact point of the next curve.
+        return getCable()
+            .getObstacleCurveSegment(nextObstacle)
+            .calcInitialContactPoint_G(state);
+    };
+    // There are no curve segments following given obstacle: the next point
+    // is the path's termination point.
+    const CableSpan::Impl& cable = getCable();
+    return cable.getTerminationBody()
+        .getBodyTransform(state)
+        .shiftFrameStationToBase(cable.getTerminationStation());
+}
+
+//==============================================================================
+//                      CABLE FORCE COMPUTATIONS
+//==============================================================================
+// This section contains all force related computations.
+namespace
+{
+
+/* Computes the unit force exerted by a CurveSegment on the obstacle body
+represented in ground frame. The force can then be obtained by multiplication
+with the cable tension. */
+void calcUnitForceExertedByCurve(
+    const CurveSegment& curve,
+    const State& s,
+    SpatialVec& unitForce_G)
+{
+    const CurveSegmentData::Position& dataPos = curve.getDataPos(s);
+    const Vec3& x_GB = curve.getMobilizedBody().getBodyOriginLocation(s);
+
+    // Contact point moment arms in ground.
+    const Vec3 r_P = dataPos.X_GP.p() - x_GB;
+    const Vec3 r_Q = dataPos.X_GQ.p() - x_GB;
+
+    // Tangent directions at contact points in ground.
+    const UnitVec3& t_P = getTangent(dataPos.X_GP);
+    const UnitVec3& t_Q = getTangent(dataPos.X_GQ);
+
+    // The tangent at the first contact point is along the negative force
+    // direction, while at the last contact point the tangent is along the
+    // force direction:
+    unitForce_G[0] = r_Q % t_Q - r_P % t_P;
+    unitForce_G[1] = t_Q - t_P;
+}
+
+/* Computes the unit force exerted by the cable at the cable origin, on the
+origin body, represented in ground frame. The force can then be obtained by
+multiplication with the cable tenson. */
+void calcUnitForceAtCableOrigin(
+    const CableSpan::Impl& cable,
+    const State& s,
+    SpatialVec& unitForce_G)
+{
+    const CableSpanData::Position& dataPos = cable.getDataPos(s);
+
+    // Origin contact point moment arm in ground.
+    const Vec3 arm_G =
+        dataPos.originPoint_G - cable.getOriginBody().getBodyOriginLocation(s);
+
+    // The tangent at the cable origin is along the force direction:
+    unitForce_G[0] = arm_G % dataPos.originTangent_G;
+    unitForce_G[1] = Vec3(dataPos.originTangent_G);
+}
+
+/* Computes the unit force exerted by the cable at the cable termination, on the
+termination body, represented in ground frame. The force can then be obtained by
+multiplication with the cable tenson. */
+void calcUnitForceAtCableTermination(
+    const CableSpan::Impl& cable,
+    const State& s,
+    SpatialVec& unitForce_G)
+{
+    const CableSpanData::Position& dataPos = cable.getDataPos(s);
+
+    const Vec3 arm_G = dataPos.terminationPoint_G -
+                       cable.getTerminationBody().getBodyOriginLocation(s);
+
+    // The tangent at the cable termination is along the negative force
+    // direction:
+    unitForce_G[0] = -arm_G % dataPos.terminationTangent_G;
+    unitForce_G[1] = -Vec3(dataPos.terminationTangent_G);
+}
+
+} // namespace
+
+void CableSpan::Impl::applyBodyForces(
+    const State& s,
+    Real tension,
+    Vector_<SpatialVec>& bodyForcesInG) const
+{
+    realizePosition(s);
+
+    if (tension < 0.) {
+        return;
+    }
+
+    SpatialVec unitForce_G;
+
+    // Force applied at cable origin point.
+    {
+        calcUnitForceAtCableOrigin(*this, s, unitForce_G);
+        getOriginBody().applyBodyForce(s, unitForce_G * tension, bodyForcesInG);
+    }
+
+    // Forces applied to each obstacle body.
+    for (const CurveSegment& curve : m_curveSegments) {
+        if (!curve.isInContactWithSurface(s)) {
+            continue;
+        }
+
+        calcUnitForceExertedByCurve(curve, s, unitForce_G);
+        curve.getMobilizedBody().applyBodyForce(
+            s,
+            unitForce_G * tension,
+            bodyForcesInG);
+    }
+
+    // Force applied at cable termination point.
+    {
+        calcUnitForceAtCableTermination(*this, s, unitForce_G);
+        getTerminationBody().applyBodyForce(
+            s,
+            unitForce_G * tension,
+            bodyForcesInG);
+    }
+}
+
+Real CableSpan::Impl::calcCablePower(const State& state, Real tension) const
+{
+    realizePosition(state);
+
+    if (tension < 0.) {
+        return 0.;
+    }
+
+    SpatialVec unitForce_G;
+
+    Real unitPower = 0.;
+
+    {
+        calcUnitForceAtCableOrigin(*this, state, unitForce_G);
+        SpatialVec v = getOriginBody().getBodyVelocity(state);
+        unitPower += ~unitForce_G * v;
+    }
+
+    for (const CurveSegment& curve : m_curveSegments) {
+        if (!curve.isInContactWithSurface(state)) {
+            continue;
+        }
+
+        calcUnitForceExertedByCurve(curve, state, unitForce_G);
+        SpatialVec v = curve.getMobilizedBody().getBodyVelocity(state);
+        unitPower += ~unitForce_G * v;
+    }
+
+    {
+        calcUnitForceAtCableTermination(*this, state, unitForce_G);
+        SpatialVec v = getTerminationBody().getBodyVelocity(state);
+        unitPower += ~unitForce_G * v;
+    }
+
+    return unitPower * tension;
+}
+
+//==============================================================================
+//                             Path Error Vector and Jacobian
+//==============================================================================
+/* This section contains helper functions for computing the path error vector
+and it's Jacobian to the natural geodesic corrections.
+
+For derivations and background we will refer to the relevant parts in the
+original paper: "A fast multi-obstacle muscle wrapping method using natural
+geodesic variations" by Andreas Scholz et al (Scholz2015). */
+namespace
+{
+
+/* Compute the straight line segments in between the obstacles.
+
+Denoted by "e^i" and "e^{i+1} in Scholz2015 Fig 1. */
+void calcLineSegments(
+    const CableSpan::Impl& cable,
+    const State& s,
+    const Vec3& pathOriginPoint,
+    const Vec3& pathTerminationPoint,
+    std::vector<LineSegment>& lines)
+{
+    lines.clear();
+    Vec3 prevPathPoint(pathOriginPoint);
+
+    for (CableSpanObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
+        const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
+        if (!curve.isInContactWithSurface(s)) {
+            continue;
+        }
+        const CurveSegmentData::Position& dataPos = curve.getDataPos(s);
+
+        // Compute the line segment from the previous point to the
+        // first curve contact point.
+        lines.emplace_back(prevPathPoint, dataPos.X_GP.p());
+
+        // The next line segment will start at the curve's final contact
+        // point.
+        prevPathPoint = dataPos.X_GQ.p();
+    }
+
+    // Compute the last line segment.
+    lines.emplace_back(prevPathPoint, pathTerminationPoint);
+}
+
+/* Helper for computing a single element of the path error vector.
+The algorithm for finding the correct path will attempt to drive this path
+error to zero.
+
+These are the elements in equation 14 in Scholz2015. */
+Real calcPathErrorElement(
+    const LineSegment& e,
+    const FrenetFrame& X,
+    CoordinateAxis axis)
+{
+    return dot(e.direction, X.R().getAxisUnitVec(axis));
+}
+
+/* Compute the path error for each curve segment at the boundary frames, and
+stack them in a vector.
+
+If axes = {NormalAxis, BinormalAxis} this gives equation 14 in Scholz2015 */
+template <size_t N>
+void calcPathErrorVector(
+    const CableSpan::Impl& cable,
+    const State& s,
+    const std::vector<LineSegment>& lines,
+    std::array<CoordinateAxis, N> axes,
+    Vector& pathError)
+{
+    // Reset path error vector to zero.
+    pathError.setToZero();
+
+    // The element in the path error vector to write to.
+    int pathErrorIx = -1;
+    // Index to a straight line segment.
+    int lineIx = 0;
+
+    for (CableSpanObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
+        // Path errors are only computed for obstacles that make contact.
+        const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
+        if (!curve.isInContactWithSurface(s)) {
+            continue;
+        }
+        const CurveSegmentData::Position& dataPos = curve.getDataPos(s);
+        // Compute path error at first contact point.
+        for (CoordinateAxis axis : axes) {
+            pathError(++pathErrorIx) =
+                calcPathErrorElement(lines.at(lineIx), dataPos.X_GP.R(), axis);
+        }
+        ++lineIx;
+        // Compute path error at final contact point.
+        for (CoordinateAxis axis : axes) {
+            pathError(++pathErrorIx) =
+                calcPathErrorElement(lines.at(lineIx), dataPos.X_GQ.R(), axis);
+        }
+    }
+}
+
+} // namespace
+
+//==============================================================================
+//                             Path Error Jacobian
+//==============================================================================
+namespace
+{
+
+/* Given the path error related to the final contact point of the previous
+CurveSegment, compute the Jacobian to the NaturalGeodesicCorrections of the
+current CurveSegment.
+
+See Scholz2015 equation 56: if axis = NormalAxis this computes the third row,
+if axis = BinormalAxis this computes the fourth row. */
+Vec4 calcJacobianOfPrevPathError(
+    const CurveSegment& curve,
+    const State& state,
+    const LineSegment& line,
+    const UnitVec3& axis)
+{
+    const Transform& X_GP = curve.getDataPos(state).X_GP;
+
+    Vec3 dErrDx = axis - line.direction * dot(line.direction, axis);
+    dErrDx      = X_GP.RInv() * (dErrDx / line.length);
+
+    return {dErrDx[0], dErrDx[2], 0., 0.};
+}
+
+/* Given the path error related to the initial contact point of the next
+CurveSegment, compute the Jacobian to the NaturalGeodesicCorrections of the
+current CurveSegment.
+
+See Scholz2015 equation 55: if axis = NormalAxis this computes the first row,
+if axis = BinormalAxis this computes the second row. */
+Vec4 calcJacobianOfNextPathError(
+    const CurveSegment& curve,
+    const State& s,
+    const LineSegment& line,
+    const UnitVec3& axis)
+{
+    const Transform& X_GQ = curve.getDataPos(s).X_GQ;
+
+    const CurveSegmentData::Instance& dataInst = curve.getDataInst(s);
+    const Real a                               = dataInst.jacobi_Q[0];
+    const Real r                               = dataInst.jacobi_Q[1];
+
+    // Partial derivative of path error to contact point position (x_QS),
+    // represented in the Frenet frame.
+    Vec3 dErrDx = axis - line.direction * dot(line.direction, axis);
+    dErrDx      = X_GQ.RInv() * (-dErrDx / line.length);
+
+    return {dErrDx[0], dErrDx[2] * a, dErrDx[2] * r, dErrDx[0]};
+}
+
+/* Given the path error related to the initial contact point of a CurveSegment
+compute the Jacobian to the NaturalGeodesicCorrections.
+
+See Scholz2015 equation 54: if axis = NormalAxis this computes the first row,
+if axis = BinormalAxis this computes the second row. */
+Vec4 calcJacobianOfPathErrorAtP(
+    const CurveSegment& curve,
+    const State& s,
+    const LineSegment& line,
+    const UnitVec3& axis)
+{
+    const Transform& X_GP = curve.getDataPos(s).X_GP;
+
+    const CurveSegmentData::Instance& dataInst = curve.getDataInst(s);
+
+    const Real tau = dataInst.torsion_P;
+    const Real kt  = dataInst.curvatures_P[0];
+    const Real kb  = dataInst.curvatures_P[1];
+
+    const Vec3 y = X_GP.RInv() * cross(axis, line.direction);
+
+    const Real v0 = dot(y, Vec3{tau, 0., kt});
+    const Real v1 = dot(y, Vec3{-kb, 0., -tau});
+    const Real v2 = -y[1];
+
+    return Vec4{v0, v1, v2, 0.} +
+           calcJacobianOfPrevPathError(curve, s, line, axis);
+}
+
+/* Given the path error related to the final contact point of a CurveSegment
+compute the Jacobian to the NaturalGeodesicCorrections.
+
+See Scholz2015 equation 54: if axis = NormalAxis this computes the third row,
+if axis = BinormalAxis this computes the fourth row. */
+Vec4 calcJacobianOfPathErrorAtQ(
+    const CurveSegment& curve,
+    const State& s,
+    const LineSegment& line,
+    const UnitVec3& axis)
+{
+    const Transform& X_GQ = curve.getDataPos(s).X_GQ;
+
+    const CurveSegmentData::Instance& dataInst = curve.getDataInst(s);
+
+    const Real tau = dataInst.torsion_Q;
+    const Real kt  = dataInst.curvatures_Q[0];
+    const Real kb  = dataInst.curvatures_Q[1];
+
+    const Real a = dataInst.jacobi_Q[0];
+    const Real r = dataInst.jacobi_Q[1];
+
+    const Real aDot = dataInst.jacobiDot_Q[0];
+    const Real rDot = dataInst.jacobiDot_Q[1];
+
+    const Vec3 y = X_GQ.RInv() * cross(axis, line.direction);
+
+    const Real v0 = dot(y, Vec3{tau, 0., kt});
+    const Real v1 = dot(y, Vec3{-a * kb, -aDot, -a * tau});
+    const Real v2 = dot(y, Vec3{-r * kb, -rDot, -r * tau});
+    const Real v3 = dot(y, Vec3{tau, 0., kt});
+
+    return Vec4{v0, v1, v2, v3} +
+           calcJacobianOfNextPathError(curve, s, line, axis);
+}
+
+/* Computes the Jacobian of the path error vector to the
+NaturalGeodesicCorrections of all CurveSegments.
+
+When axes = {Normal, Binormal}, this equals equation 53 in Scholz2015. */
+template <size_t N>
+void calcPathErrorJacobian(
+    const CableSpan::Impl& cable,
+    const State& s,
+    const std::vector<LineSegment>& lines,
+    std::array<CoordinateAxis, N> axes,
+    Matrix& J)
+{
+    // Number of free coordinates for a generic geodesic.
+    constexpr int NQ = c_GeodesicDOF;
+
+    // Reset the values in the Jacobian.
+    J.setToZero();
+
+    // Sanity check on the matrix dimensions.
+    const int numberOfCurvesInContact = static_cast<int>(lines.size()) - 1;
+    SimTK_ASSERT3(
+        J.ncol() == numberOfCurvesInContact * NQ &&
+            J.nrow() ==
+                numberOfCurvesInContact * MatrixWorkspace::c_NumConstraints,
+        "Jacobian matrix size (%d x %d) does not match number of curves (%d)",
+        J.nrow(),
+        J.ncol(),
+        numberOfCurvesInContact);
+
+    // Current indexes to write the elements of the Jacobian to,
+    int row = 0;
+    int col = 0;
+
+    // Helper for adding a computed block to the Jacobian.
+    auto AddBlock = [&](const Vec4& block, int colOffset = 0)
+    {
+        for (int ix = 0; ix < 4; ++ix) {
+            J(row, col + colOffset + ix) += block[ix];
+        }
+    };
+
+    // Index to a straight line segment.
+    int lineIx = 0;
+    for (ObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
+        const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
+        if (!curve.isInContactWithSurface(s)) {
+            continue;
+        }
+        const CurveSegmentData::Position& dataPos = curve.getDataPos(s);
+
+        // Compute the Jacobian elements of the path error related to the
+        // initial contact point.
+        for (CoordinateAxis axis : axes) {
+            // The path error of which to take the Jacobian is: dot(a_P, l_P)
+            const UnitVec3 a_P     = dataPos.X_GP.R().getAxisUnitVec(axis);
+            const LineSegment& l_P = lines.at(lineIx);
+
+            // Write to the block diagonal of J the Jacobian of the path error
+            // to the CurveSegment's NaturalGeodesicCorrection.
+            AddBlock(calcJacobianOfPathErrorAtP(curve, s, l_P, a_P));
+
+            // Write to the off-diagonal of J the Jacobian of the path
+            // error to the previous CurveSegment's NaturalGeodesicCorrection.
+            const ObstacleIndex prevObsIx =
+                curve.findPrevObstacleInContactWithCable(s);
+            if (prevObsIx.isValid()) {
+                constexpr int colShift = -NQ; // the off-diagonal block.
+                AddBlock(
+                    calcJacobianOfNextPathError(
+                        cable.getObstacleCurveSegment(prevObsIx),
+                        s,
+                        l_P,
+                        a_P),
+                    colShift);
+            }
+            // Increment to the next path error element.
+            ++row;
+        }
+
+        // Compute the Jacobian elements of the path error related to the final
+        // contact point.
+        ++lineIx; // Increment to the next straight line segment.
+        for (CoordinateAxis axis : axes) {
+            // The path error of which to take the Jacobian is: dot(a_Q, l_Q)
+            const UnitVec3 a_Q     = dataPos.X_GQ.R().getAxisUnitVec(axis);
+            const LineSegment& l_Q = lines.at(lineIx);
+
+            // Write to the block diagonal of J the Jacobian of the path error
+            // to the CurveSegment's NaturalGeodesicCorrection.
+            AddBlock(calcJacobianOfPathErrorAtQ(curve, s, l_Q, a_Q));
+
+            // Write to the off-diagonal of J the Jacobian of the path
+            // error to the next CurveSegment's NaturalGeodesicCorrection.
+            const ObstacleIndex nextObsIx =
+                curve.findNextObstacleInContactWithCable(s);
+            if (nextObsIx.isValid()) {
+                constexpr int colShift = NQ; // the off-diagonal block.
+                AddBlock(
+                    calcJacobianOfPrevPathError(
+                        cable.getObstacleCurveSegment(nextObsIx),
+                        s,
+                        l_Q,
+                        a_Q),
+                    colShift);
+            }
+            // Increment to the next path error element.
+            ++row;
+        }
+
+        col += NQ;
+    }
+}
+
+} // namespace
+
+//==============================================================================
+//                      Solving for NaturalGeodesicCorrections
+//==============================================================================
+
+namespace
+{
+
+// Solve for the geodesic corrections by attempting to set the path error to
+// zero. We call this after having filled in the pathError vector and pathError
+// Jacobian in the MatrixWorkspace. The result is a vector of Corrections for
+// each curve.
+void calcPathCorrections(MatrixWorkspace& data)
+{
+    // The last elements of the path error vector contain the change in length
+    // of each curve segment, and require it to remain zero. The change in
+    // length is the last element of the NaturalGeodesicCorrection vector. The
+    // Jacobian is therefore zero everywhere, except for one (=1) at the element
+    // of the third NaturalGeodesicCorrection of the corresponding curve
+    // segment. Finally we write a weight instead of a one to obtain a weighted
+    // least squares. As the weight we take the current maximum path error. This
+    // will heavily penalize changing the length when we are far from the
+    // optimal solution, and ramp up convergence as we get closer.
+    for (int i = 0; i < data.nObstaclesInContact; ++i) {
+        // Determine the row and column of the nonzero element in the Jacobian.
+        int r = data.nObstaclesInContact *
+                    MatrixWorkspace::c_NumPathErrorConstraints + i;
+        int c = c_GeodesicDOF * (i + 1) - 1;
+        // Write the weight that will penalize changing the curve length.
+        data.pathErrorJacobian.set(r, c, data.maxPathError);
+    }
+
+    data.factor = data.pathErrorJacobian;
+    data.factor.solve(data.pathError, data.pathCorrection);
+    data.pathCorrection *= -1.;
+}
+
+// Given a correction vector computed from minimizing the cost function,
+// compute the maximum allowed stepsize along that correction vector.
+// The allowed step is computed by approximating the surface locally as
+// a circle in each direction, and limiting the radial displacement on that
+// circle.
+void calcMaxAllowedCorrectionStepSize(
+    const CurveSegment& curve,
+    const State& s,
+    const NaturalGeodesicCorrection& c,
+    Real maxAngularStepsize,
+    Real& maxAllowedStepSize)
+{
+    // Helper to update the maximum allowed stepsize such that the linear
+    // displacement does not violate the max allowed step size.
+    auto UpdateMaxStepSize = [&](Real maxDisplacementEstimate, Real curvature)
+    {
+        // Use the local curvature to convert the allowed angular step size to
+        // a linear step size.
+        const Real maxAllowedDisplacement = maxAngularStepsize / curvature;
+        const Real allowedStepSize =
+            std::abs(maxAllowedDisplacement / maxDisplacementEstimate);
+        maxAllowedStepSize = std::min(maxAllowedStepSize, allowedStepSize);
+    };
+
+    const CurveSegmentData::Instance& dataInst = curve.getDataInst(s);
+
+    // Clamp tangential displacement at the initial contact point.
+    {
+        const Real dxEst = c[0];
+        const Real k     = dataInst.curvatures_P[0];
+        UpdateMaxStepSize(dxEst, k);
+    }
+
+    // Clamp binormal displacement at the initial contact point.
+    {
+        const Real dxEst = c[1];
+        const Real k     = dataInst.curvatures_P[1];
+        UpdateMaxStepSize(dxEst, k);
+    }
+
+    // Clamp tangential displacement at the final contact point.
+    {
+        const Real dxEst = std::abs(c[0]) + std::abs(c[3]);
+        const Real k     = dataInst.curvatures_Q[0];
+        UpdateMaxStepSize(dxEst, k);
+    }
+
+    // Clamp binormal displacement at the final contact point.
+    {
+        const Real a     = dataInst.jacobi_Q[0];
+        const Real r     = dataInst.jacobi_Q[1];
+        const Real dxEst = std::abs(c[1] * a) + std::abs(c[2] * r);
+        const Real k     = dataInst.curvatures_Q[1];
+        UpdateMaxStepSize(dxEst, k);
+    }
+}
+
+} // namespace
+
+//------------------------------------------------------------------------------
+//                      CableSpan::Impl Cache Computation
+//------------------------------------------------------------------------------
+
+const MatrixWorkspace& CableSpan::Impl::calcDataInst(const State& s) const
+{
+    CableSpanData::Instance& dataInst = updDataInst(s);
+
+    // Axes considered when computing the path error.
+    const std::array<CoordinateAxis, 2> axes{NormalAxis, BinormalAxis};
+
+    // Make sure all curve segments are realized to position stage.
+    // This will transform all last computed geodesics to Ground frame, and
+    // will update each curve's WrappingStatus.
+    for (ObstacleIndex ix(0); ix < getNumObstacles(); ++ix) {
+        getObstacleCurveSegment(ix).calcDataPos(s);
+    }
+
+    // Now that the WrappingStatus of all curve segments is known: Count
+    // the number of obstacles in contact with the path.
+    const int nActive = countActive(s);
+
+    // If some obstacles are in contact with the cable the path error needs
+    // to be checked. If the path error is small, i.e. there are no "kinks"
+    // anywhere, the current path is OK. If the path error is too large,
+    // corrections need to be computed for each curve segment in order to
+    // drive the path error to zero.
+
+    // Grab the shared data cache for helping with computing the path
+    // corrections. This data is only used as an intermediate variable, and
+    // will be discarded after each iteration. Note that the number active
+    // segments determines the sizes of the matrices involved.
+    MatrixWorkspace& data = updDataInst(s).updOrInsert(nActive);
+
+    // Reset before computing new values.
+    data.maxPathError = 0.;
+
+    // Compute the straight-line segments of this cable span.
+    calcLineSegments(
+        *this,
+        s,
+        calcOriginPointInGround(s),
+        calcTerminationPointInGround(s),
+        data.lineSegments);
+
+    // If the path contains no curved segments it is a straight line.
+    if (nActive == 0) {
+        return data;
+    }
+
+    // Evaluate the current path error as the misalignment of the straight
+    // line segments with the curve segment's tangent vectors at the
+    // contact points.
+    calcPathErrorVector<2>(*this, s, data.lineSegments, axes, data.pathError);
+    data.maxPathError = data.pathError.normInf();
+
+    // Only proceed with computing the Jacobian and geodesic corrections if the
+    // path error is large.
+    if (data.maxPathError < getParameters().smoothnessTolerance) {
+        data.pathCorrection *= 0.;
+        return data;
+    }
+
+    // Evaluate the path error Jacobian to the natural geodesic corrections
+    // of each curve segment.
+    calcPathErrorJacobian<2>(
+        *this,
+        s,
+        data.lineSegments,
+        axes,
+        data.pathErrorJacobian);
+
+    // Compute the geodesic corrections for each curve segment: This gives
+    // us a correction vector in a direction that reduces the path error.
+    calcPathCorrections(data);
+
+    // Compute the maximum allowed step size that we take along the
+    // correction vector.
+    Real stepSize     = 1.;
+    int activeCurveIx = 0; // Index of curve in all that are in contact.
+    for (const CurveSegment& curve : m_curveSegments) {
+        if (curve.isInContactWithSurface(s)) {
+            // Each curve segment will evaluate if the stepsize is not too large
+            // given the local curvature.
+            calcMaxAllowedCorrectionStepSize(
+                curve,
+                s,
+                data.getCurveCorrection(activeCurveIx),
+                getParameters().solverMaxStepSize,
+                stepSize);
+            ++activeCurveIx;
+        }
+    }
+    // Apply the maximum stepsize to the corrections.
+    data.pathCorrection *= stepSize;
+
+    return data;
+}
+
+//==============================================================================
+//                         CableSubsystemTestHelper
+//==============================================================================
+// Test correctness of the path error Jacobian by applying a small perturbation
+// and comparing the effect on the path error. The perturbation is applied in
+// the form of a small geodesic correction along each degree of freedom
+// subsequently.
+// Only curve segments that are in contact with their respective obstacles are
+// tested.
+void CableSubsystemTestHelper::Impl::runPerturbationTest(
+    const State& state,
+    const CableSubsystem& subsystem,
+    std::ostream& testReport) const
+{
+    // Result of this perturbation test.
+    bool success = true;
+
+    // Helper lambda for comparing two vectors of ObstacleWrappingStatus.
+    auto isEqual = [](const std::vector<ObstacleWrappingStatus>& a,
+                      const std::vector<ObstacleWrappingStatus>& b) -> bool
+    {
+        bool out = a.size() == b.size();
+        for (size_t i = 0; i < a.size(); ++i) {
+            out = out && a.at(i) == b.at(i);
+        }
+        return out;
+    };
+
+    // Helper lambda returning true if any active curve segment has zero length.
+    auto anyCurveSegmentHasZeroLength =
+        [&](const State& s, const CableSpan::Impl& cable) -> bool
+    {
+        for (ObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
+            const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
+            if (!curve.isInContactWithSurface(s)) {
+                continue;
+            }
+            if (std::abs(curve.getDataInst(s).arcLength) < Eps) {
+                return true;
+            }
+        }
+        return false;
+    };
+
+    for (CableSpanIndex cableIx(0); cableIx < subsystem.getNumCables();
+         ++cableIx) {
+        testReport << "START Jacobian Perturbation Test of Cable " << cableIx
+                   << "\n";
+        const CableSpan::Impl& cable = subsystem.getCable(cableIx).getImpl();
+
+        // Sanity checks on the config parameters:
+
+        // The Jacobian should predict effect on the path error vector up to 1
+        // percent, at least.
+        SimTK_ERRCHK1_ALWAYS(
+            m_perturbationTestParameters.tolerance <= 1.,
+            "CableSubsystemTestHelper::Impl::runPerturbationTest",
+            "Perturbation test tolerance (=%e) should be less or equal to 1",
+            m_perturbationTestParameters.tolerance);
+        // Assertions below are ball park estimates, but what we want to avoid
+        // is testing a very small perturbation on a very inaccurate curve
+        // segment. That won't work.
+        SimTK_ERRCHK2_ALWAYS(
+            cable.getParameters().geodesicIntegratorAccuracy <
+                m_perturbationTestParameters.perturbation * 1e-3,
+            "CableSubsystemTestHelper::Impl::runPerturbationTest",
+            "Curve segment accuracy (=%e) should be smaller than the applied perturbation (=%e) times 1e-3",
+            cable.getParameters().geodesicIntegratorAccuracy,
+            m_perturbationTestParameters.perturbation);
+        SimTK_ERRCHK2_ALWAYS(
+            m_perturbationTestParameters.perturbation <=
+                m_perturbationTestParameters.tolerance * 1e-4,
+            "CableSubsystemTestHelper::Impl::runPerturbationTest",
+            "Applied perturbation (=%e) should be less or equal to the assertion tolerance (=%e) times 1e-4.",
+            m_perturbationTestParameters.perturbation,
+            m_perturbationTestParameters.tolerance);
+
+        // Axes considered when computing the path error.
+        const std::array<CoordinateAxis, 2> axes{NormalAxis, BinormalAxis};
+
+        // Count the number of active curve segments.
+        const int nActive = cable.countActive(state);
+
+        if (nActive == 0) {
+            testReport << "Cable has no active segments:";
+            testReport << "Skipping perturbation test\n";
+            continue;
+        }
+
+        if (anyCurveSegmentHasZeroLength(state, cable)) {
+            testReport << "Cable has zero-length curve segments:";
+            testReport << "Skipping perturbation test\n";
+            continue;
+        }
+
+        // Apply a small perturbation to each of the curve segments in the form
+        // of a geodesic correction. There are 4 DOF for each geodesic, and
+        // just to be sure we apply a negative and positive perturbation along
+        // each DOF of each geodesic.
+        Real perturbation = m_perturbationTestParameters.perturbation;
+        for (int i = 0; i < c_GeodesicDOF * 2 * nActive + 1; ++i) {
+            // We do not want to mess with the actual state, so we make a copy.
+            const State sCopy = state;
+            subsystem.getMultibodySystem().realize(sCopy, Stage::Position);
+
+            // Trigger realizing position level cache, resetting the
+            // configuration.
+            const CableSpanData::Position& dataPos = cable.getDataPos(sCopy);
+
+            // The wrapping status of each obstacle is reset after copying the
+            // state. The matrix sizes are no longer compatible if this results
+            // in a change in wrapping status (if we are touching down during
+            // this realization for example). We can only test the Jacobian if
+            // the wrapping status of all obstacles remains the same.
+            if (cable.countActive(sCopy) != nActive) {
+                testReport
+                    << "Cable wrapping status changed after cloning the state: "
+                       "Skipping perturbation test\n";
+                break;
+            }
+
+            // Compute the path error vector and Jacobian, before the applied
+            // perturbation.
+
+            MatrixWorkspace& data =
+                cable.updDataInst(sCopy).updOrInsert(nActive);
+
+            calcLineSegments(
+                cable,
+                sCopy,
+                dataPos.originPoint_G,
+                dataPos.terminationPoint_G,
+                data.lineSegments);
+
+            calcPathErrorVector<2>(
+                cable,
+                sCopy,
+                data.lineSegments,
+                axes,
+                data.pathError);
+
+            calcPathErrorJacobian<2>(
+                cable,
+                sCopy,
+                data.lineSegments,
+                axes,
+                data.pathErrorJacobian);
+
+            // Define the perturbation we will use for testing the Jacobian.
+            data.pathCorrection.setTo(0.);
+            if (i != 0) {
+                perturbation *= -1.;
+                data.pathCorrection.set((i - 1) / 2, perturbation);
+            }
+
+            // Use the Jacobian to predict the perturbed path error vector.
+            Vector predictedPathError =
+                data.pathErrorJacobian * data.pathCorrection + data.pathError;
+
+            // Store the wrapping status before applying the perturbation.
+            std::vector<ObstacleWrappingStatus> prevWrappingStatus;
+            for (const CurveSegment& curve : cable.m_curveSegments) {
+                prevWrappingStatus.push_back(
+                    curve.getDataInst(sCopy).wrappingStatus);
+            }
+
+            // Apply the perturbation.
+            int activeCurveIx = 0; // Index of curve in all that are in contact.
+            for (ObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
+                const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
+                if (curve.isInContactWithSurface(sCopy)) {
+                    curve.applyGeodesicCorrection(
+                        sCopy,
+                        data.getCurveCorrection(activeCurveIx));
+                    ++activeCurveIx;
+                }
+            }
+
+            for (const CurveSegment& curve : cable.m_curveSegments) {
+                curve.invalidatePosEntry(sCopy);
+            }
+
+            for (ObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
+                cable.getObstacleCurveSegment(ix).calcDataPos(sCopy);
+            }
+
+            // Compute the path error vector after having applied the
+            // perturbation.
+            calcLineSegments(
+                cable,
+                sCopy,
+                dataPos.originPoint_G,
+                dataPos.terminationPoint_G,
+                data.lineSegments);
+            calcPathErrorVector<2>(
+                cable,
+                sCopy,
+                data.lineSegments,
+                axes,
+                data.pathError);
+
+            // The curve lengths are clipped at zero, which distorts the
+            // perturbation test. We simply skip these edge cases.
+            if (anyCurveSegmentHasZeroLength(sCopy, cable)) {
+                testReport << "Cable has zero-length curve segments after "
+                              "perturbation:";
+                testReport << "Skipping perturbation test\n";
+                continue;
+            }
+
+            // We can only use the path error Jacobian if the small
+            // perturbation did not trigger any liftoff or touchdown on any
+            // obstacles. If any CurveSegment's WrappingStatus has changed, we
+            // will not continue with the test. Since the perturbation is
+            // small, this is unlikely to happen often.
+            std::vector<ObstacleWrappingStatus> nextWrappingStatus;
+            for (const CurveSegment& curve : cable.m_curveSegments) {
+                nextWrappingStatus.push_back(
+                    curve.getDataInst(sCopy).wrappingStatus);
+            }
+            if (!isEqual(prevWrappingStatus, nextWrappingStatus)) {
+                testReport << "Wrapping status changed: Stopping test\n";
+                break;
+            }
+
+            const Real predictionError =
+                (predictedPathError - data.pathError).normInf();
+
+            // Tolerance was given as a percentage, multiply by 0.01 to get the
+            // correct scale.
+            const Real tolerance =
+                m_perturbationTestParameters.tolerance * 1e-2;
+            bool passedTest =
+                std::abs(predictionError / perturbation) <= tolerance;
+            if (!passedTest) {
+                testReport << "FAILED perturbation test for correction = "
+                           << data.pathCorrection << "\n";
+                testReport << "path error after perturbation:\n";
+                testReport << "    Got        : " << data.pathError << "\n";
+                testReport << "    Predicted  : " << predictedPathError << "\n";
+                testReport << "    Difference : "
+                           << (predictedPathError - data.pathError) /
+                                  perturbation
+                           << "\n";
+                testReport << "    Max diff   : "
+                           << (predictedPathError - data.pathError).normInf() /
+                                  perturbation
+                           << " <= " << tolerance << " = eps\n";
+            } else {
+                testReport << "PASSED perturbation test for correction = "
+                           << data.pathCorrection << "\n";
+                testReport << " ( max diff = "
+                           << (predictedPathError - data.pathError).normInf() /
+                                  perturbation
+                           << " <= " << tolerance << " = eps )\n";
+            }
+            success = success && passedTest;
+        }
+    }
+    // Flush all info to the report, in case we throw an exception.
+    if (success) {
+        testReport << "PASSED TEST: Jacobian perturbation test" << std::endl;
+    } else {
+        testReport << "FAILED TEST: Jacobian perturbation test" << std::endl;
+    }
+    SimTK_ASSERT_ALWAYS(success, "Perturbation test failed");
+}
+
+//==============================================================================
+//                      Resampling geodesic path points
+//==============================================================================
+/* This section contains functions for resampling a computed geodesic. */
+
+namespace
+{
+
+/* Bound for the distance between two knots when interpolation will switch
+from a Hermite interpolation to a linear interpolation to retain stability. */
+constexpr Real s_SMALL_KNOT_DISTANCE_BOUND = 1e-6;
+
+// Perform Hermite interpolation given the knot = [(y0, y0Dot) @ x0] and
+// knot = [(y1, y1Dot) @ x1], to compute y at given x. If the distance dx=x1-x0
+// becomes too small this function falls back to a linear interpolation.
+Vec3 calcHermiteInterpolation(
+    Real x0,
+    const Vec3& y0,
+    const Vec3& y0Dot,
+    Real x1,
+    const Vec3& y1,
+    const Vec3& y1Dot,
+    Real x)
+{
+    SimTK_ASSERT2(
+        x0 <= x,
+        "Hermite interpolation domain error: "
+        "x0 = %e must be smaller or equal than x = %e",
+        x0,
+        x);
+    SimTK_ASSERT2(
+        x <= x1,
+        "Hermite interpolation domain error: "
+        "x = %e must be smaller or equal than x1 = %e",
+        x,
+        x1);
+
+    // Distance between the knots:
+    const Real dx = x1 - x0;
+    // For very very small distance between the knots just return the average of
+    // the values.
+    if (dx < Eps) {
+        return (y0 + y1) / 2.;
+    }
+
+    // Normalize the point of interpolation:
+    const Real s = (x - x0) / dx; // Range of s is [0, 1].
+    // For small distance between the knots return the linear interpolation
+    // between the values.
+    if (dx < s_SMALL_KNOT_DISTANCE_BOUND) {
+        return y0 + (y1 - y0) * s;
+    }
+
+    // Otherwise do Hermite interpolation.
+    // Helper constants:
+    const Vec3 dy = y1 - y0;
+    const Vec3 m  = 0.5 * dx * (y0Dot + y1Dot);
+    // Compute coefficients of polynomial:
+    // y = c0 + c1 * s + c2 * s^2 + c3 * s^3
+    const Vec3& c0 = y0;
+    const Vec3& c1 = y0Dot * dx;
+    const Vec3 c3  = 2. * (m - dy);
+    const Vec3 c2  = 3. * dy - 2. * m - c1;
+    // Evaluate polynomial at s.
+    return c0 + s * (c1 + s * (c2 + s * c3));
+}
+
+// Resample the geodesic at equal length intervals, and write the computed
+// points to the provided sink.
+void calcResampledGeodesicPoints(
+    const std::vector<ContactGeometry::GeodesicKnotPoint>& geodesic,
+    int numSamples,
+    const std::function<void(const Vec3& interpolatedPoint_S)>& sink)
+{
+    // Some sanity checks.
+    SimTK_ASSERT(
+        !geodesic.empty(),
+        "Resampling of geodesic failed: Provided geodesic is empty.");
+    SimTK_ASSERT(
+        geodesic.front().arcLength == 0.,
+        "Resampling of geodesic failed: First frame must be at arcLength = "
+        "zero");
+    SimTK_ASSERT(
+        geodesic.back().arcLength >= 0.,
+        "Resampling of geodesic failed: Last frame must be at arcLength >= "
+        "zero");
+    SimTK_ASSERT1(
+        numSamples >= 2,
+        "Resampling of geodesic failed: Minimum number of samples for "
+        "resampling is 2 (got %i)",
+        numSamples);
+
+    // If there is but one sample (arcLength = 0), write that sample.
+    if (geodesic.size() == 1) {
+        for (int i = 0; i < numSamples; ++i) {
+            sink(geodesic.front().point);
+        }
+        return;
+    }
+
+    // The resampled geodesic will capture the first and last value exactly.
+    // Write the first value:
+    sink(geodesic.front().point);
+
+    // Since the first and last point do not need interpolation, compute the
+    // remaining n=(numSamples-2) points using interpolation:
+    auto it                   = geodesic.begin();
+    const Real finalArcLength = geodesic.back().arcLength;
+    for (int i = 1; i < numSamples - 1; ++i) {
+        // Length at the current interpolation point.
+        const Real lenghtAtInterpolationPoint =
+            finalArcLength *
+            (static_cast<Real>(i) / static_cast<Real>(numSamples - 1));
+
+        // Find the two knots (a, b) of the geodesic such that the
+        // arcLength of the interpolation point l lies between them.
+        // i.e. find: a.arcLength <= l <= b.arcLength
+        auto b = std::lower_bound(
+            it,
+            geodesic.end(),
+            lenghtAtInterpolationPoint,
+            [&](const ContactGeometry::GeodesicKnotPoint& y, Real x)
+            { return y.arcLength < x; });
+        auto a = b == geodesic.begin() ? b : b - 1;
+
+        SimTK_ASSERT(
+            b != geodesic.end(),
+            "Attempting to access out-of-range element");
+
+        // Interpolate between knots (a, b).
+        const Vec3 interpolatedPoint = calcHermiteInterpolation(
+            a->arcLength,
+            a->point,
+            a->tangent,
+            b->arcLength,
+            b->point,
+            b->tangent,
+            lenghtAtInterpolationPoint);
+        // Write interpolated point to the output.
+        sink(interpolatedPoint);
+
+        // Update the search range.
+        it = a;
+    }
+
+    // Write the last value:
+    sink(geodesic.back().point);
+}
+
+} // namespace
+
+void CurveSegment::calcResampledPoints(
+    const State& state,
+    int numSamples,
+    const std::function<void(Vec3 point_G)>& sink) const
+{
+    const CurveSegmentData::Instance& dataInst = getDataInst(state);
+    const CurveSegmentData::Position& dataPos  = getDataPos(state);
+    const ContactGeometry& geometry            = getContactGeometry();
+
+    // If the obstacle's surface is analytic we compute the geodesic with the
+    // desired granularity.
+    if (geometry.isAnalyticFormAvailable()) {
+        geometry.shootGeodesicInDirectionAnalytically(
+            dataInst.X_SP.p(),
+            getTangent(dataInst.X_SP),
+            dataInst.arcLength,
+            numSamples,
+            // Transform points to ground frame and write to the output sink.
+            [&](const ContactGeometry::GeodesicKnotPoint& q)
+            {
+                const Vec3 point_G =
+                    dataPos.X_GS.shiftFrameStationToBase(q.point);
+                sink(point_G);
+            });
+        return;
+    }
+
+    // If the obstacle's surface is not analytic we will resample the points
+    // from the integrator at equal length intervals using Hermite
+    // interpolation.
+    calcResampledGeodesicPoints(
+        dataInst.geodesicKnotPoints,
+        numSamples,
+        // Transform points to ground frame and write to the output sink.
+        [&](const Vec3& x_S)
+        {
+            const Vec3 x_G = dataPos.X_GS.shiftFrameStationToBase(x_S);
+            sink(x_G);
+        });
+}
+
+void CableSpan::Impl::calcCurveSegmentResampledPoints(
+    const State& state,
+    CableSpanObstacleIndex ix,
+    int numSamples,
+    const std::function<void(Vec3 point_G)>& sink) const
+{
+    realizePosition(state);
+    const CurveSegment& curve = getObstacleCurveSegment(ix);
+    SimTK_ERRCHK1_ALWAYS(
+        curve.isInContactWithSurface(state),
+        "CableSpan::calcCurveSegmentResampledPoints",
+        "Obstacle %i is not in contact with cable",
+        ix);
+    SimTK_ERRCHK1_ALWAYS(
+        numSamples >= 2,
+        "CableSpan::calcCurveSegmentResampledPoints",
+        "Number of resampling points must be larger or equal to 2, but got %i",
+        numSamples);
+    curve.calcResampledPoints(state, numSamples, sink);
+}
+
+//==============================================================================
+//                          CableSubsystem::Impl
+//==============================================================================
+
+const CableSpan::Impl& CableSubsystem::Impl::getCableImpl(
+    CableSpanIndex index) const
+{
+    return getCable(index).getImpl();
+}
+
+int CableSubsystem::Impl::realizeSubsystemTopologyImpl(State& state) const
+{
+    // Briefly allow writing into the Topology cache. After this the
+    // Topology cache is const.
+    Impl* mutableThis = const_cast<Impl*>(this);
+
+    CacheEntryIndex indexDataInst = allocateCacheEntry(
+        state,
+        Stage::Instance,
+        Stage::Infinity,
+        new Value<CableSpanData::Instance>());
+
+    for (CableSpanIndex ix(0); ix < cables.size(); ++ix) {
+        CableSpan& path = mutableThis->updCable(ix);
+        path.updImpl().realizeTopology(state, indexDataInst);
+    }
+
+    return 0;
+}
+
+const CableSpan& CableSubsystem::Impl::getCable(CableSpanIndex index) const
+{
+    SimTK_ERRCHK1_ALWAYS(
+        &cables[index].getImpl().getSubsystem().getImpl() == this,
+        "CableSubsystem::getCable",
+        "Cable %d is not owned by this subsystem",
+        index);
+    SimTK_ERRCHK1_ALWAYS(
+        cables[index].getImpl().getIndex() == index,
+        "CableSubsystem::getCable",
+        "Cable %d has an invalid index",
+        index);
+    return cables[index];
+}
+
+CableSpan& CableSubsystem::Impl::updCable(CableSpanIndex index)
+{
+    SimTK_ERRCHK1_ALWAYS(
+        &cables[index].getImpl().getSubsystem().getImpl() == this,
+        "CableSubsystem::updCable",
+        "Cable %d is not owned by this subsystem",
+        index);
+    SimTK_ERRCHK1_ALWAYS(
+        cables[index].getImpl().getIndex() == index,
+        "CableSubsystem::getCable",
+        "Cable %d has an invalid index",
+        index);
+    return cables[index];
+}
+
+int CableSubsystem::Impl::calcDecorativeGeometryAndAppendImpl(
+    const State& state,
+    Stage stage,
+    Array_<DecorativeGeometry>& decorations) const
+{
+    if (stage != Stage::Position) {
+        return 0;
+    }
+    for (const CableSpan& cable : cables) {
+        cable.getImpl().calcDecorativeGeometryAndAppend(state, decorations);
+    }
+    return 0;
+}
+
+//==============================================================================
+//                          CableSubsystem
+//==============================================================================
+
+CableSubsystem::CableSubsystem(MultibodySystem& mbs)
+{
+    adoptSubsystemGuts(new Impl());
+    mbs.adoptSubsystem(*this);
+}
+
+const MultibodySystem& CableSubsystem::getMultibodySystem() const
+{
+    return getImpl().getMultibodySystem();
+}
+
+int CableSubsystem::getNumCables() const
+{
+    return getImpl().getNumCables();
+}
+
+const CableSpan& CableSubsystem::getCable(CableSpanIndex ix) const
+{
+    return getImpl().getCable(ix);
+}
+
+CableSpan& CableSubsystem::updCable(CableSpanIndex ix)
+{
+    return updImpl().updCable(ix);
+}
+
+bool CableSubsystem::isInstanceOf(const Subsystem& s)
+{
+    return Impl::isA(s.getSubsystemGuts());
+}
+
+const CableSubsystem& CableSubsystem::downcast(const Subsystem& s)
+{
+    assert(isInstanceOf(s));
+    return static_cast<const CableSubsystem&>(s);
+}
+
+CableSubsystem& CableSubsystem::updDowncast(Subsystem& s)
+{
+    assert(isInstanceOf(s));
+    return static_cast<CableSubsystem&>(s);
+}
+
+const CableSubsystem::Impl& CableSubsystem::getImpl() const
+{
+    return SimTK_DYNAMIC_CAST_DEBUG<const Impl&>(getSubsystemGuts());
+}
+
+CableSubsystem::Impl& CableSubsystem::updImpl()
+{
+    return SimTK_DYNAMIC_CAST_DEBUG<Impl&>(updSubsystemGuts());
+}
+
+//==============================================================================
+//                                CableSpan
+//==============================================================================
+
+CableSpan::CableSpan() : m_impl(new Impl())
+{}
+
+CableSpan::CableSpan(
+    CableSubsystem& subsystem,
+    MobilizedBodyIndex originBody,
+    const Vec3& originStation,
+    MobilizedBodyIndex terminationBody,
+    const Vec3& terminationStation) :
+    m_impl(new Impl(
+        originBody,
+        originStation,
+        terminationBody,
+        terminationStation))
+{
+    CableSpanIndex ix = subsystem.updImpl().adoptCable(*this);
+    updImpl().setSubsystem(subsystem, ix);
+}
+
+MobilizedBodyIndex CableSpan::getOriginBodyIndex() const
+{
+    return m_impl->getOriginBodyIndex();
+}
+
+void CableSpan::setOriginBodyIndex(MobilizedBodyIndex originBody)
+{
+    m_impl->setOriginBodyIndex(originBody);
+}
+
+MobilizedBodyIndex CableSpan::getTerminationBodyIndex() const
+{
+    return m_impl->getTerminationBodyIndex();
+}
+
+void CableSpan::setTerminationBodyIndex(MobilizedBodyIndex terminationBody)
+{
+    m_impl->setTerminationBodyIndex(terminationBody);
+}
+
+Vec3 CableSpan::getOriginStation() const
+{
+    return m_impl->getOriginStation();
+}
+
+void CableSpan::setOriginStation(const Vec3& originStation)
+{
+    m_impl->setOriginStation(originStation);
+}
+
+Vec3 CableSpan::getTerminationStation() const
+{
+    return m_impl->getTerminationStation();
+}
+
+void CableSpan::setTerminationStation(const Vec3& terminationStation)
+{
+    m_impl->setTerminationStation(terminationStation);
+}
+
+ObstacleIndex CableSpan::addObstacle(
+    MobilizedBodyIndex obstacleBody,
+    const Transform& X_BS,
+    std::shared_ptr<const ContactGeometry> obstacleGeometry)
+{
+    return updImpl().addObstacle(
+        obstacleBody,
+        X_BS,
+        std::move(obstacleGeometry),
+        Vec3{NaN}); // Invalid contactPointHint_S
+}
+
+ObstacleIndex CableSpan::addObstacle(
+    MobilizedBodyIndex obstacleBody,
+    const Transform& X_BS,
+    std::shared_ptr<const ContactGeometry> obstacleGeometry,
+    const Vec3& contactPointHint_S)
+{
+    return updImpl().addObstacle(
+        obstacleBody,
+        X_BS,
+        std::move(obstacleGeometry),
+        contactPointHint_S);
+}
+
+int CableSpan::getNumObstacles() const
+{
+    return getImpl().getNumObstacles();
+}
+
+const MobilizedBodyIndex& CableSpan::getObstacleMobilizedBodyIndex(
+    ObstacleIndex ix) const
+{
+    return getImpl().getObstacleCurveSegment(ix).getMobilizedBodyIndex();
+}
+
+void CableSpan::setObstacleMobilizedBodyIndex(
+    ObstacleIndex ix,
+    MobilizedBodyIndex body)
+{
+    updImpl().updObstacleCurveSegment(ix).setMobilizedBodyIndex(body);
+}
+
+const Transform& CableSpan::getObstacleTransformSurfaceToBody(
+    ObstacleIndex ix) const
+{
+    return getImpl().getObstacleCurveSegment(ix).getTransformSurfaceToBody();
+}
+void CableSpan::setObstacleTransformSurfaceToBody(
+    ObstacleIndex ix,
+    const Transform& X_BS)
+{
+    updImpl().updObstacleCurveSegment(ix).setTransformSurfaceToBody(X_BS);
+}
+
+const ContactGeometry& CableSpan::getObstacleContactGeometry(
+    ObstacleIndex ix) const
+{
+    return getImpl().getObstacleCurveSegment(ix).getContactGeometry();
+}
+void CableSpan::setObstacleContactGeometry(
+    ObstacleIndex ix,
+    std::shared_ptr<const ContactGeometry> geometry)
+{
+    updImpl().updObstacleCurveSegment(ix).setContactGeometry(geometry);
+}
+
+Vec3 CableSpan::getObstacleContactPointHint(ObstacleIndex ix) const
+{
+    return getImpl().getObstacleCurveSegment(ix).getContactPointHint();
+}
+
+void CableSpan::setObstacleContactPointHint(
+    ObstacleIndex ix,
+    Vec3 initialContactPointHint)
+{
+    updImpl().updObstacleCurveSegment(ix).setContactPointHint(
+        initialContactPointHint);
+}
+
+bool CableSpan::isInContactWithObstacle(const State& state, ObstacleIndex ix)
+    const
+{
+    getImpl().realizePosition(state);
+    return getImpl().getObstacleCurveSegment(ix).isInContactWithSurface(state);
+}
+
+Transform CableSpan::calcCurveSegmentInitialFrenetFrame(
+    const State& state,
+    CableSpanObstacleIndex ix) const
+{
+    getImpl().realizePosition(state);
+    return getImpl().getObstacleCurveSegment(ix).getDataPos(state).X_GP;
+}
+
+Transform CableSpan::calcCurveSegmentFinalFrenetFrame(
+    const State& state,
+    CableSpanObstacleIndex ix) const
+{
+    getImpl().realizePosition(state);
+    return getImpl().getObstacleCurveSegment(ix).getDataPos(state).X_GQ;
+}
+
+Real CableSpan::calcCurveSegmentArcLength(
+    const State& state,
+    CableSpanObstacleIndex ix) const
+{
+    getImpl().realizePosition(state);
+    return getImpl().getObstacleCurveSegment(ix).getDataInst(state).arcLength;
+}
+
+Real CableSpan::getCurveSegmentAccuracy() const
+{
+    return getImpl().getParameters().geodesicIntegratorAccuracy;
+}
+
+void CableSpan::setCurveSegmentAccuracy(Real accuracy)
+{
+    updImpl().updParameters().geodesicIntegratorAccuracy = accuracy;
+}
+
+int CableSpan::getSolverMaxIterations() const
+{
+    return getImpl().getParameters().solverMaxIterations;
+}
+
+void CableSpan::setSolverMaxIterations(int maxIterations)
+{
+    updImpl().updParameters().solverMaxIterations = maxIterations;
+}
+
+Real CableSpan::getSmoothnessTolerance() const
+{
+    return getImpl().getParameters().smoothnessTolerance;
+}
+
+void CableSpan::setSmoothnessTolerance(Real tolerance)
+{
+    updImpl().updParameters().smoothnessTolerance = tolerance;
+}
+
+Real CableSpan::calcLength(const State& s) const
+{
+    return getImpl().getDataPos(s).cableLength;
+}
+
+Real CableSpan::calcLengthDot(const State& s) const
+{
+    return getImpl().getDataVel(s).lengthDot;
+}
+
+void CableSpan::applyBodyForces(
+    const State& s,
+    Real tension,
+    Vector_<SpatialVec>& bodyForcesInG) const
+{
+    return getImpl().applyBodyForces(s, tension, bodyForcesInG);
+}
+
+void CableSpan::calcDecorativePathPoints(
+    const State& state,
+    const std::function<void(Vec3 point_G)>& sink) const
+{
+    getImpl().calcDecorativePathPoints(state, sink);
+}
+
+Real CableSpan::calcCablePower(const State& state, Real tension) const
+{
+    return getImpl().calcCablePower(state, tension);
+}
+
+int CableSpan::getNumSolverIterations(const State& state) const
+{
+    return getImpl().getDataPos(state).loopIter;
+}
+
+Real CableSpan::getSmoothness(const State& state) const
+{
+    return getImpl().getDataPos(state).smoothness;
+}
+
+void CableSpan::calcCurveSegmentResampledPoints(
+    const State& state,
+    CableSpanObstacleIndex ix,
+    int numSamples,
+    const std::function<void(Vec3 point_G)>& sink) const
+{
+    m_impl->calcCurveSegmentResampledPoints(state, ix, numSamples, sink);
+}

--- a/Simbody/src/CableSpan_SubsystemTestHelper_Impl.cpp
+++ b/Simbody/src/CableSpan_SubsystemTestHelper_Impl.cpp
@@ -1,0 +1,606 @@
+/*-----------------------------------------------------------------------------
+                               Simbody(tm)
+-------------------------------------------------------------------------------
+ Copyright (c) 2024 Authors.
+ Authors: Pepijn van den Bos
+ Contributors:
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may
+ not use this file except in compliance with the License. You may obtain a
+ copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ----------------------------------------------------------------------------*/
+
+/* This file contains the implementation of the geodesic test for the curve
+segments of a CableSpan. The implementation of the jacobian perturbation test
+can be found in the CableSpan::Impl source file, because the jacobian
+calculations are not exposed through the public interface.
+
+We will use the following notation:
+- P subscript: First contact point on obstacle
+- Q subscript: Final contact point on obstacle
+- G subscript: Ground frame
+- S subscript: Surface frame
+- X_GP, X_GQ: Frenet frame at first and final contact point w.r.t. ground.
+- X_GS: Position and orientation of surface frame w.r.t. ground.
+- x: Position at point on geodesic.
+- t: Tangent at point on geodesic.
+- n: Normal at point on geodesic.
+- b: Binormal at point on geodesic. */
+
+#include "CableSpan_SubsystemTestHelper_Impl.h"
+
+#include "simbody/internal/MultibodySystem.h"
+#include "simbody/internal/SimbodyMatterSubsystem.h"
+#include "simmath/internal/ContactGeometry.h"
+
+using namespace SimTK;
+
+namespace
+{
+using IntegratorTestParameters =
+    CableSubsystemTestHelper::Impl::GeodesicTestParameters;
+using PerturbationTestParameters =
+    CableSubsystemTestHelper::Impl::PerturbationTestParameters;
+} // namespace
+
+//==============================================================================
+//              Unconstrained Geodesic for the Geodesic Test
+//==============================================================================
+/* The following section defines the unconstrained geodesic which is used to
+test the normal curvature, geodesic torsion, and surface gradient. Furthermore,
+we can use the unconstrained geodesic to verify that the curve segments of a
+CableSpan are indeed geodesics. */
+namespace
+{
+
+/* This struct contains the state of the unconstrained geodesic. */
+struct UnconstrainedGeodesicState {
+    // Position of the current point on the geodeisc.
+    Vec3 x{NaN};
+    // The (unconstrained) Frenet frame orientation at the current point on the
+    // geodesic, with the columns containing the tangent, normal and binormal
+    // directions (in that order). Note that this orientation should be a
+    // Rotation matrix, but since it is unconstrained, it is just a Mat33.
+    Mat33 R{NaN}; // = [t_G, n_G, b_G]
+};
+
+/* This helper converts an UnconstrainedGeodesicState to a Frenet frame. */
+Transform calcFrenetFrame(const UnconstrainedGeodesicState& q)
+{
+    const UnitVec3 n(q.R.col(1));
+    const Vec3 t = q.R.col(0);
+    return {Rotation().setRotationFromTwoAxes(n, YAxis, t, XAxis), q.x};
+}
+
+/* Helper function for projecting the approximate initial Frenet frame
+X_GP_approx to the surface. It is important when integrating the
+UnconstrainedGeodesicState that we do start on the surface. */
+Transform projectFirstContactFrameToSurface(
+    const ContactGeometry& geometry,
+    const Transform& X_GS,
+    const Transform& X_GP_approx)
+{
+    const Vec3 x_S = geometry.projectDownhillToNearestPoint(
+        X_GS.shiftBaseStationToFrame(X_GP_approx.p()));
+    const UnitVec3 n_S = geometry.calcSurfaceUnitNormal(x_S);
+
+    const Vec3 x_G(X_GS.shiftFrameStationToBase(x_S));
+    const UnitVec3 n_G(X_GS.xformFrameVecToBase(n_S));
+
+    return {
+        Rotation().setRotationFromTwoAxes(
+            n_G,
+            YAxis,
+            X_GP_approx.R().getAxisUnitVec(XAxis),
+            XAxis),
+        x_G};
+}
+
+/* Helper function for computing a CableSpan's obstacle's surface to ground
+transform. */
+Transform getXformSurfaceToGround(
+    const State& state,
+    const CableSubsystem& subsystem,
+    CableSpanIndex cableIx,
+    CableSpanObstacleIndex obsIx)
+{
+    const CableSpan& cable = subsystem.getCable(cableIx);
+    const Mobod& body =
+        subsystem.getMultibodySystem().getMatterSubsystem().getMobilizedBody(
+            cable.getObstacleMobilizedBodyIndex(obsIx));
+    return body.getBodyTransform(state).compose(
+        cable.getObstacleTransformSurfaceToBody(obsIx));
+}
+
+/* This is the unconstrained geodesic (system) which has the
+UnconstrainedGeodesicState as state, and uses the RungeKuttaMersonIntegrator to
+integrate the state to the final arc length.
+
+The elements in the State vector are ordered as:
+
+S = [x_G, t_G, n_G, b_G]
+
+The goal is to verify correctness of the CableSpan's curve segment over an
+obstacle: Therefore the constructor takes the obstacle geometry, the surface
+offset frame, and the curve segment's initial Frenet frame. With this
+information we should be able to compute the geodesic that matches the curve
+segment.
+*/
+class UnconstrainedGeodesic : public System {
+public:
+    /* Constructor that takes all information to compute the geodesic that
+    matches the CableSpan's curve segment. */
+    UnconstrainedGeodesic(
+        const ContactGeometry& geometry,
+        const Transform& X_GS,
+        const Transform& X_GP);
+
+    /* Construct the UnconstrainedGeodesic that will match the curve segment of
+    the given cable over the given obstacle */
+    UnconstrainedGeodesic(
+        const State& state,
+        const CableSubsystem& subsystem,
+        CableSpanIndex cableIx,
+        CableSpanObstacleIndex obsIx) :
+        UnconstrainedGeodesic(
+            subsystem.getCable(cableIx).getObstacleContactGeometry(obsIx),
+            getXformSurfaceToGround(state, subsystem, cableIx, obsIx),
+            subsystem.getCable(cableIx).calcCurveSegmentInitialFrenetFrame(
+                state,
+                obsIx))
+    {}
+
+    /* Helper function for getting the UnconstrainedGeodesicState from the
+    State vector. */
+    static UnconstrainedGeodesicState getGeodesicState(const State& state)
+    {
+        UnconstrainedGeodesicState y;
+        int ix = -1;
+
+        for (int row = 0; row < 3; ++row) {
+            y.x[row] = state.getZ()[++ix];
+        }
+
+        for (int col = 0; col < 3; ++col) {
+            for (int row = 0; row < 3; ++row) {
+                y.R(row, col) = state.getZ()[++ix];
+            }
+        }
+
+        return y;
+    }
+
+    class Guts : public System::Guts {
+        friend UnconstrainedGeodesic;
+
+        explicit Guts(
+            const ContactGeometry& geometry,
+            const Transform& X_GS,
+            const Transform& X_GP) :
+            m_geometry(geometry), m_X_GS(X_GS),
+            m_X_GP(projectFirstContactFrameToSurface(geometry, m_X_GS, X_GP))
+        {}
+
+        Guts* cloneImpl() const override
+        {
+            return new Guts(*this);
+        }
+
+        /* During realizeTopology() we allocate the State for holding the
+        UnconstrainedGeodesicState. */
+        int realizeTopologyImpl(State& state) const override
+        {
+            Vector zInit(3 + 9, 0.);
+
+            int ix = -1;
+
+            for (int row = 0; row < 3; ++row) {
+                zInit[++ix] = m_X_GP.p()[row];
+            }
+
+            for (int col = 0; col < 3; ++col) {
+                for (int row = 0; row < 3; ++row) {
+                    zInit[++ix] = m_X_GP.R().asMat33()(row, col);
+                }
+            }
+
+            state.allocateZ(SubsystemIndex(0), zInit);
+            return 0;
+        }
+
+        // Calculates the State (=UnconstrainedGeodesicState) derivative.
+        int realizeAccelerationImpl(const State& state) const override
+        {
+            UnconstrainedGeodesicState y = getGeodesicState(state);
+
+            const Vec3 t_G = y.R.col(0);
+
+            const Vec3 x_S = m_X_GS.shiftBaseStationToFrame(y.x);
+            const UnitVec3 t_S(m_X_GS.xformBaseVecToFrame(t_G));
+
+            // NOTE do not use the normal from the state, but compute it from
+            // the point, as explained in
+            // CableSubsystemTestHelper::Impl::runGeodesicTest.
+            const UnitVec3 n_S = m_geometry.calcSurfaceUnitNormal(x_S);
+
+            const UnitVec3 n_G(m_X_GS.xformFrameVecToBase(n_S));
+            const UnitVec3 b_G(t_G % n_G);
+
+            // NOTE Simbody uses curvature with sign flipped from convention.
+            const Real kn =
+                -m_geometry.calcSurfaceCurvatureInDirection(x_S, t_S);
+            const Real tau_g =
+                -m_geometry.calcSurfaceTorsionInDirection(x_S, t_S);
+
+            int ix = -1;
+
+            // xDot
+            state.updZDot()[++ix] = t_G[0];
+            state.updZDot()[++ix] = t_G[1];
+            state.updZDot()[++ix] = t_G[2];
+
+            // tDot
+            state.updZDot()[++ix] = kn * n_G[0];
+            state.updZDot()[++ix] = kn * n_G[1];
+            state.updZDot()[++ix] = kn * n_G[2];
+
+            // nDot
+            state.updZDot()[++ix] = -kn * t_G[0] - tau_g * b_G[0];
+            state.updZDot()[++ix] = -kn * t_G[1] - tau_g * b_G[1];
+            state.updZDot()[++ix] = -kn * t_G[2] - tau_g * b_G[2];
+
+            // bDot
+            state.updZDot()[++ix] = tau_g * n_G[0];
+            state.updZDot()[++ix] = tau_g * n_G[1];
+            state.updZDot()[++ix] = tau_g * n_G[2];
+
+            return 0;
+        }
+
+    private:
+        // Surface geometry for the geodesic.
+        ContactGeometry m_geometry;
+        // Surface to ground transform.
+        Transform m_X_GS;
+        // Initial Frenet frame of the geodesic.
+        Transform m_X_GP;
+    };
+};
+
+UnconstrainedGeodesic::UnconstrainedGeodesic(
+    const ContactGeometry& geometry,
+    const Transform& X_GS,
+    const Transform& X_GP)
+{
+    adoptSystemGuts(new Guts(geometry, X_GS, X_GP));
+    DefaultSystemSubsystem defsub(*this);
+}
+
+/* Compute the UnconstrainedGeodesic that should match the curve segment on an
+obstacle within a CableSpan. Returns the initial and final state of the
+unconstrained geodesic. */
+std::array<UnconstrainedGeodesicState, 2>
+calcUnconstrainedGeodesicAtCableObstacle(
+    const State& state,
+    const CableSubsystem& subsystem,
+    CableSpanIndex cableIx,
+    CableSpanObstacleIndex obsIx,
+    const IntegratorTestParameters& parameters)
+{
+    SimTK_ASSERT_ALWAYS(
+        subsystem.getCable(cableIx).isInContactWithObstacle(state, obsIx),
+        "Curve segment does not exist if obstacle not in contact with cable");
+    const Real finalArcLength =
+        subsystem.getCable(cableIx).calcCurveSegmentArcLength(state, obsIx);
+
+    // Create the UnconstrainedGeodesic system.
+    UnconstrainedGeodesic sys(state, subsystem, cableIx, obsIx);
+
+    // Setup the integrator for computing the unconstrained geodesic.
+    RungeKuttaMersonIntegrator integ(sys);
+    integ.setAccuracy(parameters.accuracy);
+    integ.setFinalTime(finalArcLength);
+
+    // Initialize the unconstrained geodesic state.
+    State initState = sys.realizeTopology();
+    initState.setTime(0.);
+    integ.initialize(initState);
+
+    // Hold on to the initial state; We return it at the function end.
+    UnconstrainedGeodesicState y0 =
+        UnconstrainedGeodesic::getGeodesicState(integ.getState());
+
+    // Integrate to fhe final arc length.
+    constexpr int c_maxIntegrationSteps = 1000000;
+    for (int i = 0; i < c_maxIntegrationSteps; ++i) {
+        if (integ.stepTo(finalArcLength) == Integrator::EndOfSimulation) {
+            break;
+        }
+    }
+    SimTK_ASSERT_ALWAYS(
+        std::abs(integ.getState().getTime() - finalArcLength) < Eps,
+        "Failed to integrate UnconstrainedGeodesicState to final arc length");
+
+    // Get the state at the final arc length.
+    UnconstrainedGeodesicState y1 =
+        UnconstrainedGeodesic::getGeodesicState(integ.getState());
+
+    // Return the initial and final state of the UnconstrainedGeodesic.
+    return {y0, y1};
+}
+
+} // namespace
+
+//==============================================================================
+//                      Geodesic test for the CableSubsystem
+//==============================================================================
+namespace
+{
+
+// Given a CableSpan's curve segment compute the unconstrained geodesic from
+// the same initial conditions and assert correctness of both the unconstrained
+// geodesic and the curve segment.
+void runCurveSegmentGeodesicTest(
+    const State& state,
+    const CableSubsystem& subsystem,
+    CableSpanIndex cableIx,
+    CableSpanObstacleIndex obsIx,
+    const IntegratorTestParameters& parameters,
+    std::ostream& os)
+{
+    const CableSpan& cable = subsystem.getCable(cableIx);
+
+    // Skip obstacles that are not in contact with the cable.
+    if (!cable.isInContactWithObstacle(state, obsIx)) {
+        os << "skip Geodesic Test of";
+        os << ": cable " << cableIx;
+        os << ", obstacle " << obsIx;
+        os << ": Obstacle not in contact\n";
+        return;
+    }
+
+    os << "START Geodesic Test of";
+    os << ": cable " << cableIx;
+    os << ", obstacle " << obsIx;
+    os << ", with length " << cable.calcCurveSegmentArcLength(state, obsIx)
+       << "\n";
+
+    // First some sanity checks on the configuration parameters.
+
+    // The accuracy of the unconstrained geodesic state should be relatively
+    // small (= very accurate). How small depends on the model scale, but let's
+    // just make sure it is not too large here.
+    constexpr Real c_minAccuracy = 1e-10;
+    SimTK_ERRCHK2_ALWAYS(
+        parameters.accuracy <= c_minAccuracy,
+        "CableSubsystemTestHelper::Impl::runGeodesicTest",
+        "Invalid parameter: Unconstrained geodesic accuracy (=%e) should be "
+        "less or equal to %e",
+        parameters.accuracy,
+        c_minAccuracy);
+    SimTK_ERRCHK2_ALWAYS(
+        parameters.accuracy < parameters.driftTolerance,
+        "CableSubsystemTestHelper::Impl::runGeodesicTest",
+        "Invalid parameter: Unconstrained geodesic accuracy (=%e) should be "
+        "smaller than the drift tolerance (=%e)",
+        parameters.accuracy,
+        parameters.driftTolerance);
+    SimTK_ERRCHK2_ALWAYS(
+        parameters.accuracy < parameters.assertionTolerance,
+        "CableSubsystemTestHelper::Impl::runGeodesicTest",
+        "Invalid parameter: Unconstrained geodesic accuracy (=%e) should be "
+        "smaller than the assertion tolerance (=%e)",
+        cable.getCurveSegmentAccuracy(),
+        parameters.assertionTolerance);
+    SimTK_ERRCHK2_ALWAYS(
+        cable.getCurveSegmentAccuracy() < parameters.assertionTolerance,
+        "CableSubsystemTestHelper::Impl::runGeodesicTest",
+        "Invalid parameter: Curve segment accuracy (=%e) should be smaller "
+        "than the assertion tolerance (=%e)",
+        cable.getCurveSegmentAccuracy(),
+        parameters.assertionTolerance);
+
+    // Compute the unconstrained geodesic that should match the cable obstacle's
+    // curve segment.
+    std::array<UnconstrainedGeodesicState, 2> unconstrainedGeodesicStates =
+        calcUnconstrainedGeodesicAtCableObstacle(
+            state,
+            subsystem,
+            cableIx,
+            obsIx,
+            parameters);
+    // Alias for the initial state.
+    const UnconstrainedGeodesicState& y0 = unconstrainedGeodesicStates.front();
+    // Alias for the final state.
+    const UnconstrainedGeodesicState& y1 = unconstrainedGeodesicStates.back();
+
+    // Helper for computing the surface constraint value given the
+    // UnconstrainedGeodesicState.
+    auto calcSurfaceValue = [&](const UnconstrainedGeodesicState& y) -> Real
+    {
+        const ContactGeometry& geometry =
+            subsystem.getCable(cableIx).getObstacleContactGeometry(obsIx);
+        const Transform X_GS =
+            getXformSurfaceToGround(state, subsystem, cableIx, obsIx);
+        const Vec3 x_S = X_GS.shiftBaseStationToFrame(y.x);
+        return geometry.calcSurfaceValue(x_S);
+    };
+
+    // Helper for computing the surface unit normal given the
+    // UnconstrainedGeodesicState.
+    auto calcSurfaceUnitNormal =
+        [&](const UnconstrainedGeodesicState& y) -> UnitVec3
+    {
+        const ContactGeometry& geometry =
+            subsystem.getCable(cableIx).getObstacleContactGeometry(obsIx);
+        const Transform X_GS =
+            getXformSurfaceToGround(state, subsystem, cableIx, obsIx);
+        const Vec3 x_S = X_GS.shiftBaseStationToFrame(y.x);
+        return UnitVec3(
+            X_GS.xformFrameVecToBase(geometry.calcSurfaceUnitNormal(x_S)));
+    };
+
+    // This max error we only use to print some information for the user.
+    Real maxErr = 0.;
+    // Helper for updating the max error, given a new error evaluation.
+    auto trackMaxErr = [&](Real err) -> Real
+    {
+        maxErr = std::max(err, maxErr);
+        return err;
+    };
+
+    // Assert the initial state of the UnconstrainedGeodesic.
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr(std::abs(calcSurfaceValue(y0))) <
+            parameters.constraintTolerance,
+        "Initial point of UnconstrainedGeodesic not on surface");
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr((y0.R.col(0).norm() - 1.)) < parameters.constraintTolerance,
+        "Initial tangent of UnconstrainedGeodesic does not have unit norm");
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr((y0.R.col(1).norm() - 1.)) < parameters.constraintTolerance,
+        "Initial normal of UnconstrainedGeodesic does not have unit norm");
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr((y0.R.col(2).norm() - 1.)) < parameters.constraintTolerance,
+        "Initial binormal of UnconstrainedGeodesic does not have unit norm");
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr((calcSurfaceUnitNormal(y0) - y0.R.col(1)).norm()) <
+            parameters.constraintTolerance,
+        "Initial normal of UnconstrainedGeodesic does not match surface normal");
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr((y0.R * (~y0.R) - Mat33(1)).norm()) <
+            parameters.constraintTolerance,
+        "Initial axes of UnconstrainedGeodesic are not mutually perpendicular");
+    os << "PASSED TEST: Initial UnconstrainedGeodesicState on surface";
+    os << " (err = " << maxErr << " < " << parameters.constraintTolerance
+       << " = eps)" << std::endl;
+    maxErr = 0.; // Reset the max error after each section of tests.
+
+    // Assert the final state of the UnconstrainedGeodesic.
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr(std::abs(calcSurfaceValue(y1))) < parameters.driftTolerance,
+        "Final point of UnconstrainedGeodesic not on surface");
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr((y1.R.col(0).norm() - 1.)) < parameters.driftTolerance,
+        "Final tangent of UnconstrainedGeodesic does not have unit norm");
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr((y1.R.col(1).norm() - 1.)) < parameters.driftTolerance,
+        "Final normal of UnconstrainedGeodesic does not have unit norm");
+    SimTK_ASSERT1_ALWAYS(
+        trackMaxErr((y1.R.col(2).norm() - 1.)) < parameters.driftTolerance,
+        "Final binormal of UnconstrainedGeodesic does not have unit norm (%e)",
+        y1.R.col(2).norm() - 1.);
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr((calcSurfaceUnitNormal(y1) - y1.R.col(1)).norm()) <
+            parameters.driftTolerance,
+        "Final normal of UnconstrainedGeodesic does not match surface normal");
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr((y1.R * (~y1.R) - Mat33(1)).norm()) <
+            parameters.driftTolerance,
+        "Final axes of UnconstrainedGeodesic are not mutually perpendicular");
+    os << "PASSED TEST: Final UnconstrainedGeodesic on surface";
+    os << " (err = " << maxErr << " < " << parameters.driftTolerance
+       << " = eps)" << std::endl;
+    maxErr = 0.;
+
+    // Assert that the curve segment matches the UnconstrainedGeodesic at the
+    // first contact point.
+    const Transform X_GP =
+        cable.calcCurveSegmentInitialFrenetFrame(state, obsIx);
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr((X_GP.p() - y0.x).norm()) < parameters.assertionTolerance,
+        "Curve segment Frenet frame at initial contact point does not match UnconstrainedGeodesic");
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr((X_GP.R().asMat33() * (~y0.R) - Mat33(1)).norm()) <
+            parameters.assertionTolerance,
+        "Curve segment Frenet frame at initial contact point does not match UnconstrainedGeodesic");
+    os << "PASSED TEST: Initial curve segment frame on surface";
+    os << " (err = " << maxErr << " < " << parameters.assertionTolerance
+       << " = eps)" << std::endl;
+    maxErr = 0.;
+
+    // Assert that the curve segment matches the UnconstrainedGeodesic at the
+    // final contact point.
+    const Transform X_GQ = cable.calcCurveSegmentFinalFrenetFrame(state, obsIx);
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr((X_GQ.p() - y1.x).norm()) < parameters.assertionTolerance,
+        "Curve segment Frenet frame at final contact point does not match UnconstrainedGeodesic");
+    SimTK_ASSERT_ALWAYS(
+        trackMaxErr((X_GQ.R().asMat33() * (~y1.R) - Mat33(1)).norm()) <
+            parameters.assertionTolerance,
+        "Curve segment Frenet frame at final contact point does not match UnconstrainedGeodesic");
+    os << "PASSED TEST: Final curve segment frame matches "
+          "UnconstrainedGeodesic";
+    os << " (err = " << maxErr << " < " << parameters.assertionTolerance
+       << " = eps)" << std::endl;
+}
+
+} // namespace
+
+void CableSubsystemTestHelper::Impl::runGeodesicTest(
+    const State& state,
+    const CableSubsystem& subsystem,
+    std::ostream& testReport) const
+{
+    // Call the geodesic test for each curve segment of each cable in the
+    // subsystem.
+    for (CableSpanIndex cableIx(0); cableIx < subsystem.getNumCables();
+         ++cableIx) {
+        for (CableSpanObstacleIndex obsIx(0);
+             obsIx < subsystem.getCable(cableIx).getNumObstacles();
+             ++obsIx) {
+            runCurveSegmentGeodesicTest(
+                state,
+                subsystem,
+                cableIx,
+                obsIx,
+                m_integratorTestParameters,
+                testReport);
+        }
+    }
+}
+
+//==============================================================================
+//                  Implementation of CableSubsystemTestHelper
+//==============================================================================
+
+void CableSubsystemTestHelper::Impl::testCurrentPath(
+    const State& state,
+    const CableSubsystem& subsystem,
+    std::ostream& testReport) const
+{
+    // Intentionally skip the perturbation test if the geodesic test fails.
+    runGeodesicTest(state, subsystem, testReport);
+    runPerturbationTest(state, subsystem, testReport);
+}
+
+CableSubsystemTestHelper::CableSubsystemTestHelper() :
+    m_impl(new CableSubsystemTestHelper::Impl())
+{}
+
+CableSubsystemTestHelper::~CableSubsystemTestHelper() noexcept = default;
+
+CableSubsystemTestHelper::CableSubsystemTestHelper(
+    const CableSubsystemTestHelper& source) :
+    m_impl(new CableSubsystemTestHelper::Impl(*source.m_impl))
+{}
+
+CableSubsystemTestHelper& CableSubsystemTestHelper::operator=(
+    const CableSubsystemTestHelper& source)
+{
+    return *this = CableSubsystemTestHelper(source);
+}
+
+void CableSubsystemTestHelper::testCurrentPath(
+    const State& state,
+    const CableSubsystem& subsystem,
+    std::ostream& testReport) const
+{
+    m_impl->testCurrentPath(state, subsystem, testReport);
+}

--- a/Simbody/src/CableSpan_SubsystemTestHelper_Impl.h
+++ b/Simbody/src/CableSpan_SubsystemTestHelper_Impl.h
@@ -1,0 +1,193 @@
+#ifndef SimTK_SIMBODY_CABLE_SUBSYSTEM_TEST_HELPER_H_
+#define SimTK_SIMBODY_CABLE_SUBSYSTEM_TEST_HELPER_H_
+
+/*-----------------------------------------------------------------------------
+                               Simbody(tm)
+-------------------------------------------------------------------------------
+ Copyright (c) 2024 Authors.
+ Authors: Pepijn van den Bos
+ Contributors:
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may
+ not use this file except in compliance with the License. You may obtain a
+ copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ----------------------------------------------------------------------------*/
+
+#include "simbody/internal/CableSpan.h"
+
+namespace SimTK
+{
+
+/** This class is the implementation side of CableSubsystemTestHelper. **/
+class CableSubsystemTestHelper::Impl final {
+public:
+    //--------------------------------------------------------------------------
+    //  Interface Translation Function
+    //--------------------------------------------------------------------------
+
+    /** See CableSpan::testCurrentPath **/
+    void testCurrentPath(
+        const State& state,
+        const CableSubsystem& subsystem,
+        std::ostream& testReport) const;
+
+    //--------------------------------------------------------------------------
+    // Configuration Parameters
+    //--------------------------------------------------------------------------
+    // These data structures contain the parameters for configuring the tests.
+
+    /** Parameters for configuring the geodesic test. **/
+    struct GeodesicTestParameters {
+        /** Integrator accuracy of the unconstrained geodesic. **/
+        Real accuracy = 1e-13;
+        /** Tolerance used to assert constraint violation after projecting the
+        curve segment's initial conditions to the surface. **/
+        Real constraintTolerance = 1e-9;
+        /** Tolerance used to assert constraint violation of the unconstrained
+        geodesic state at the final arc length. **/
+        Real driftTolerance = 1e-8;
+        /** Tolerance used to assert equality between the CableSpan's curve
+        segment and the unconstrained geodesic. **/
+        Real assertionTolerance = 1e-7;
+    };
+
+    /** Parameters for configuring the jacobian perturbation test. **/
+    struct PerturbationTestParameters {
+        /** Perturbation value used. **/
+        Real perturbation = 1e-5;
+        /** Tolerance used to assert that the jacobian correctly predicts the
+        perturbation effect. This is a percentage: e.g. tolerance = 1 would
+        mean that the jacobian has a prediction error less or equal to 1
+        percent for the given perturbation. **/
+        Real tolerance = 0.1;
+    };
+
+private:
+    //--------------------------------------------------------------------------
+    // Tests
+    //--------------------------------------------------------------------------
+
+    /** This function asserts that the internally computed path error jacobian
+    is correct using a perturbation test.
+
+    The perturbation test is done as follows:
+    1. Compute the path error vector and jacobian before perturbation.
+    2. Take the perturbation as a small nonzero NaturalGeodesicCorrection, for a
+        single obstacle, and predict the effect on the path error vector using
+        the jacobian.
+    3. Apply the NaturalGeodesicCorrection (i.e. the perturbation) to the path,
+        and evaluate the path error vector again.
+    4. The test passes if the predicted path error vector obtained from the
+        jacobian, matches the evaluated path error vector after the
+        perturbation, up to tolerance.
+
+    The above test is repeated for each of the four NaturalGeodesicCorrection
+    elements, and for each obstacle that comes into contact with the cable.
+
+    Note that the jacobian is a local predictor of the effect of the
+    NaturalGeodesicCorrection on the path error vector. This means that
+    switching behavior due to touchdown and liftoff would result in an incorrect
+    prediction. Whenever a switching behavior is detected, the test is skipped.
+
+    Interesting test results are written to the testReport.
+    An exception is thrown when the test fails. **/
+    void runPerturbationTest(
+        const State& state,
+        const CableSubsystem& subsystem,
+        std::ostream& testReport) const;
+
+    /** This function asserts that each curve segment of each CableSpan in the
+    CableSubsystem is a correct geodesic.
+
+    This test will verify correctness of the ContactGeometry's computed:
+    - normal curvature
+    - geodesic torsion
+    - surface constraint gradient direction
+    and verify that any curve segment of the CableSpan's path is a geodeisc.
+    It is assumed that ContactGeometry::calcSurfaceValue is correct.
+
+    Verifying that the segment is a geodesic is done by computing an
+    unconstrained geodesic starting from the same initial conditions. The
+    unconstrained geodesic uses the implicit geodesic equations to compute the
+    frenet frame at the final arc length, but does not enforce any constraints
+    during the numerical integration.
+
+    The unconstrained geodesic uses the following state:
+    - x: The point, or position in ground
+    - t: The tangent vector in ground
+    - n: The normal vector in ground
+    - b: The binormal vector in ground
+
+    Consider the differential equations for integrating the position of the
+    point on the geodesic:
+
+    dx = t
+    dt = f(x) = kn(x) * g(x) / |g(x)|
+
+    where kn(x) is the normal curvature, and g(x) is the gradient of the surface
+    constraint. Clearly the dynamics of the point and tangent form an isolated
+    system of equations along the geodesic. If we integrate this system to the
+    final arc length, without enforcing any constraints (i.e. no surface
+    projection, tangent norm, tangent plane, etc), then any bugs in either kn(x)
+    or g(x) will cause the constraints to be violated. These constraint
+    violations are easily evaluated:
+    1. The point should not drift away from the surface.
+    2. The tangent vector should have unit norm.
+    3. The tangent vector should be perpendicular to the surface normal.
+    So, we can test the normal curvature and gradient direction using the
+    position and tangent of the final frenet frame, of the unconstrained
+    geodesic.
+
+    Next, consider the differential equation for the binormal vector:
+
+    db = tau_g(x, t) * g(x) / |g(x)|
+
+    where tau_g(x, t) is the geodesic torsion. Again we can evaluate the
+    binormal after integrating to the final arc length: It should have unit
+    length, and be perpendicular to the tangent and surface normal. Any bugs in
+    computing the geodesic torsion will result in a strange direction of the
+    binormal at the final arc length.
+
+    Finally, we have the differential equation for the normal vector:
+
+    dn = -tau_g * b - kn * t
+
+    Integrating this differential equation should result in a vector that
+    matches computing the surface normal at the final arc length.
+
+    Given the initial conditions, the arc length, the normal curvature and
+    geodesic torsion: the geodesic is completely determined. We assert that the
+    unconstrained geodesic gives the same final frenet frame as the curve
+    segment over the obstacle, and we can be sure that this curve segment is
+    indeed a geodesic.
+
+    Interesting test results are written to the testReport.
+    An exception is thrown when the test fails. **/
+    void runGeodesicTest(
+        const State& state,
+        const CableSubsystem& subsystem,
+        std::ostream& testReport) const;
+
+    //--------------------------------------------------------------------------
+    //  Data: Configuration parameters
+    //--------------------------------------------------------------------------
+    // NOTE Currently these are not exposed, so they are effectively fixed to
+    // their default values. But should this ever change, it helps that the
+    // current structure is in place.
+
+    /* Configuration parameters for the jacobian perturbation test. */
+    PerturbationTestParameters m_perturbationTestParameters;
+
+    /* Configuration parameters for the geodesic test. */
+    GeodesicTestParameters m_integratorTestParameters;
+};
+
+} // namespace SimTK
+
+#endif

--- a/Simbody/tests/TestCableSpan.cpp
+++ b/Simbody/tests/TestCableSpan.cpp
@@ -1,0 +1,764 @@
+/*-----------------------------------------------------------------------------
+                Simbody(tm) Test: Cable Over Several Smooth Surfaces
+-------------------------------------------------------------------------------
+ Copyright (c) 2024 Authors.
+ Authors: Pepijn van den Bos
+ Contributors:
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may
+ not use this file except in compliance with the License. You may obtain a
+ copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ----------------------------------------------------------------------------*/
+
+#include "Simbody.h"
+
+using namespace SimTK;
+
+/**
+This file contains tests for the CableSpan's path over different obstacles.
+**/
+
+/* A helper class for drawing interesting things of a CableSpan. */
+class CableDecorator : public SimTK::DecorationGenerator {
+public:
+    CableDecorator(MultibodySystem& mbs, const CableSpan& cable) :
+        m_mbs(&mbs), m_cable(cable)
+    {
+        for (CableSpanObstacleIndex ix(0); ix < m_cable.getNumObstacles();
+             ++ix) {
+            m_obstacleDecorations.push_back(
+                m_cable.getObstacleContactGeometry(ix)
+                    .createDecorativeGeometry()
+                    .setResolution(3));
+            m_obstacleDecorationsOffsets.push_back(
+                m_obstacleDecorations.back().getTransform());
+        }
+    }
+
+    void generateDecorations(
+        const State& state,
+        Array_<DecorativeGeometry>& decorations) override
+    {
+        for (CableSpanObstacleIndex ix(0); ix < m_cable.getNumObstacles();
+             ++ix) {
+            // Draw the obstacle surface.
+            const ContactGeometry& geometry =
+                m_cable.getObstacleContactGeometry(ix);
+            // If cable is not in contact with the surface grey it out.
+            const bool isInContactWithSurface =
+                m_cable.isInContactWithObstacle(state, ix);
+            const Vec3 color   = isInContactWithSurface ? Yellow : Gray;
+            const Real opacity = isInContactWithSurface ? 0.5 : 0.25;
+            // Transform from Ground to obstacle body.
+            Transform X_GB =
+                m_mbs->getMatterSubsystem()
+                    .getMobilizedBody(m_cable.getObstacleMobilizedBodyIndex(ix))
+                    .getBodyTransform(state);
+            // Transform from Ground to obstacle contact surface offset frame.
+            const Transform X_GS =
+                X_GB.compose(m_cable.getObstacleTransformSurfaceToBody(ix));
+            // Transform from ground to decoration surface.
+            const Transform X_GD =
+                X_GS.compose(m_obstacleDecorationsOffsets.at(ix));
+            // Draw the obstacle's local frame.
+            // This is the frame that you define the contact point hint in.
+            decorations.push_back(
+                DecorativeFrame(0.5).setTransform(X_GS).setColor(Purple));
+            // Draw the obstacle contact geometry.
+            decorations.push_back(m_obstacleDecorations.at(ix)
+                                      .setTransform(X_GD)
+                                      .setColor(color)
+                                      .setOpacity(opacity));
+
+            // Draw the initial contact point hints (these are user-defined) as
+            // a line and a point.
+            const Vec3 x_PS = m_cable.getObstacleContactPointHint(ix);
+            decorations.push_back(
+                DecorativeLine(X_GS.p(), X_GS.shiftFrameStationToBase(x_PS))
+                    .setColor(Green)
+                    .setLineThickness(3));
+            decorations.push_back(
+                DecorativePoint(X_GS.shiftFrameStationToBase(x_PS))
+                    .setColor(Green));
+        }
+    }
+
+    MultibodySystem* m_mbs;
+    CableSpan m_cable;
+    Array_<DecorativeGeometry, CableSpanObstacleIndex> m_obstacleDecorations;
+    Array_<Transform, CableSpanObstacleIndex> m_obstacleDecorationsOffsets;
+};
+
+/** Simple CableSpon path with known solution.
+
+Wrap a cable over (in order):
+1. Torus
+2. Ellipsoid
+3. Sphere
+4. Cylinder
+
+We wrap the cable conveniently over the obstacles such that each curve
+segment becomes a circular-arc shape. This allows us to check the results by
+hand. **/
+void testSimpleCable()
+{
+    const bool show = false;
+
+    // Create the system.
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    // A dummy body.
+    Body::Rigid aBody(MassProperties(1., Vec3(0), Inertia(1)));
+
+    // Mobilizer for path origin.
+    MobilizedBody::Translation cableOriginBody(
+        matter.Ground(),
+        Vec3(0.),
+        aBody,
+        Transform());
+
+    // Mobilizer for path termination.
+    MobilizedBody::Translation cableTerminationBody(
+        matter.Ground(),
+        Transform(Vec3(-4., 0., 0.)),
+        aBody,
+        Transform());
+
+    // Construct a new cable.
+    CableSpan cable(
+        cables,
+        cableOriginBody,
+        Vec3{0.},
+        cableTerminationBody,
+        Vec3{0.});
+    cable.setCurveSegmentAccuracy(1e-12);
+    cable.setSmoothnessTolerance(1e-6);
+
+    // Add initial torus obstacle.
+    MobilizedBody::Translation torusBody(
+        matter.Ground(),
+        Transform(Vec3(0., 10., 0.)),
+        aBody,
+        Transform());
+    cable.addObstacle(
+        torusBody,
+        Transform(Rotation(0.5 * Pi, YAxis), Vec3{1., 1., 0.}),
+        std::shared_ptr<ContactGeometry>(new ContactGeometry::Torus(10., 1.)),
+        {0., -9., 0.});
+
+    // Add ellipsoid obstacle.
+    MobilizedBody::Translation ellipsoidBody(
+        torusBody,
+        Transform(Vec3(4., -10., 0.)),
+        aBody,
+        Transform());
+    cable.addObstacle(
+        ellipsoidBody,
+        Transform(Vec3{0.5, 1., 0.}),
+        std::shared_ptr<ContactGeometry>(
+            new ContactGeometry::Ellipsoid({1., 1., 0.75})),
+        {1., 1., 0.});
+
+    // Add sphere obstacle.
+    cable.addObstacle(
+        matter.Ground(),
+        Transform(Vec3{4., -2., 0.}),
+        std::shared_ptr<ContactGeometry>(new ContactGeometry::Sphere(1.5)),
+        {0., -1., 0.});
+
+    // Add cylinder obstacle.
+    cable.addObstacle(
+        matter.Ground(),
+        Transform(Vec3{-2., -1.5, 0.}),
+        std::shared_ptr<ContactGeometry>(new ContactGeometry::Cylinder(2.)),
+        Vec3{0., -1., 0.});
+
+    // Optionally visualize the system.
+    system.setUseUniformBackground(true); // no ground plane in display
+    std::unique_ptr<Visualizer> viz(show ? new Visualizer(system) : nullptr);
+
+    if (viz) {
+        viz->setShowFrameNumber(true);
+        viz->addDecorationGenerator(new CableDecorator(system, cable));
+    }
+
+    // Initialize the system and state.
+    system.realizeTopology();
+    State s = system.getDefaultState();
+
+    // Compute the CableSpan's path.
+    system.realize(s, Stage::Report);
+    const Real cableLength = cable.calcLength(s);
+    if (viz) {
+        viz->report(s);
+    }
+
+    SimTK_ASSERT_ALWAYS(
+        cable.getNumObstacles() == 4,
+        "Invalid number of obstacles");
+
+    SimTK_ASSERT2_ALWAYS(
+        cable.getSmoothness(s) <= cable.getSmoothnessTolerance(),
+        "Test failed: Cable smoothness (=%e) must be smaller than set tolerance (=%e)",
+        cable.getSmoothness(s),
+        cable.getSmoothnessTolerance());
+
+    std::array<std::string, 4> obsNames{
+        "torus",
+        "ellipsoid",
+        "sphere",
+        "cylinder"};
+
+    // Note that the length deviates because the path is solved up to angle
+    // tolerance, not length tolerance.
+    const Real lengthTolerance = 1e-5;
+    auto assertCurveSegmentLength =
+        [&](CableSpanObstacleIndex obsIx, Real obsRadius)
+    {
+        SimTK_ASSERT1_ALWAYS(
+            cable.isInContactWithObstacle(s, obsIx),
+            "Cable not in contact with %s obstacle",
+            obsNames.at(obsIx).c_str());
+
+        const Real angle          = 0.5 * Pi;
+        const Real expectedLength = angle * obsRadius;
+        const Real gotLength      = cable.calcCurveSegmentArcLength(s, obsIx);
+
+        SimTK_ASSERT4_ALWAYS(
+            std::abs(gotLength - expectedLength) < lengthTolerance,
+            "%s curve segment length (=%f) does not match expected length (=%f), with error %e",
+            obsNames.at(obsIx).c_str(),
+            gotLength,
+            expectedLength,
+            gotLength - expectedLength);
+    };
+
+    assertCurveSegmentLength(CableSpanObstacleIndex(0), 1.);
+    assertCurveSegmentLength(CableSpanObstacleIndex(1), 1.);
+    assertCurveSegmentLength(CableSpanObstacleIndex(2), 1.5);
+    assertCurveSegmentLength(CableSpanObstacleIndex(3), 2.);
+
+    // Sum all straight line segment lengths + curve line segment lengths.
+    const Real sumStraightLineSegmentLengths = 1. + 3.5 + 3. + 6. + 1.5;
+    const Real sumCurveLineSegmentLengths    = 0.5 * Pi * (1. + 1. + 1.5 + 2.);
+    const Real expectedTotalCableLength =
+        sumStraightLineSegmentLengths + sumCurveLineSegmentLengths;
+    const Real gotTotalCableLength = cable.calcLength(s);
+    SimTK_ASSERT3_ALWAYS(
+        std::abs(expectedTotalCableLength - gotTotalCableLength) <
+            lengthTolerance,
+        "Expected cable length (=%f) does not match computed cable length (=%f), error = %e",
+        expectedTotalCableLength,
+        gotTotalCableLength,
+        expectedTotalCableLength - gotTotalCableLength);
+
+    // We should pass the generic tests:
+    CableSubsystemTestHelper().testCurrentPath(s, cables, std::cout);
+
+    const Real frenetFrameTolerance     = 1e-6;
+    auto assertCurveSegmentFrenetFrames = [&](CableSpanObstacleIndex obsIx,
+                                              const Transform& expected_X_GP,
+                                              const Transform& expected_X_GQ)
+    {
+        const Transform& got_X_GP =
+            cable.calcCurveSegmentInitialFrenetFrame(s, obsIx);
+        const Transform& got_X_GQ =
+            cable.calcCurveSegmentFinalFrenetFrame(s, obsIx);
+
+        SimTK_ASSERT1_ALWAYS(
+            (expected_X_GP.p() - got_X_GP.p()).norm() < frenetFrameTolerance,
+            "%s curve segment position at initial contact point incorrect",
+            obsNames.at(obsIx).c_str());
+        SimTK_ASSERT1_ALWAYS(
+            (expected_X_GP.R().asMat33() - got_X_GP.R().asMat33()).norm() <
+                frenetFrameTolerance,
+            "%s curve segment frame orientation at initial contact point incorrect",
+            obsNames.at(obsIx).c_str());
+
+        SimTK_ASSERT1_ALWAYS(
+            (expected_X_GQ.p() - got_X_GQ.p()).norm() < frenetFrameTolerance,
+            "%s curve segment position at final contact point incorrect",
+            obsNames.at(obsIx).c_str());
+        SimTK_ASSERT1_ALWAYS(
+            (expected_X_GQ.R().asMat33() - got_X_GQ.R().asMat33()).norm() <
+                frenetFrameTolerance,
+            "%s curve segment frame orientation at final contact point incorrect",
+            obsNames.at(obsIx).c_str());
+    };
+
+    assertCurveSegmentFrenetFrames(
+        CableSpanObstacleIndex(0),
+        Transform(
+            Rotation().setRotationFromTwoAxes(
+                UnitVec3(Vec3(0., 1., 0.)),
+                XAxis,
+                UnitVec3(Vec3(-1., 0., 0.)),
+                YAxis),
+            Vec3(0., 1., 0.)),
+        Transform(
+            Rotation().setRotationFromTwoAxes(
+                UnitVec3(Vec3(1., 0., 0.)),
+                XAxis,
+                UnitVec3(Vec3(0., 1., 0.)),
+                YAxis),
+            Vec3(1., 2., 0.)));
+    assertCurveSegmentFrenetFrames(
+        CableSpanObstacleIndex(1),
+        Transform(
+            Rotation().setRotationFromTwoAxes(
+                UnitVec3(Vec3(1., 0., 0.)),
+                XAxis,
+                UnitVec3(Vec3(0., 1., 0.)),
+                YAxis),
+            Vec3(4.5, 2., 0.)),
+        Transform(
+            Rotation().setRotationFromTwoAxes(
+                UnitVec3(Vec3(0., -1., 0.)),
+                XAxis,
+                UnitVec3(Vec3(1., 0., 0.)),
+                YAxis),
+            Vec3(5.5, 1., 0.)));
+    assertCurveSegmentFrenetFrames(
+        CableSpanObstacleIndex(2),
+        Transform(
+            Rotation().setRotationFromTwoAxes(
+                UnitVec3(Vec3(0., -1., 0.)),
+                XAxis,
+                UnitVec3(Vec3(1., 0., 0.)),
+                YAxis),
+            Vec3(5.5, -2., 0.)),
+        Transform(
+            Rotation().setRotationFromTwoAxes(
+                UnitVec3(Vec3(-1., 0., 0.)),
+                XAxis,
+                UnitVec3(Vec3(0., -1., 0.)),
+                YAxis),
+            Vec3(4., -3.5, 0.)));
+    assertCurveSegmentFrenetFrames(
+        CableSpanObstacleIndex(3),
+        Transform(
+            Rotation().setRotationFromTwoAxes(
+                UnitVec3(Vec3(-1., 0., 0.)),
+                XAxis,
+                UnitVec3(Vec3(0., -1., 0.)),
+                YAxis),
+            Vec3(-2., -3.5, 0.)),
+        Transform(
+            Rotation().setRotationFromTwoAxes(
+                UnitVec3(Vec3(0., 1., 0.)),
+                XAxis,
+                UnitVec3(Vec3(-1., 0., 0.)),
+                YAxis),
+            Vec3(-4., -1.5, 0.)));
+
+    Vector_<SpatialVec> expectedBodyForcesInG(5, {{0., 0., 0.}, {0., 0., 0.}});
+    // Ground body - Sphere and cylinder are connected to it.
+    expectedBodyForcesInG[0] = (SpatialVec{{0., 0., 1.5}, {0., 2., 0.}});
+    // Cable origin body.
+    expectedBodyForcesInG[1] = (SpatialVec{{0., 0., 0.}, {0., 1., 0.}});
+    // Cable termination body.
+    expectedBodyForcesInG[2] = (SpatialVec{{0., 0., 0.}, {0., -1., 0.}});
+    // Torus body.
+    expectedBodyForcesInG[3] = (SpatialVec{{0., 0., 8.}, {1., -1., 0.}});
+    // Ellipsoid body.
+    expectedBodyForcesInG[4] = (SpatialVec{{0., 0., 0.5}, {-1., -1., 0.}});
+
+    const Real tension = Pi;
+    Vector_<SpatialVec> gotBodyForcesInG(5, {{0., 0., 0.}, {0., 0., 0.}});
+    cable.applyBodyForces(s, tension, gotBodyForcesInG);
+
+    for (int i = 0; i < gotBodyForcesInG.size(); ++i) {
+        const Real tolerance = 1e-5;
+        SimTK_ASSERT1_ALWAYS(
+            (expectedBodyForcesInG[i] * tension - gotBodyForcesInG[i]).norm() <
+                tolerance,
+            "Unexpected force applied to body %i",
+            i);
+    }
+}
+
+/** Test computed cable path over all supported surfaces, testing geodesics,
+Jacobians, and kinematics.
+
+The cable wraps over (in order):
+1. Torus,
+2. Ellipsoid,
+3. Sphere,
+4. Cylinder,
+5. Bicubic patch,
+6. Torus.
+
+The flag assertCableLengthDerivative is used to switch between verifying that
+the computed cable length derivative matches the change in length during
+simulation, OR verifying that all computed geodesics and Jacobians are
+correct. Doing both requires too much time. **/
+void testAllSurfaceKinds(bool assertCableLengthDerivative)
+{
+    const bool show = false;
+
+    // Create the system.
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    // A dummy body.
+    Body::Rigid aBody(MassProperties(1., Vec3(0), Inertia(1)));
+
+    // Mobilizer for path origin.
+    MobilizedBody::Translation cableOriginBody(
+        matter.Ground(),
+        Vec3(-8., 0.1, 0.),
+        aBody,
+        Transform());
+
+    // Mobilizer for path termination.
+    MobilizedBody::Translation cableTerminationBody(
+        matter.Ground(),
+        Transform(Vec3(20., 1.0, -1.)),
+        aBody,
+        Transform());
+
+    // Construct a new cable.
+    CableSpan cable(
+        cables,
+        cableOriginBody,
+        Vec3{0.},
+        cableTerminationBody,
+        Vec3{0.});
+    cable.setCurveSegmentAccuracy(1e-9);
+    cable.setSmoothnessTolerance(1e-4);
+
+    // Add initial torus obstacle.
+    cable.addObstacle(
+        matter.Ground(),
+        Transform(Rotation(0.5 * Pi, YAxis), Vec3{-4., 0., 0.}),
+        std::shared_ptr<ContactGeometry>(new ContactGeometry::Torus(1., 0.2)),
+        {0.1, 0.2, 0.});
+
+    // Add ellipsoid obstacle.
+    cable.addObstacle(
+        matter.Ground(),
+        Transform(Vec3{-2., 0., 0.}),
+        std::shared_ptr<ContactGeometry>(
+            new ContactGeometry::Ellipsoid({1.5, 2.6, 1.})),
+        {0.0, 0., 1.1});
+
+    // Add sphere obstacle.
+    cable.addObstacle(
+        matter.Ground(),
+        Transform(Vec3{2., 0., 0.}),
+        std::shared_ptr<ContactGeometry>(new ContactGeometry::Sphere(1.)),
+        {0.1, 1.1, 0.});
+
+    // Add cylinder obstacle.
+    cable.addObstacle(
+        matter.Ground(),
+        Transform(Rotation(0.5 * Pi, XAxis), Vec3{5., 0., 0.}),
+        std::shared_ptr<ContactGeometry>(new ContactGeometry::Cylinder(1.)),
+        Vec3{0., -1., 0.});
+
+    // Add bicubic surface obstacle.
+    {
+        Real patchScaleX = 2.0;
+        Real patchScaleY = 2.0;
+        Real patchScaleF = 0.75;
+
+        constexpr int Nx = 4;
+        constexpr int Ny = 4;
+
+        const Real xData[Nx] = {-2, -1, 1, 2};
+        const Real yData[Ny] = {-2, -1, 1, 2};
+
+        const Real fData[Nx * Ny] =
+            {2, 3, 3, 1, 0, 1.5, 1.5, 0, 0, 1.5, 1.5, 0, 2, 3, 3, 1};
+
+        const Vector x_(Nx, xData);
+        const Vector y_(Ny, yData);
+        const Matrix f_(Nx, Ny, fData);
+
+        Vector x = patchScaleX * x_;
+        Vector y = patchScaleY * y_;
+        Matrix f = patchScaleF * f_;
+
+        BicubicSurface patch(x, y, f, 0);
+        Transform patchTransform(
+            Rotation(0.5 * Pi, Vec3(0., 0., 1.)),
+            Vec3(10., 0., -1.));
+
+        cable.addObstacle(
+            matter.Ground(),
+            patchTransform,
+            std::shared_ptr<const ContactGeometry>(
+                new ContactGeometry::SmoothHeightMap(patch)),
+            Vec3{0., 0., 1.});
+    }
+
+    // Add final torus obstacle.
+    cable.addObstacle(
+        matter.Ground(),
+        Transform(Rotation(0.5 * Pi, YAxis), Vec3{14., 0., 0.}),
+        std::shared_ptr<ContactGeometry>(new ContactGeometry::Torus(1., 0.2)),
+        {0.1, 0.2, 0.});
+
+    // Optionally visualize the system.
+    system.setUseUniformBackground(true); // no ground plane in display
+    std::unique_ptr<Visualizer> viz(show ? new Visualizer(system) : nullptr);
+
+    if (viz) {
+        viz->setShowFrameNumber(true);
+        viz->addDecorationGenerator(new CableDecorator(system, cable));
+    }
+
+    // Initialize the system and state.
+    system.realizeTopology();
+    State s = system.getDefaultState();
+
+    // Use this to assert cable length time derivative.
+    Real prevCableLength = NaN;
+
+    // Let the cable end points be parameterized by an angle, and draw the path
+    // for different angles. If we want to check the CableSpan::lengthDot we
+    // will use a smaller stepsize, and smaller final angle, and not run
+    // CableSubsystemTestHelper on each computed path.
+    const Real dAngle     = assertCableLengthDerivative ? 1e-4 : 0.05;
+    const Real finalAngle = assertCableLengthDerivative ? 0.5 * Pi : 2. * Pi;
+    for (Real angle = 0.; angle < finalAngle; angle += dAngle) {
+
+        // Move the cable end points.
+        cableOriginBody.setQ(
+            s,
+            Vec3(
+                1.1 * sin(angle),
+                5. * sin(angle * 1.5),
+                5. * sin(angle * 2.)));
+        cableOriginBody.setU(
+            s,
+            Vec3(
+                1.1 * cos(angle),
+                5. * 1.5 * cos(angle * 1.5),
+                5. * 2. * cos(angle * 2.)));
+        cableTerminationBody.setQ(
+            s,
+            Vec3(
+                0.1 * sin(angle),
+                2. * sin(angle * 0.7),
+                5. * sin(angle * 1.3)));
+        cableTerminationBody.setU(
+            s,
+            Vec3(
+                0.1 * cos(angle),
+                2. * 0.7 * cos(angle * 0.7),
+                5. * 1.3 * cos(angle * 1.3)));
+
+        // Compute the CableSpan's path.
+        system.realize(s, Stage::Report);
+        const Real cableLength = cable.calcLength(s);
+        if (viz) {
+            viz->report(s);
+        }
+
+        // Check that the geodesics and path error vector & Jacobian are
+        // correct.
+        if (!assertCableLengthDerivative) {
+            CableSubsystemTestHelper().testCurrentPath(s, cables, std::cout);
+        }
+
+        // Assert length derivative using the change in length.
+        if (assertCableLengthDerivative && !isNaN(prevCableLength)) {
+            const Real tolerance = 5e-3;
+            const Real expectedCableLengthDot =
+                (cableLength - prevCableLength) / dAngle;
+            const Real gotCableLengthDot = cable.calcLengthDot(s);
+            SimTK_ASSERT4_ALWAYS(
+                std::abs(gotCableLengthDot - expectedCableLengthDot) <
+                    tolerance,
+                "Test failed: Cable length dot (=%f) does not match expected cable length dot (=%f), with error %f, at angle %f",
+                gotCableLengthDot,
+                expectedCableLengthDot,
+                gotCableLengthDot - expectedCableLengthDot,
+                angle);
+        }
+
+        // Total cable length should be longer than direct distance between the
+        // cable endpoints.
+        const Real distanceBetweenEndPoints =
+            (cableTerminationBody.getBodyOriginLocation(s) -
+             cableOriginBody.getBodyOriginLocation(s))
+                .norm();
+        SimTK_ASSERT2_ALWAYS(
+            cableLength > distanceBetweenEndPoints,
+            "Test failed: Cable length (=%f) smaller than distance between end points (=%f)",
+            cableLength,
+            distanceBetweenEndPoints);
+
+        // Make sure that we acutally solved the path up to tolerance.
+        SimTK_ASSERT2_ALWAYS(
+            cable.getSmoothness(s) <= cable.getSmoothnessTolerance(),
+            "Test failed: Cable smoothness (=%e) must be smaller than set tolerance (=%e)",
+            cable.getSmoothness(s),
+            cable.getSmoothnessTolerance());
+
+        prevCableLength = cableLength;
+    }
+    std::cout
+        << "PASSED TEST: testAllSurfaceKinds (assertCableLengthDerivative = "
+        << assertCableLengthDerivative << std::endl;
+}
+
+/** CableSpan touchdown and liftoff test.
+
+Create a simple touchdown and liftoff case on a:
+- torus,
+- ellipsoid,
+- sphere,
+- cylinder.
+
+A cable is spanned over each obstacle individually, so there are 4 cables, each
+with one obstacle. **/
+void testTouchdownAndLiftoff()
+{
+    const bool show = false;
+
+    // Create the system.
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    // A dummy body.
+    Body::Rigid aBody(MassProperties(1., Vec3(0), Inertia(1)));
+
+    // Helper for creating a cable with a single obstacle at a certain offset location.
+    auto createCable =
+        [&](const std::function<ContactGeometry*()>& createSurface,
+            const Transform& X_BS, const Transform& sceneOffset)
+    {
+        // Mobilizer for path origin.
+        MobilizedBody::Translation cableOriginBody(
+            matter.Ground(),
+            sceneOffset.shiftFrameStationToBase(Vec3(-2., 0., 0.)),
+            aBody,
+            Transform());
+
+        // Mobilizer for path termination.
+        MobilizedBody::Translation cableTerminationBody(
+            matter.Ground(),
+            sceneOffset.shiftFrameStationToBase(Vec3(2., 0., 0.)),
+            aBody,
+            Transform());
+
+        CableSpan cable(
+            cables,
+            cableOriginBody,
+            Vec3{0.},
+            cableTerminationBody,
+            Vec3{0.});
+        cable.setCurveSegmentAccuracy(1e-12);
+        cable.setSmoothnessTolerance(1e-6);
+
+        cable.addObstacle(
+            matter.Ground(),
+            sceneOffset.compose(
+            X_BS),
+            std::shared_ptr<ContactGeometry>(createSurface()));
+    };
+
+    // Create a cable with a torus obstacle.
+    createCable(
+        [&]() { return new ContactGeometry::Torus(2., 0.25); },
+        Transform(Rotation(0.5 * Pi, YAxis), Vec3{0., 1.75, 0.}),
+        Transform(Vec3(0., 2., 0.)));
+
+    // Create a cable with an ellipsoid obstacle.
+    createCable(
+        [&]() { return new ContactGeometry::Ellipsoid({1., 0.5, 0.75}); },
+        Transform(Vec3{0., -0.5, 0.}),
+        Transform(Vec3(0., 0., 0.)));
+
+    // Create a cable with a sphere obstacle.
+    createCable(
+        [&]() { return new ContactGeometry::Sphere(1.5); },
+        Transform(Vec3{0., -1.5, 0.}),
+        Transform(Vec3(0., -2., 0.)));
+
+    // Create a cable with a cylinder obstacle.
+    createCable(
+        [&]() { return new ContactGeometry::Cylinder(2.); },
+        Transform(Vec3{0., -2., 0.}),
+        Transform(Vec3(0., -6., 0.)));
+
+    // Optionally visualize the system.
+    system.setUseUniformBackground(true); // no ground plane in display
+    std::unique_ptr<Visualizer> viz(show ? new Visualizer(system) : nullptr);
+    if (viz) {
+        viz->setShowFrameNumber(true);
+        for (CableSpanIndex cableIx(0); cableIx < cables.getNumCables();
+             ++cableIx) {
+            viz->addDecorationGenerator(
+                new CableDecorator(system, cables.getCable(cableIx)));
+        }
+    }
+
+    // Initialize the system and state.
+    system.realizeTopology();
+    State s = system.getDefaultState();
+
+    SimTK_ASSERT1_ALWAYS(
+        cables.getNumCables() == 4,
+        "Unexpected number of cables (=%i)",
+        cables.getNumCables());
+
+    for (Real angle = 1e-2; angle < 4. * Pi; angle += 0.02) {
+        // Move the cable end points.
+        const Real yCoord = 0.1 * sin(angle);
+        for (CableSpanIndex cableIx(0); cableIx < cables.getNumCables();
+             ++cableIx) {
+            matter
+                .getMobilizedBody(cables.getCable(cableIx).getOriginBodyIndex())
+                .setQToFitTranslation(s, Vec3(0., yCoord, 0.));
+            matter
+                .getMobilizedBody(cables.getCable(cableIx).getTerminationBodyIndex())
+                .setQToFitTranslation(s, Vec3(0., yCoord, 0.));
+        }
+
+        system.realize(s, Stage::Report);
+
+        // All obstacles are positioned such that for negative yCoord of the
+        // endpoints, the cable touches down on the obstacle.
+        for (CableSpanIndex cableIx(0); cableIx < cables.getNumCables();
+             ++cableIx) {
+            cables.getCable(cableIx).calcLength(s);
+            const bool gotContactStatus =
+                cables.getCable(cableIx).isInContactWithObstacle(
+                    s,
+                    CableSpanObstacleIndex(0));
+            const bool expectedContactStatus = yCoord < 0.;
+            SimTK_ASSERT4_ALWAYS(
+                gotContactStatus == expectedContactStatus,
+                "Cable %i expected contact status (=%i) does not match computed contact status (=%i) at yCoord = %f",
+                cableIx,
+                expectedContactStatus,
+                gotContactStatus,
+                angle);
+        }
+
+        if (viz) {
+            viz->report(s);
+        }
+    }
+}
+
+int main()
+{
+    testSimpleCable();
+    testTouchdownAndLiftoff();
+    testAllSurfaceKinds(false); // Test all geodesics and Jacobians.
+    testAllSurfaceKinds(true);  // Test length derivative.
+}

--- a/Simbody/tests/TestCableSpan_Forces.cpp
+++ b/Simbody/tests/TestCableSpan_Forces.cpp
@@ -1,0 +1,228 @@
+/*-----------------------------------------------------------------------------
+                Simbody(tm) Test: Cable Forces
+-------------------------------------------------------------------------------
+ Copyright (c) 2024 Authors.
+ Authors: Pepijn van den Bos
+ Contributors:
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may
+ not use this file except in compliance with the License. You may obtain a
+ copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ----------------------------------------------------------------------------*/
+
+#include "Simbody.h"
+
+using namespace SimTK;
+
+/**
+This file contains simple tests for checking computed forces and moments.
+**/
+
+// Helper function for the force assertion.
+void assertForces(
+    MultibodySystem& system,
+    CableSpan& cable,
+    const Vector_<SpatialVec>& expectedBodyForcesInG)
+{
+    cable.setCurveSegmentAccuracy(1e-12);
+    cable.setSmoothnessTolerance(1e-8);
+
+    // Initialize the system and state.
+    system.realizeTopology();
+    State s = system.getDefaultState();
+    system.realize(s, Stage::Report);
+
+    const int numBodies = system.getMatterSubsystem().getNumBodies();
+    Vector_<SpatialVec> forces(numBodies, SpatialVec{Vec3{0.}, Vec3{0.}});
+    cable.applyBodyForces(s, 1., forces);
+
+    SimTK_ASSERT2_ALWAYS(
+        expectedBodyForcesInG.size() == numBodies,
+        "Size of expected forces (=%i) does not match number of bodies (=%i)",
+        expectedBodyForcesInG.size(),
+        numBodies);
+
+    for (int i = 0; i < numBodies; ++i) {
+        SimTK_ASSERT1_ALWAYS(
+            (forces[i] - expectedBodyForcesInG[i]).norm() < 1e-13,
+            "Test failed: force error = %e",
+            (forces[i] - expectedBodyForcesInG[i]).norm());
+    }
+}
+
+// A cable with both end points on the same body, and no obstacles, should
+// result in zero net force.
+void testCableForceOnSameBody()
+{
+    // Create the system.
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    // Construct a new cable.
+    CableSpan cable(
+        cables,
+        matter.Ground(),
+        Vec3{0., 1., 0.},
+        matter.Ground(),
+        Vec3{1., 1., 0.});
+
+    // The expected result.
+    const Vector_<SpatialVec> expectedBodyForcesInG(
+        1,
+        SpatialVec(Vec3{0.}, Vec3{0.}));
+    assertForces(system, cable, expectedBodyForcesInG);
+}
+
+// A cable spanned between two bodies, and no obstacles, should result in a
+// force pulling them towards each other.
+void testCableForceBetweenTwoBodies()
+{
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    Body::Rigid aBody(MassProperties(1., Vec3(0), Inertia(1)));
+
+    MobilizedBody::Free cableOriginBody(
+        matter.Ground(),
+        Vec3(1., 0., 0.),
+        aBody,
+        Transform());
+
+    CableSpan cable(
+        cables,
+        matter.Ground(),
+        Vec3{0.},
+        cableOriginBody,
+        Vec3{0., 0., 0.});
+
+    Vector_<SpatialVec> expectedBodyForcesInG(matter.getNumBodies());
+    expectedBodyForcesInG[0] = SpatialVec(Vec3{0.}, Vec3{1., 0., 0.});
+    expectedBodyForcesInG[1] = SpatialVec(Vec3{0.}, Vec3{-1., 0., 0.});
+    assertForces(system, cable, expectedBodyForcesInG);
+}
+
+// Consider a cable spanned between two bodies and no obstacles: If the
+// attachment point is not at the body origin, it should generate a moment on
+// the body.
+void testCableForceAndMomentBetweenTwoBodies()
+{
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    Body::Rigid aBody(MassProperties(1., Vec3(0), Inertia(1)));
+
+    MobilizedBody::Free cableOriginBody(
+        matter.Ground(),
+        Vec3(1., -2., 0.),
+        aBody,
+        Transform());
+
+    CableSpan cable(
+        cables,
+        matter.Ground(),
+        Vec3{0.},
+        cableOriginBody,
+        Vec3{0., 2., 0.});
+
+    Vector_<SpatialVec> expectedBodyForcesInG(matter.getNumBodies());
+    expectedBodyForcesInG[0] = SpatialVec(Vec3{0.}, Vec3{1., 0., 0.});
+    expectedBodyForcesInG[1] = SpatialVec(Vec3{0., 0., 2.}, Vec3{-1., 0., 0.});
+    assertForces(system, cable, expectedBodyForcesInG);
+}
+
+// Sling shot case: A cable with both attachment points fixed in Ground, along
+// the Y-axis, and a sphere obstacle which is pulled along the X-axis should
+// generate a force on the obstacle.
+void testCableForceOnSingleObstacle()
+{
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    // Sphere obstacle radius.
+    const Real radius = 1.;
+
+    Body::Rigid aBody(MassProperties(1., Vec3(0), Inertia(1)));
+    MobilizedBody::Free obstacleBody(
+        matter.Ground(),
+        Vec3(radius, 0., 0.),
+        aBody,
+        Transform());
+
+    CableSpan cable(
+        cables,
+        matter.Ground(),
+        Vec3{0., radius, 0.},
+        matter.Ground(),
+        Vec3{0., -radius, 0.});
+
+    // Add sphere obstacle.
+    cable.addObstacle(
+        obstacleBody,
+        Transform(),
+        std::shared_ptr<ContactGeometry>(new ContactGeometry::Sphere(radius)),
+        Vec3(radius, 0., 0.));
+
+    Vector_<SpatialVec> forcesExpected(matter.getNumBodies());
+    forcesExpected[0] = SpatialVec(Vec3{0.}, Vec3{2., 0., 0.});
+    forcesExpected[1] = SpatialVec(Vec3{0., 0., 0.}, Vec3{-2., 0., 0.});
+
+    assertForces(system, cable, forcesExpected);
+}
+
+// Consider a single sphere obstacle, with an offset between the obstacle
+// surface frame and obstacle body, to verify the generated torque.
+void testCableForceAndMomentOnSingleObstacle()
+{
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    Body::Rigid aBody(MassProperties(1., Vec3(0), Inertia(1)));
+
+    const Real radius  = 1.;
+    const Real offsetY = 1.;
+
+    MobilizedBody::Free obstacleBody(
+        matter.Ground(),
+        Vec3(radius, -offsetY, 0.),
+        aBody,
+        Transform());
+
+    CableSpan cable(
+        cables,
+        matter.Ground(),
+        Vec3{0., radius, 0.},
+        matter.Ground(),
+        Vec3{0., -radius, 0.});
+
+    cable.addObstacle(
+        obstacleBody,
+        Transform(Vec3(0., offsetY, 0.)),
+        std::shared_ptr<ContactGeometry>(new ContactGeometry::Sphere(radius)),
+        Vec3(radius, 0., 0.));
+
+    Vector_<SpatialVec> forcesExpected(matter.getNumBodies());
+    forcesExpected[0] = SpatialVec(Vec3{0.}, Vec3{2., 0., 0.});
+    forcesExpected[1] = SpatialVec(Vec3{0., 0., 2.}, Vec3{-2., 0., 0.});
+
+    assertForces(system, cable, forcesExpected);
+}
+
+int main()
+{
+    testCableForceOnSameBody();
+    testCableForceBetweenTwoBodies();
+    testCableForceAndMomentBetweenTwoBodies();
+    testCableForceOnSingleObstacle();
+    testCableForceAndMomentOnSingleObstacle();
+}

--- a/Simbody/tests/TestCableSpan_LengthDot.cpp
+++ b/Simbody/tests/TestCableSpan_LengthDot.cpp
@@ -1,0 +1,285 @@
+/*-----------------------------------------------------------------------------
+                Simbody(tm) Test: Cable Forces
+-------------------------------------------------------------------------------
+ Copyright (c) 2024 Authors.
+ Authors: Pepijn van den Bos
+ Contributors:
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may
+ not use this file except in compliance with the License. You may obtain a
+ copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ----------------------------------------------------------------------------*/
+
+#include "Simbody.h"
+
+using namespace SimTK;
+
+/**
+This file contains simple tests for checking computed forces and moments.
+**/
+
+// Helper function for the force assertion.
+void assertLengthDot(
+    const std::string& testCase,
+    MultibodySystem& system,
+    CableSpan& cable,
+    const std::function<void(State& s)>& setU,
+    Real expectedLengthDot)
+{
+    cable.setCurveSegmentAccuracy(1e-12);
+    cable.setSmoothnessTolerance(1e-8);
+
+    // Initialize the system and state.
+    system.realizeTopology();
+    State s = system.getDefaultState();
+    setU(s);
+    system.realize(s, Stage::Report);
+
+    const Real gotLengthDot = cable.calcLengthDot(s);
+
+    for (CableSpanObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
+        SimTK_ASSERT2_ALWAYS(
+            cable.isInContactWithObstacle(s, ix),
+            "%s failed: Cable not in contact with obstacle %i",
+            testCase.c_str(),
+            ix);
+    }
+
+    SimTK_ASSERT4_ALWAYS(
+        std::abs(gotLengthDot - expectedLengthDot) < 1e-13,
+        "%s failed: expected lengthDot (=%f) does not match computed "
+        "lengthDot (=%f), with error %e",
+        testCase.c_str(),
+        expectedLengthDot,
+        gotLengthDot,
+        expectedLengthDot - gotLengthDot);
+}
+
+// A cable with both end points on the same body, and no obstacles, should
+// result in zero lengthening speed.
+void testCableLengthDotOnSameBody()
+{
+    // Create the system.
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    Body::Rigid aBody(MassProperties(1., Vec3(0), Inertia(1)));
+    MobilizedBody::Free aMovingBody(
+        matter.Ground(),
+        Vec3(0., 0., 0.),
+        aBody,
+        Transform());
+
+    // Construct a new cable.
+    CableSpan cable(
+        cables,
+        aMovingBody,
+        Vec3(-1., 0., 0.),
+        aMovingBody,
+        Vec3(0., 1., 0.));
+
+    // Moving body velocity:
+    const Vec6 u{
+        // angular velocity
+        1., 2., 3.,
+        // linear velocity
+        4., 5., 6.,
+    };
+    const Real expectedLengthDot = 0.;
+
+    assertLengthDot(
+        "testCableLengthDotOnSameBody",
+        system,
+        cable,
+        [&](State& s) { aMovingBody.setU(s, u); },
+        expectedLengthDot);
+}
+
+// A cable with both end points on the same body, and two obstacles on that
+// body, should result in zero lengthening speed.
+void testCableLengthDotOnSameBodyWitObstacles()
+{
+    // Create the system.
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    Body::Rigid aBody(MassProperties(1., Vec3(0), Inertia(1)));
+    MobilizedBody::Free aMovingBody(
+        matter.Ground(),
+        Transform(),
+        aBody,
+        Transform());
+
+    // Construct a new cable.
+    CableSpan cable(
+        cables,
+        aMovingBody,
+        Vec3(2., 0., 0.),
+        aMovingBody,
+        Vec3(-2., 0., 0.));
+
+    cable.addObstacle(
+        aMovingBody,
+        Transform(Vec3(1., 1., 0.)),
+        std::shared_ptr<ContactGeometry>(new ContactGeometry::Sphere(1.)),
+        Vec3(1., 1., 0.));
+
+    cable.addObstacle(
+        aMovingBody,
+        Transform(Vec3(-1., 1., 0.)),
+        std::shared_ptr<ContactGeometry>(
+            new ContactGeometry::Ellipsoid(Vec3{0.5, 0.75, 1.})),
+        Vec3(-1., 1., 0.));
+
+    const Vec6 u{
+        1., 2., 3.,
+        4., 5., 6.,
+    };
+    const Real expectedLengthDot = 0.;
+
+    assertLengthDot(
+        "testCableLengthDotOnSameBodyWitObstacles",
+        system,
+        cable,
+        [&](State& s) { aMovingBody.setU(s, u); },
+        expectedLengthDot);
+}
+
+// Consider a cable spanned between two bodies and no obstacles. Verify
+// lengthening speed for different body velocities.
+void testCableLengthDotBetweenTwoBodies()
+{
+    // Create the system.
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    Body::Rigid aBody(MassProperties(1., Vec3(0), Inertia(1)));
+    MobilizedBody::Free aMovingBody(
+        matter.Ground(),
+        Vec3(1., -2., 0.),
+        aBody,
+        Transform());
+
+    // Construct a new cable.
+    CableSpan cable(
+        cables,
+        matter.Ground(),
+        Vec3(0., 0., 0.),
+        aMovingBody,
+        Vec3(0., 2., 0.));
+
+    // Translation only.
+    {
+        const Vec6 u{
+            0., 0., 0.,
+            4., 5., 6.,
+        };
+        // Since the cable direction is along the XAxis:
+        const Real expectedLengthDot = u[3];
+
+        assertLengthDot(
+            "testCableLengthDotBetweenTwoBodies(Translation)",
+            system,
+            cable,
+            [&](State& s) { aMovingBody.setU(s, u); },
+            expectedLengthDot);
+    }
+
+    // Rotation only.
+    {
+        const Vec6 u{
+            0., 1., 2.,
+            0., 0., 0.,
+        };
+        // Cross the angular rate with the attachment point offset.
+        const Real expectedLengthDot = -2. * 2.;
+
+        assertLengthDot(
+            "testCableLengthDotBetweenTwoBodies(Rotation)",
+            system,
+            cable,
+            [&](State& s) { aMovingBody.setU(s, u); },
+            expectedLengthDot);
+    }
+
+    // Both.
+    {
+        const Vec6 u{
+            0., 1., 2.,
+            4., 5., 6.,
+        };
+        const Real expectedLengthDot = 0.;
+
+        assertLengthDot(
+            "testCableLengthDotBetweenTwoBodies(Both)",
+            system,
+            cable,
+            [&](State& s) { aMovingBody.setU(s, u); },
+            expectedLengthDot);
+    }
+}
+
+// Sling shot case: A cable with both attachment points fixed in Ground, along
+// the Y-axis, and a sphere obstacle which is pulled along the X-axis. The
+// velocity of the obstacle should double the lengthening speed of the cable.
+void testCableLengthDotWithSingleObstacle()
+{
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    // Sphere obstacle radius.
+    const Real radius = 1.;
+
+    Body::Rigid aBody(MassProperties(1., Vec3(0), Inertia(1)));
+    MobilizedBody::Free aMovingBody(
+        matter.Ground(),
+        Vec3(radius, 0., 0.),
+        aBody,
+        Transform());
+
+    // Construct a new cable.
+    CableSpan cable(
+        cables,
+        matter.Ground(),
+        Vec3{0., radius, 0.},
+        matter.Ground(),
+        Vec3{0., -radius, 0.});
+
+    // Add sphere obstacle.
+    cable.addObstacle(
+        aMovingBody,
+        Transform(),
+        std::shared_ptr<ContactGeometry>(new ContactGeometry::Sphere(radius)),
+        Vec3(radius, 0., 0.));
+
+    const Vec6 u{
+        1., 2., 3.,
+        4., 5., 6.,
+    };
+    const Real expectedLengthDot = 2. * 4.;
+
+    assertLengthDot(
+        "testCableLengthDotBetweenTwoBodies(Both)",
+        system,
+        cable,
+        [&](State& s) { aMovingBody.setU(s, u); },
+        expectedLengthDot);
+}
+
+int main()
+{
+    testCableLengthDotOnSameBody();
+    testCableLengthDotOnSameBodyWitObstacles();
+    testCableLengthDotBetweenTwoBodies();
+    testCableLengthDotWithSingleObstacle();
+}

--- a/examples/ExampleCableSpan.cpp
+++ b/examples/ExampleCableSpan.cpp
@@ -1,0 +1,307 @@
+/*-----------------------------------------------------------------------------
+                Simbody(tm) Example: Cable Over Smooth Surfaces
+-------------------------------------------------------------------------------
+ Copyright (c) 2024 Authors.
+ Authors: Pepijn van den Bos
+ Contributors:
+
+ Licensed under the Apache License, Version 2.0 (the "License"); you may
+ not use this file except in compliance with the License. You may obtain a
+ copy of the License at http://www.apache.org/licenses/LICENSE-2.0.
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ ----------------------------------------------------------------------------*/
+
+/* This example is for experimenting with a CableSpan over obstacle surfaces.
+The cable endpoints are manually repositioned to control the next path
+solving problem. */
+
+#include "Simbody.h"
+#include "simbody/internal/CableSpan.h"
+#include <iostream>
+
+using namespace SimTK;
+
+// A helper class for printing interesting cable outputs.
+class ShowStuff : public PeriodicEventReporter {
+public:
+    ShowStuff(const CableSubsystem& cables, Real interval) :
+        PeriodicEventReporter(interval), m_cables(cables)
+    {}
+
+    static void showHeading(std::ostream& o)
+    {
+        printf(
+            "%10s %10s %10s %10s",
+            "Cable index",
+            "iterations",
+            "path error",
+            "length");
+    }
+
+    /** This is the implementation of the EventReporter virtual. **/
+    void handleEvent(const State& s) const override
+    {
+        for (CableSpanIndex cableIx(0); cableIx < m_cables.getNumCables();
+             ++cableIx) {
+            const CableSpan& cable = m_cables.getCable(cableIx);
+            printf(
+                "%d %d %g %g",
+                static_cast<int>(cableIx),
+                cable.getNumSolverIterations(s),
+                cable.getSmoothness(s),
+                cable.calcLength(s));
+        }
+    }
+
+private:
+    const CableSubsystem& m_cables;
+};
+
+/* A helper class for drawing interesting things of a CableSpan. */
+class CableDecorator : public SimTK::DecorationGenerator {
+public:
+    CableDecorator(MultibodySystem& mbs, const CableSpan& cable) :
+        m_mbs(&mbs), m_cable(cable)
+    {
+        for (CableSpanObstacleIndex ix(0); ix < m_cable.getNumObstacles();
+             ++ix) {
+            m_obstacleDecorations.push_back(
+                m_cable.getObstacleContactGeometry(ix)
+                    .createDecorativeGeometry()
+                    .setResolution(3));
+            m_obstacleDecorationsOffsets.push_back(
+                m_obstacleDecorations.back().getTransform());
+        }
+    }
+
+    virtual void generateDecorations(
+        const State& state,
+        Array_<DecorativeGeometry>& decorations) override
+    {
+        for (CableSpanObstacleIndex ix(0); ix < m_cable.getNumObstacles();
+             ++ix) {
+            // Draw the obstacle surface.
+            // Green if cable is in contact with surface, grey otheriwse.
+            const ContactGeometry& geometry =
+                m_cable.getObstacleContactGeometry(ix);
+            const bool isInContactWithSurface =
+                m_cable.isInContactWithObstacle(state, ix);
+            const Vec3 color   = isInContactWithSurface ? Yellow : Gray;
+            const Real opacity = isInContactWithSurface ? 1. : 0.25;
+            Transform X_GB =
+                m_mbs->getMatterSubsystem()
+                    .getMobilizedBody(m_cable.getObstacleMobilizedBodyIndex(ix))
+                    .getBodyTransform(state);
+            const Transform X_GS =
+                X_GB.compose(m_cable.getObstacleTransformSurfaceToBody(ix));
+
+            const Transform X_SD = m_obstacleDecorationsOffsets.at(ix);
+            const Transform X_GD = X_GS.compose(X_SD);
+            // Draw the obstacle's local frame.
+            // This is the frame that you define the contact point hint in.
+            decorations.push_back(
+                DecorativeFrame(0.5).setTransform(X_GS).setColor(Purple));
+            // Draw the obstacle contact geometry.
+            decorations.push_back(m_obstacleDecorations.at(ix)
+                                      .setTransform(X_GD)
+                                      .setColor(color)
+                                      .setOpacity(opacity));
+
+            // Draw the initial contact point hints (these are user-defined) as
+            // an orange line with a point.
+            const Vec3 x_PS = m_cable.getObstacleContactPointHint(ix);
+            decorations.push_back(
+                DecorativeLine(X_GS.p(), X_GS.shiftFrameStationToBase(x_PS))
+                    .setColor(Orange)
+                    .setLineThickness(3));
+            decorations.push_back(
+                DecorativePoint(X_GS.shiftFrameStationToBase(x_PS))
+                    .setColor(Orange));
+
+            // Only draw curve segment related decorations if the cable is in
+            // contact with the corresponding obstacle.
+            if (!isInContactWithSurface) {
+                continue;
+            }
+
+            // Draw a fixed number of sphere points per curve segment.
+            const int numDecorativePoints = 4;
+            m_cable.calcCurveSegmentResampledPoints(
+                state,
+                ix,
+                numDecorativePoints,
+                [&](Vec3 x_G)
+                {
+                    decorations.push_back(
+                        DecorativeSphere(0.1).setTransform(x_G).setColor(Blue));
+                });
+
+            // Draw the Frenet frames at the geodesic boundary points.
+            decorations.push_back(DecorativeFrame(0.2).setTransform(
+                m_cable.calcCurveSegmentInitialFrenetFrame(state, ix)));
+            decorations.push_back(DecorativeFrame(0.2).setTransform(
+                m_cable.calcCurveSegmentFinalFrenetFrame(state, ix)));
+        }
+    }
+
+    MultibodySystem* m_mbs;
+    CableSpan m_cable;
+    int m_lineThickness = 3;
+
+    Array_<DecorativeGeometry, CableSpanObstacleIndex> m_obstacleDecorations;
+    Array_<Transform, CableSpanObstacleIndex> m_obstacleDecorationsOffsets;
+};
+
+int main()
+{
+    // Create the system.
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    // A dummy body.
+    Body::Rigid aBody(MassProperties(1.0, Vec3(0), Inertia(1)));
+
+    // Mobilizer for path origin.
+    MobilizedBody::Translation cableOriginBody(
+        matter.Ground(),
+        Vec3(-8., 0.1, 0.),
+        aBody,
+        Transform());
+
+    // Mobilizer for path termination.
+    MobilizedBody::Translation cableTerminationBody(
+        matter.Ground(),
+        Transform(Vec3(20., 1.0, -1.)),
+        aBody,
+        Transform());
+
+    // Construct a new cable.
+    CableSpan cable(
+        cables,
+        cableOriginBody,
+        Vec3{0.},
+        cableTerminationBody,
+        Vec3{0.});
+
+    // Add some obstacles to the cable.
+
+    // Add torus obstacle.
+    cable.addObstacle(
+        matter.Ground(), // Obstacle mobilizer body.
+        Transform(
+            Rotation(0.5 * Pi, YAxis),
+            Vec3{-4., 0., 0.}), // Surface to body transform.
+        std::shared_ptr<ContactGeometry>(
+            new ContactGeometry::Torus(1., 0.2)), // Obstacle geometry.
+        {0.1, 0.2, 0.}                            // Initial contact point hint.
+    );
+
+    // Add ellipsoid obstacle.
+    cable.addObstacle(
+        matter.Ground(),
+        Transform(Vec3{-2., 0., 0.}),
+        std::shared_ptr<ContactGeometry>(
+            new ContactGeometry::Ellipsoid({1.5, 2.6, 1.})),
+        {0.0, 0., 1.1});
+
+    // Add sphere obstacle.
+    cable.addObstacle(
+        matter.Ground(),
+        Transform(Vec3{2., 0., 0.}),
+        std::shared_ptr<ContactGeometry>(new ContactGeometry::Sphere(1.)),
+        {0.1, 1.1, 0.});
+
+    // Add cylinder obstacle.
+    cable.addObstacle(
+        matter.Ground(),
+        Transform(Rotation(0.5 * Pi, XAxis), Vec3{5., 0., 0.}),
+        std::shared_ptr<ContactGeometry>(new ContactGeometry::Cylinder(1.)),
+        Vec3{0., -1., 0.});
+
+    // Add bicubic surface obstacle.
+    {
+        Real patchScaleX = 2.0;
+        Real patchScaleY = 2.0;
+        Real patchScaleF = 0.75;
+
+        const int Nx = 4, Ny = 4;
+
+        const Real xData[Nx] = {-2, -1, 1, 2};
+        const Real yData[Ny] = {-2, -1, 1, 2};
+
+        const Real fData[Nx*Ny] = {
+            2,    3,      3,      1,
+            0,    1.5,    1.5,    0,
+            0,    1.5,    1.5,    0,
+            2,    3,      3,      1};
+
+        const Vector x_(Nx, xData);
+        const Vector y_(Ny, yData);
+        const Matrix f_(Nx, Ny, fData);
+
+        Vector x = patchScaleX * x_;
+        Vector y = patchScaleY * y_;
+        Matrix f = patchScaleF * f_;
+
+        BicubicSurface patch(x, y, f, 0);
+        Transform patchTransform(
+            Rotation(0.5 * Pi, Vec3(0., 0., 1.)),
+            Vec3(10., 0., -1.));
+
+        // Draw wire frame on surface patch.
+        /* PolygonalMesh patchMesh = patch.createPolygonalMesh(10); */
+        /* matter.Ground().addBodyDecoration( */
+        /*     patchTransform, */
+        /*     DecorativeMesh(patchMesh) */
+        /*         .setColor(Cyan) */
+        /*         .setOpacity(.75) */
+        /*         .setRepresentation(DecorativeGeometry::DrawWireframe)); */
+
+        cable.addObstacle(
+            matter.Ground(),
+            patchTransform,
+            std::shared_ptr<const ContactGeometry>(
+                new ContactGeometry::SmoothHeightMap(patch)),
+            Vec3{0., 0., 1.});
+    }
+
+    // Visaulize the system.
+    system.setUseUniformBackground(true); // no ground plane in display
+    Visualizer viz(system);
+    viz.addDecorationGenerator(new CableDecorator(system, cable));
+    ShowStuff showStuff(cables, 1e-3);
+
+    // Initialize the system and s.
+    system.realizeTopology();
+    State s = system.getDefaultState();
+    system.realize(s, Stage::Position);
+
+    system.realize(s, Stage::Report);
+    viz.report(s);
+    showStuff.handleEvent(s);
+
+    std::cout << "Hit ENTER ..., or q\n";
+    const char ch = getchar();
+    if (ch == 'Q' || ch == 'q') {
+        return 0;
+    }
+
+    Real angle = 0.;
+    while (true) {
+        system.realize(s, Stage::Position);
+        cable.calcLength(s);
+        viz.report(s);
+
+        // Move the cable origin.
+        angle += 0.01;
+        cableOriginBody.setQ(
+            s,
+            Vec3(sin(angle), 5. * sin(angle * 1.5), 5. * sin(angle * 2.)));
+    }
+}


### PR DESCRIPTION
# Scholz2015 Wrapping Algorithm
Implementation of a new algorithm for computing the path of a weightless, and frictionless cable spanning over multiple smooth obstacle surfaces[^fn].

[^fn]: Scholz, A., Sherman, M., Stavness, I. et al (2016). A fast multi-obstacle muscle wrapping method using natural geodesic variations. Multibody System Dynamics 36, 195–219.
## Algorithm Overview
**Creating a cable**
A new subsystem class `CableSubsystem` is added to manage the cables in a simulation:
```cpp
MultibodySystem system;
CableSubsystem cables(system);
```
A cable is represented by the new class `CableSpan`, and allows a path to be spanned between two points:
```cpp
CableSpan cable(
        cables,
        body1, Vec3(0.), // Path origin
        body2, Vec3(0.)); // Path termination
```
![a_cable](https://github.com/simbody/simbody/assets/46680867/b32e3473-4fb3-43b2-8391-64fec5f7c48f)
Obstacles can be added to the cable to make it more interesting:
```cpp
cable.addObstacle(obstacleBody, obstacleOffset, obstacleGeometry);
```
For example, we can add a torus to the scene:

https://github.com/simbody/simbody/assets/46680867/49ea834d-bf1b-49fd-9d11-b90ef7dfeb69

**Initializing the Path**
To help control the cable's path you can choose a contact point hint for each obstacle. For example, placing the contact point within the torus:
```cpp
cable.setContactPointHint(obsIndex, -torusRadius * Vec3{YAxis} / 2);
```
allows spanning the cable through the torus:
![set_contact_point_hint](https://github.com/simbody/simbody/assets/46680867/ec1ebc60-c638-4705-8df4-85da049d955d)

**Obstacle Ordering**
Currently, the order in which the cable can come into contact with the obstacle is ordered based on the order in which the obstacles are added to the cable. This was done to reduce both the algorithm complexity and simplify building your path, while being useful in a large set of problems.

For the previous example this means that a `CableSpan` will not collide with the torus twice:

https://github.com/simbody/simbody/assets/46680867/94917a9f-1a10-485c-be53-dad9d78cfa4f

or in the case of two obstacles, that collision with the first obstacle will not be detected after contact with the second obstacle:

https://github.com/simbody/simbody/assets/46680867/38173be5-de17-44e5-ae77-48ee69d7a3a0

It is still possible to make contact with a single *surface geometry* multiple times. But you have to add that surface as an obstacle multiple times. For example, if we wish to make contact with a torus twice, it can be added as an obstacle twice:
```cpp
// Start with torus obstacle
cable.addObstacle(ground, offset, torusGeometry, contactPoint1);
// Add other obstacles
...
// End with same torus obstacle.
cable.addObstacle(ground, offset, torusGeometry, contactPoint2);
```
which allows the cable to make contact with the same torus as the initial and final obstacle:
![torus_double_contact](https://github.com/simbody/simbody/assets/46680867/3dbcd1e1-c8ed-43fa-af47-b4692c39c38b)

**Contact Detection**
The cable can lose and regain contact with an obstacle, by lifting-off or touching down on the surface.
Lift-off is detected when:
1. The length of the geodesic is zero, and
2. the path point before and after the geodesic are above the surface

https://github.com/simbody/simbody/assets/46680867/7668045d-727d-4482-811b-8bb7c5990886

After lifting off, the cable misses the obstacle in a straight line. Touchdown is detected by tracking the point on the line that is nearest the surface. This tracking point is visualized by a red line. For example, a cable that misses all obstacles:

https://github.com/simbody/simbody/assets/46680867/5bf31b47-8ec0-45a2-b676-8e05b5bfa05b

A common approach is to put the tracking point on the obstacle, and  not the line. I found this to be less robust and more computationally expensive. Especially for a torus it can be hard to jump over the "hole" (which happens above).

**Implicit, Parametric, Analytic Surfaces**
Whenever the cable touches down on a suface this adds a curved segment to the path. Each curved segment is a geodesic for that obstacle surface.
The geodesic is computed analytically if possible, and otherwise using the implicit surface equations. The parametric form is not used in this PR, and would be part of future work.

**Continuous Wrapping**
When solving for the path, the corrections are applied to the path locally. This means that the path will not jump to the other surface side, and allows for winding over an obstacle multiple times:

https://github.com/simbody/simbody/assets/46680867/b9a920e8-4ca8-4a15-96a8-dd590ad73c94

The `CableSpan` stores the last computed geodesic in local obstacle coordinates in a discrete cache variable. This is then used as a warm-start at the next realization. For example, after computing the initial path, the path below is computed in zero solver iterations:

https://github.com/simbody/simbody/assets/46680867/179cc2c2-d985-4b38-84d4-81a3198766e5

During the above rotation the only computation done by `CableSpan` is to transform the cached geodesic to ground frame, which is considerably cheaper than recomputing the path.

**Added Example**
A new example is added `examples/ExampleCableSpan.cpp`, that combines the currently tested surfaces:

https://github.com/user-attachments/assets/49c6dd87-a9af-43f4-8f6e-97dc223d593a

## Test Cases

The `CableSubsystemTestHelper` is added and can be used to assert that:
1. all curve segments in a path are correct geodesics, and
2. the computed path error Jacobian is correct.

This test can be used during a simulation to check your currently computed path:
```cpp
CableSubsystemTestHelper().testCurrentPath(s, cables, std::cout);
```
This allows testing all computed paths during a test case simulation. Additionally it will catch bugs in geodesic related math in `ContactGeometry`, which has been modified in this PR. See description of `CableSubsystemTestHelper` in `CableSpan.h` for details.

Additionally, the following test cases have been added at `Simbody/tests/TestCableSpan.cpp`:

**Test Case 1**: A test case using all currently supported surfaces, and with different cable end point locations:

https://github.com/user-attachments/assets/cd714afa-e904-46cd-bb8d-a54ef1425a85

For each computed path, the test checks that:
1. The curve segments are correct geodesics.
2. The path error jacobian is correct.
3. The computed length derivative matches the change in length.

**Test Case 2**: A test case verifying touchdown and liftoff on a torus, ellipsoid, sphere and cylinder surface:

https://github.com/user-attachments/assets/2a54f76d-3e90-4954-a846-3120de312811

This test verifies that the path loses/regains contact with the obstacles when you would expect it to.

**Test Case 3**: A test case for which the path is simple enough such that we can check the result by hand:

![TestCableSpan_simple](https://github.com/user-attachments/assets/ad7faaa2-5a79-4486-a23a-43efc6edcdc6)

Here we verify that the following computations give the expected result:
1. Curve segment lengths, and total cable length.
2. Computed forces and torques.
3. Computed Frenet frames at the obstacle contact points.

## Future Work
Some issues have been spotted, and will still be collected. They are important to address, but should not effect the currently proposed framework. The idea is to create new PRs for each, and not make them part of this PR.

**Configuration Parameters**:
There are some issues regarding the configuration parameters:
1. The surface constraint tolerance could/should be related to the integrator accuracy.
2. The path solver accuracy could/should be related to the integrator accuracy.
3. The max number of iterations allowed during surface projection is not exposed.

**Geodesic Math Speedup**
The original implementation of `ContactGeometry::calcSurfaceValue()`, `ContactGeometry::calcSurfaceGradient()`,  `ContactGeometry::calcSurfaceHessian()` and `ContactGeometry::calcSurfaceCurvatureInDirection()` was taking up most of the time during the computation of a path. These have been overridden for some surfaces (ellipsoid, sphere, cylinder), but not yet for others (torus, bicubic-patch). This will make some surfaces significantly slower than others.
Similarly, the proposed touchdown detection is using the implicit equations for all surfaces. For the analytic surfaces this could be done much more efficiently.

**Path Initialization**
Currently the path has trouble initializing when the initial guess is too far (angular distance > 90 degrees) from the optimal path.

**Touchdown Misses**
The path can miss touching down on the surface if the configuration changes too much between states. Here we escape the torus when forcing large translation of the cable origin:

https://github.com/user-attachments/assets/6392f6e2-c3dc-4070-8358-119b38d595d8

**Alternate Cost Function**
Currently the optimal path is found by minimizing the angular discontinuities at the segment connection points. This is not always equivalent to minimizing the path length.

**Visualizer Path Points**
The interface required for visualizing the path points in OpenSim GUI could be improved. For example: If needed interpolation could be done efficiently by the `CableSpan`.

## Changes Summary
The following files have been changed/added:

The new classes `CableSpan` and `CableSubsystem` are:
- Declared in: `Simbody/include/simbody/internal/CableSpan.h`
- Defined in: `Simbody/src/CableSpan.cpp`

The helper class `CableSubsystemTestHelper` is:
- Declared in:  `Simbody/include/simbody/internal/CableSpan.h`
- Implementation class declared in:  `Simbody/src/CableSpan_SubsystemTestHelper_Impl.h`
- Defined in: `Simbody/src/CableSpan_SubsystemTestHelper_Impl.cpp`

The following functions are added to `ContactGeometry`:
- `calcSurfaceTorsionInDirection`: Computing the geodesic torsion of the surface.
- `calcNearestPointOnLineImplicitly`: Computing a point on a line that is nearest to the surface.
- `shootGeodesicInDirectionImplicitly`: Computing a new geodesic implicitly.
- `shootGeodesicInDirectionAnalytically`: Computing a new geodesic analytically.
- `isAnalyticFormAvailable`: Returns whether an analytic form is available for this geometry.
- `isSurfaceDefined`: Returns whether a surface is defined at a given point (used to check domain of the bicubic surface)

The following functions in `ContactGeometry` are virtualized:
- `calcSurfaceValue`
- `calcSurfaceGradient`
- `calcSurfaceHessian`
- `calcSurfaceCurvatureInDirection`
and are overridden for the sphere, cylinder and ellipsoid.

The analytic geodesic `shootGeodesicInDirectionAnalytically` is implemented in:
- `SimTKmath/Geometry/src/ContactGeometry_Sphere.cpp`: for the sphere
- `SimTKmath/Geometry/src/ContactGeometry_Cylinder.cpp`: for the cylinder

An example is added: `examples/ExampleCableSpan.cpp`
Unit tests are collected in: `Simbody/tests/TestCableSpan.cpp`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/791)
<!-- Reviewable:end -->
