### PR TITLE
Check BLAS/LAPACK libraries at configure time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -483,6 +483,50 @@ add_compile_definitions(
    SimTK_SIMBODY_AUTHORS="${SIMBODY_AUTHORS}"
 )
 
+#
+# Allow automated build and dashboard.
+#
+
+if(BUILD_TESTING)
+    include(CTest) # automatically calls enable_testing()
+    ## When in Debug mode and running valgrind, some of the test
+    ## cases take longer than the default 1500 seconds.
+    set(CTEST_TESTING_TIMEOUT 7200)
+endif()
+
+# These are used in Doxyfile.in and SimbodyConfig.cmake.in.
+set(SIMBODY_INSTALL_DOXYGENDIR   "${CMAKE_INSTALL_DOCDIR}/api")
+set(SIMBODY_DOXYGEN_TAGFILE_NAME "SimbodyDoxygenTagfile")
+if( INSTALL_DOCS )
+    add_subdirectory(doc)
+endif()
+
+# Specify where visualizer should be installed. This needs to be in the
+# root CMakeLists.txt so the cmake config file can see this value.
+#
+# Also specify where include files are installed.
+if(WIN32)
+    # Install visualizer to bin, since it needs to be co-located with dll's
+    set(SIMBODY_VISUALIZER_REL_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})
+    # Install include files into base include folder since it's a sandbox
+    set(SIMBODY_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
+else()
+    # Visualizer is not intended to be a user executable. Proper place is
+    # inside the lib directory
+    set(SIMBODY_VISUALIZER_REL_INSTALL_DIR ${CMAKE_INSTALL_LIBEXECDIR}/simbody)
+    # Install include files in simbody subfolder to avoid polluting the
+    # global build folder
+    set(SIMBODY_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/simbody)
+endif()
+set(SIMBODY_VISUALIZER_INSTALL_DIR
+    ${CMAKE_INSTALL_PREFIX}/${SIMBODY_VISUALIZER_REL_INSTALL_DIR})
+
+# Each of these returns a list of API include directories for
+# use by the later builds.
+add_custom_target(PlatformFiles ALL)
+add_subdirectory( Platform )
+# PLATFORM_INCLUDE_DIRECTORIES now set; 'blas' and 'lapack' targets defined on Windows
+
 if(BUILD_USING_OTHER_LAPACK)
     set(LAPACK_BEING_USED ${BUILD_USING_OTHER_LAPACK} CACHE INTERNAL
         "The BLAS/LAPACK libraries that will be linked against by the Simbody libraries.")
@@ -553,49 +597,7 @@ set(MATH_LIBS_TO_USE    ${LAPACK_BEING_USED} ${PTHREAD_LIB}
                         ${REALTIME_LIB} ${DL_LIBRARY} ${MATH_LIBRARY})
 set(MATH_LIBS_TO_USE_VN ${MATH_LIBS_TO_USE})
 
-#
-# Allow automated build and dashboard.
-#
 
-if(BUILD_TESTING)
-    include(CTest) # automatically calls enable_testing()
-    ## When in Debug mode and running valgrind, some of the test
-    ## cases take longer than the default 1500 seconds.
-    set(CTEST_TESTING_TIMEOUT 7200)
-endif()
-
-# These are used in Doxyfile.in and SimbodyConfig.cmake.in.
-set(SIMBODY_INSTALL_DOXYGENDIR   "${CMAKE_INSTALL_DOCDIR}/api")
-set(SIMBODY_DOXYGEN_TAGFILE_NAME "SimbodyDoxygenTagfile")
-if( INSTALL_DOCS )
-    add_subdirectory(doc)
-endif()
-
-# Specify where visualizer should be installed. This needs to be in the
-# root CMakeLists.txt so the cmake config file can see this value.
-#
-# Also specify where include files are installed.
-if(WIN32)
-    # Install visualizer to bin, since it needs to be co-located with dll's
-    set(SIMBODY_VISUALIZER_REL_INSTALL_DIR ${CMAKE_INSTALL_BINDIR})
-    # Install include files into base include folder since it's a sandbox
-    set(SIMBODY_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR})
-else()
-    # Visualizer is not intended to be a user executable. Proper place is
-    # inside the lib directory
-    set(SIMBODY_VISUALIZER_REL_INSTALL_DIR ${CMAKE_INSTALL_LIBEXECDIR}/simbody)
-    # Install include files in simbody subfolder to avoid polluting the
-    # global build folder
-    set(SIMBODY_INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_INCLUDEDIR}/simbody)
-endif()
-set(SIMBODY_VISUALIZER_INSTALL_DIR
-    ${CMAKE_INSTALL_PREFIX}/${SIMBODY_VISUALIZER_REL_INSTALL_DIR})
-
-# Each of these returns a list of API include directories for
-# use by the later builds.
-add_custom_target(PlatformFiles ALL)
-add_subdirectory( Platform )
-# PLATFORM_INCLUDE_DIRECTORIES now set
 add_subdirectory( SimTKcommon )
 # SimTKCOMMON_INCLUDE_DIRECTORIES now set
 add_subdirectory( SimTKmath )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -556,8 +556,7 @@ endif()
 
 # Try to link against the requested BLAS/LAPACK libraries
 set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
-try_compile(OTHER_LAPACK_FUNCTIONAL
-    SOURCE_FROM_CONTENT lapack_test.c
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lapack_test.c
 "\
 #include \"SimTKlapack.h\"
 int main () {
@@ -570,7 +569,10 @@ float d = sdot_(n, x, stride, y, stride);
 
 return !(d == 5.0); // return zero if sdot_ worked
 }
-"
+")
+
+try_compile(OTHER_LAPACK_FUNCTIONAL
+    SOURCES ${CMAKE_CURRENT_BINARY_DIR}/lapack_test.c
     CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${CMAKE_CURRENT_SOURCE_DIR}/SimTKcommon/include
     LINK_LIBRARIES ${LAPACK_BEING_USED})
 if(OTHER_LAPACK_FUNCTIONAL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -571,7 +571,7 @@ return !(d == 5.0); // return zero if sdot_ worked
 }
 ")
 
-try_compile(OTHER_LAPACK_FUNCTIONAL
+try_compile(OTHER_LAPACK_FUNCTIONAL ${CMAKE_CURRENT_BINARY_DIR}
     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/lapack_test.c
     CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${CMAKE_CURRENT_SOURCE_DIR}/SimTKcommon/include
     LINK_LIBRARIES ${LAPACK_BEING_USED})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -486,7 +486,13 @@ add_compile_definitions(
 if(BUILD_USING_OTHER_LAPACK)
     set(LAPACK_BEING_USED ${BUILD_USING_OTHER_LAPACK} CACHE INTERNAL
         "The BLAS/LAPACK libraries that will be linked against by the Simbody libraries.")
+
+    message(CHECK_START "Trying to compile with requested BLAS/LAPACK libraries")
 else()
+    # Determine which math libraries to use for this platform.
+    # Intel MKL: mkl_intel_c_dll;mkl_sequential_dll;mkl_core_dll
+    set(BUILD_USING_OTHER_LAPACK "" CACHE STRING
+    "If you have your own Lapack and Blas, put libraries here, separated by semicolons (full paths or paths that are on the (DY)LD_LIBRARY_PATH (UNIX) or PATH (Windows)). See LAPACK_BEING_USED to see what's actually being used.")
     if(WIN32 AND NOT WINDOWS_USE_EXTERNAL_LIBS)
         set(LAPACK_PLATFORM_DEFAULT lapack;blas)
     else()
@@ -498,9 +504,38 @@ else()
             message(WARNING "Could not find blas/lapack")
         endif()
     endif()
-
     set(LAPACK_BEING_USED ${LAPACK_PLATFORM_DEFAULT} CACHE INTERNAL
         "The BLAS/LAPACK libraries that will be linked against by the Simbody libraries.")
+    message(CHECK_START "Trying to compile with system BLAS/LAPACK libraries")
+endif()
+
+
+# Try to link against the requested BLAS/LAPACK libraries
+set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
+try_compile(OTHER_LAPACK_FUNCTIONAL
+    SOURCE_FROM_CONTENT lapack_test.c
+"\
+#include \"SimTKlapack.h\"
+int main () {
+int* n = 2;
+int* stride = 1;
+float x[] = {1.0, 1.0};
+float y[] = {2.0, 3.0};
+
+float d = sdot_(n, x, stride, y, stride);
+
+return !(d == 5.0); // return zero if sdot_ worked
+}
+"
+    CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${CMAKE_CURRENT_SOURCE_DIR}/SimTKcommon/include
+    LINK_LIBRARIES ${LAPACK_BEING_USED})
+if(OTHER_LAPACK_FUNCTIONAL)
+    message(CHECK_PASS "success.")
+    message(STATUS "Using BLAS/LAPACK libraries ${LAPACK_BEING_USED}")
+else()
+    message(CHECK_FAIL "failed.")
+    message(FATAL_ERROR "Failed to compile using the BLAS/LAPACK libraries ${LAPACK_BEING_USED}.
+        If BUILD_USING_OTHER_LAPACK was given; check that it was set correctly.")
 endif()
 
 if(UNIX)


### PR DESCRIPTION
There are 4 ways simbody finds BLAS/LAPACK libraries:
  - Windows
    - Default (`WINDOWS_USE_EXTERNAL_LIBS=OFF AND BUILD_USING_OTHER_LAPACK=""`) is a set of simbody vendored BLAS/LAPACK libraries
    - If `WINDOWS_USE_EXTERNAL_LIBS=ON`, then the system BLAS/LAPACK is used (whatever is found by CMake FindBlas and FindLapack)
  - Unix default (`BUILD_USING_OTHER_LAPACK=""`) is the system BLAS/LAPACK (whatever is found by CMake FindBlas and FindLapack)
  - Set manually using `BUILD_USING_OTHER_LAPACK`

This could fail any number of ways (especially when using `BUILD_USING_OTHER_LAPACK`), so it
would be helpful to fail as early as possible if there is a problem. Currently, a build with
a poorly specified `BUILD_USING_OTHER_LAPACK` won't fail until linking the SimTKcommon
library, after building approximately 1/3 of Simbody.

This PR adds a `try_compile` check that try's to link to the chosen BLAS/LAPACK libraries.
If it fails, a helpful error message is printed by CMake:
```
CMake Error at CMakeLists.txt:537 (message):
  Failed to compile using the BLAS/LAPACK libraries -lnotablas.

          If BUILD_USING_OTHER_LAPACK was given; check that it was set correctly.
```

You can locally test this with either of these (valid) configurations (on Linux):
`cmake -B build -S . --fresh` 
`cmake -B build -S . --fresh -DBUILD_USING_OTHER_LAPACK="-lblas;-llapack"`

This should fail:
`cmake -B build -S . --fresh -DBUILD_USING_OTHER_LAPACK="-lnotablas"`

**Note:** This does not change any generated CMakefiles, and it won't break anything that isn't/wouldn't already be broken.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/795)
<!-- Reviewable:end -->
