### PR TITLE
Fix failed BLAS/LAPACK try_compile on MacOS

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -11,6 +11,10 @@ on:
     tags:
       - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'simbody-')}}
+
 jobs:
   windows:
     name: Windows

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -11,10 +11,6 @@ on:
     tags:
       - '*'
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ !contains(github.ref, 'simbody-')}}
-
 jobs:
   windows:
     name: Windows

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,7 +525,6 @@ add_subdirectory( Platform )
 if(BUILD_USING_OTHER_LAPACK)
     set(LAPACK_BEING_USED ${BUILD_USING_OTHER_LAPACK} CACHE INTERNAL
         "The BLAS/LAPACK libraries that will be linked against by the Simbody libraries.")
-    set(BLAS_LAPACK_LINK_OPTIONS)
 
     message(CHECK_START "Trying to compile with requested BLAS/LAPACK libraries")
 else()
@@ -535,13 +534,11 @@ else()
     "If you have your own Lapack and Blas, put libraries here, separated by semicolons (full paths or paths that are on the (DY)LD_LIBRARY_PATH (UNIX) or PATH (Windows)). See LAPACK_BEING_USED to see what's actually being used.")
     if(WIN32 AND NOT WINDOWS_USE_EXTERNAL_LIBS)
         set(LAPACK_PLATFORM_DEFAULT lapack;blas)
-        set(BLAS_LAPACK_LINK_OPTIONS)
     else()
         find_package(BLAS) # defines IMPORTED target BLAS::BLAS
         find_package(LAPACK) # defines IMPORTED target LAPACK::LAPACK
         if(BLAS_FOUND AND LAPACK_FOUND)
-            set(LAPACK_PLATFORM_DEFAULT ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
-            set(BLAS_LAPACK_LINK_OPTIONS ${BLAS_LINKER_FLAGS} ${LAPACK_LINKER_FLAGS})
+            set(LAPACK_PLATFORM_DEFAULT BLAS::BLAS LAPACK::LAPACK)
         else()
             message(WARNING "Could not find blas/lapack")
         endif()
@@ -572,15 +569,17 @@ return !(d == 5.0); // return zero if sdot_ worked
 try_compile(OTHER_LAPACK_FUNCTIONAL ${CMAKE_CURRENT_BINARY_DIR}
     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/lapack_test.c
     CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${CMAKE_CURRENT_SOURCE_DIR}/SimTKcommon/include
-    LINK_OPTIONS ${BLAS_LAPACK_LINK_OPTIONS}
+    OUTPUT_VARIABLE BLAS_TRYCOMPILE_LOG
     LINK_LIBRARIES ${LAPACK_BEING_USED})
 if(OTHER_LAPACK_FUNCTIONAL)
     message(CHECK_PASS "success.")
     message(STATUS "Using BLAS/LAPACK libraries ${LAPACK_BEING_USED}")
 else()
     message(CHECK_FAIL "failed.")
+    message(AUTHOR_WARNING ${BLAS_TRYCOMPILE_LOG})
     message(FATAL_ERROR "Failed to compile using the BLAS/LAPACK libraries ${LAPACK_BEING_USED}.
         If BUILD_USING_OTHER_LAPACK was given; check that it was set correctly.")
+
 endif()
 
 if(UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -549,35 +549,35 @@ else()
 endif()
 
 
-# Try to link against the requested BLAS/LAPACK libraries
-set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lapack_test.c
-"\
-#include \"SimTKlapack.h\"
-int main () {
-int* n = 2;
-int* stride = 1;
-float x[] = {1.0, 1.0};
-float y[] = {2.0, 3.0};
+# # Try to link against the requested BLAS/LAPACK libraries
+# set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
+# file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lapack_test.c
+# "\
+# #include \"SimTKlapack.h\"
+# int main () {
+# int* n = 2;
+# int* stride = 1;
+# float x[] = {1.0, 1.0};
+# float y[] = {2.0, 3.0};
 
-float d = sdot_(n, x, stride, y, stride);
+# float d = sdot_(n, x, stride, y, stride);
 
-return !(d == 5.0); // return zero if sdot_ worked
-}
-")
+# return !(d == 5.0); // return zero if sdot_ worked
+# }
+# ")
 
-try_compile(OTHER_LAPACK_FUNCTIONAL ${CMAKE_CURRENT_BINARY_DIR}
-    SOURCES ${CMAKE_CURRENT_BINARY_DIR}/lapack_test.c
-    CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${CMAKE_CURRENT_SOURCE_DIR}/SimTKcommon/include
-    LINK_LIBRARIES ${LAPACK_BEING_USED})
-if(OTHER_LAPACK_FUNCTIONAL)
+# try_compile(OTHER_LAPACK_FUNCTIONAL ${CMAKE_CURRENT_BINARY_DIR}
+#     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/lapack_test.c
+#     CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${CMAKE_CURRENT_SOURCE_DIR}/SimTKcommon/include
+#     LINK_LIBRARIES ${LAPACK_BEING_USED})
+# if(OTHER_LAPACK_FUNCTIONAL)
     message(CHECK_PASS "success.")
     message(STATUS "Using BLAS/LAPACK libraries ${LAPACK_BEING_USED}")
-else()
-    message(CHECK_FAIL "failed.")
-    message(FATAL_ERROR "Failed to compile using the BLAS/LAPACK libraries ${LAPACK_BEING_USED}.
-        If BUILD_USING_OTHER_LAPACK was given; check that it was set correctly.")
-endif()
+# else()
+#     message(CHECK_FAIL "failed.")
+#     message(FATAL_ERROR "Failed to compile using the BLAS/LAPACK libraries ${LAPACK_BEING_USED}.
+#         If BUILD_USING_OTHER_LAPACK was given; check that it was set correctly.")
+# endif()
 
 if(UNIX)
     if(NOT APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -525,6 +525,7 @@ add_subdirectory( Platform )
 if(BUILD_USING_OTHER_LAPACK)
     set(LAPACK_BEING_USED ${BUILD_USING_OTHER_LAPACK} CACHE INTERNAL
         "The BLAS/LAPACK libraries that will be linked against by the Simbody libraries.")
+    set(BLAS_LAPACK_LINK_OPTIONS)
 
     message(CHECK_START "Trying to compile with requested BLAS/LAPACK libraries")
 else()
@@ -534,11 +535,13 @@ else()
     "If you have your own Lapack and Blas, put libraries here, separated by semicolons (full paths or paths that are on the (DY)LD_LIBRARY_PATH (UNIX) or PATH (Windows)). See LAPACK_BEING_USED to see what's actually being used.")
     if(WIN32 AND NOT WINDOWS_USE_EXTERNAL_LIBS)
         set(LAPACK_PLATFORM_DEFAULT lapack;blas)
+        set(BLAS_LAPACK_LINK_OPTIONS)
     else()
         find_package(BLAS) # defines IMPORTED target BLAS::BLAS
         find_package(LAPACK) # defines IMPORTED target LAPACK::LAPACK
         if(BLAS_FOUND AND LAPACK_FOUND)
-            set(LAPACK_PLATFORM_DEFAULT BLAS::BLAS LAPACK::LAPACK)
+            set(LAPACK_PLATFORM_DEFAULT ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+            set(BLAS_LAPACK_LINK_OPTIONS ${BLAS_LINKER_FLAGS} ${LAPACK_LINKER_FLAGS})
         else()
             message(WARNING "Could not find blas/lapack")
         endif()
@@ -549,35 +552,36 @@ else()
 endif()
 
 
-# # Try to link against the requested BLAS/LAPACK libraries
-# set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
-# file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lapack_test.c
-# "\
-# #include \"SimTKlapack.h\"
-# int main () {
-# int* n = 2;
-# int* stride = 1;
-# float x[] = {1.0, 1.0};
-# float y[] = {2.0, 3.0};
+# Try to link against the requested BLAS/LAPACK libraries
+set(CMAKE_TRY_COMPILE_TARGET_TYPE EXECUTABLE)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lapack_test.c
+"\
+#include \"SimTKlapack.h\"
+int main () {
+int* n = 2;
+int* stride = 1;
+float x[] = {1.0, 1.0};
+float y[] = {2.0, 3.0};
 
-# float d = sdot_(n, x, stride, y, stride);
+float d = sdot_(n, x, stride, y, stride);
 
-# return !(d == 5.0); // return zero if sdot_ worked
-# }
-# ")
+return !(d == 5.0); // return zero if sdot_ worked
+}
+")
 
-# try_compile(OTHER_LAPACK_FUNCTIONAL ${CMAKE_CURRENT_BINARY_DIR}
-#     SOURCES ${CMAKE_CURRENT_BINARY_DIR}/lapack_test.c
-#     CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${CMAKE_CURRENT_SOURCE_DIR}/SimTKcommon/include
-#     LINK_LIBRARIES ${LAPACK_BEING_USED})
-# if(OTHER_LAPACK_FUNCTIONAL)
+try_compile(OTHER_LAPACK_FUNCTIONAL ${CMAKE_CURRENT_BINARY_DIR}
+    SOURCES ${CMAKE_CURRENT_BINARY_DIR}/lapack_test.c
+    CMAKE_FLAGS -DINCLUDE_DIRECTORIES=${CMAKE_CURRENT_SOURCE_DIR}/SimTKcommon/include
+    LINK_OPTIONS ${BLAS_LAPACK_LINK_OPTIONS}
+    LINK_LIBRARIES ${LAPACK_BEING_USED})
+if(OTHER_LAPACK_FUNCTIONAL)
     message(CHECK_PASS "success.")
     message(STATUS "Using BLAS/LAPACK libraries ${LAPACK_BEING_USED}")
-# else()
-#     message(CHECK_FAIL "failed.")
-#     message(FATAL_ERROR "Failed to compile using the BLAS/LAPACK libraries ${LAPACK_BEING_USED}.
-#         If BUILD_USING_OTHER_LAPACK was given; check that it was set correctly.")
-# endif()
+else()
+    message(CHECK_FAIL "failed.")
+    message(FATAL_ERROR "Failed to compile using the BLAS/LAPACK libraries ${LAPACK_BEING_USED}.
+        If BUILD_USING_OTHER_LAPACK was given; check that it was set correctly.")
+endif()
 
 if(UNIX)
     if(NOT APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,10 +535,10 @@ else()
     if(WIN32 AND NOT WINDOWS_USE_EXTERNAL_LIBS)
         set(LAPACK_PLATFORM_DEFAULT lapack;blas)
     else()
-        find_package(BLAS)
-        find_package(LAPACK)
+        find_package(BLAS) # defines IMPORTED target BLAS::BLAS
+        find_package(LAPACK) # defines IMPORTED target LAPACK::LAPACK
         if(BLAS_FOUND AND LAPACK_FOUND)
-            set(LAPACK_PLATFORM_DEFAULT ${BLAS_LIBRARIES} ${LAPACK_LIBRARIES})
+            set(LAPACK_PLATFORM_DEFAULT BLAS::BLAS LAPACK::LAPACK)
         else()
             message(WARNING "Could not find blas/lapack")
         endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -555,12 +555,12 @@ file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/lapack_test.c
 "\
 #include \"SimTKlapack.h\"
 int main () {
-int* n = 2;
-int* stride = 1;
+int n = 2;
+int stride = 1;
 float x[] = {1.0, 1.0};
 float y[] = {2.0, 3.0};
 
-float d = sdot_(n, x, stride, y, stride);
+float d = sdot_(&n, x, &stride, y, &stride);
 
 return !(d == 5.0); // return zero if sdot_ worked
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-    "version": 7,
+    "version": 3,
     "configurePresets": [
         {
             "hidden": true,
@@ -171,10 +171,8 @@
                 "CXXFLAGS": "-Werror"
             },
             "debug": {
-                "tryCompile": true
-            },
-            "trace": {
-                "mode": "expand"
+                "tryCompile": true,
+                "output": true
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -169,10 +169,6 @@
             ],
             "environment": {
                 "CXXFLAGS": "-Werror"
-            },
-            "debug": {
-                "tryCompile": true,
-                "output": true
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,5 +1,5 @@
 {
-    "version": 3,
+    "version": 7,
     "configurePresets": [
         {
             "hidden": true,
@@ -169,6 +169,12 @@
             ],
             "environment": {
                 "CXXFLAGS": "-Werror"
+            },
+            "debug": {
+                "tryCompile": true
+            },
+            "trace": {
+                "mode": "expand"
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -12,13 +12,76 @@
         },
         {
             "hidden": true,
-            "name": "ci-base",
-            "displayName": "CI configuration",
-            "description": "Sets build configuration for CI",
+            "name": "windows",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            },
+            "generator": "Visual Studio 17 2022",
+            "architecture": {
+                "value": "x64"
+            }
+        },
+        {
+            "hidden": true,
+            "name": "macos",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            },
+            "cacheVariables": {
+                "CMAKE_OSX_DEPLOYMENT_TARGET": "10.10"
+            }
+        },
+        {
+            "hidden": true,
+            "name": "release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        },
+        {
+            "hidden": true,
+            "name": "relwithdebinfo",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
+        },
+        {
+            "hidden": true,
+            "name": "debug",
+            "cacheVariables": {
+                "SIMBODY_COVERAGE": true,
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "hidden": true,
+            "name": "clang",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "clang",
+                "CMAKE_CXX_COMPILER": "clang++"
+            }
+        },
+        {
+            "hidden": true,
+            "name": "gcc",
+            "cacheVariables": {
+                "CMAKE_C_COMPILER": "gcc",
+                "CMAKE_CXX_COMPILER": "g++"
+            }
+        },
+        {
+            "hidden": true,
+            "name": "base",
+            "displayName": "Base configuration",
+            "description": "Sets basic build configuration for all presets",
             "binaryDir": "${sourceDir}/out/build/${presetName}",
             "installDir": "${sourceDir}/out/install/${presetName}",
+            "inherits": "release",
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release",
                 "BLA_VENDOR": "Generic"
             },
             "warnings": {
@@ -30,7 +93,7 @@
             "name": "default",
             "displayName": "Default build configuration",
             "description": "The right build configuration for most users",
-            "inherits": "ci-base",
+            "inherits": "base",
             "cacheVariables": {
                 "BUILD_TESTING": false,
                 "CMAKE_COMPILE_WARNING_AS_ERROR": false
@@ -44,16 +107,10 @@
             "name": "msvc-default",
             "displayName": "Default MSVC build configuration",
             "description": "The right MSVC build configuration for most users",
-            "inherits": "ci-base",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            },
-            "generator": "Visual Studio 17 2022",
-            "architecture": {
-                "value": "x64"
-            },
+            "inherits": [
+                "base",
+                "windows"
+            ],
             "cacheVariables": {
                 "BUILD_TESTING": false,
                 "CMAKE_COMPILE_WARNING_AS_ERROR": false
@@ -70,10 +127,10 @@
             "name": "dev-default",
             "displayName": "Default build configuration for devs",
             "description": "The right build configuration for most developers",
-            "inherits": "ci-base",
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            },
+            "inherits": [
+                "base",
+                "relwithdebinfo"
+            ],
             "environment": {
                 "CXXFLAGS": "-Wall"
             }
@@ -82,19 +139,11 @@
             "name": "msvc-dev-default",
             "displayName": "Default MSVC build configuration for devs",
             "description": "The right MSVC build configuration for most developers",
-            "inherits": "ci-base",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            },
-            "generator": "Visual Studio 17 2022",
-            "architecture": {
-                "value": "x64"
-            },
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
-            },
+            "inherits": [
+                "base",
+                "windows",
+                "relwithdebinfo"
+            ],
             "environment": {
                 "CXXFLAGS": "/WX"
             }
@@ -103,39 +152,20 @@
             "name": "ci-msvc-windows-release",
             "displayName": "Windows CI default",
             "description": "Default CI configuration for Windows (MSVC, Release)",
-            "inherits": "msvc-dev-default",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            },
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release"
-            }
+            "inherits": [
+                "msvc-dev-default",
+                "windows",
+                "release"
+            ]
         },
         {
             "name": "ci-make-macos-release",
             "displayName": "MacOS CI default",
             "description": "Default CI configuration for MacOS (Make, Clang, Release)",
-            "inherits": "ci-base",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Darwin"
-            },
-            "cacheVariables": {
-                "CMAKE_OSX_DEPLOYMENT_TARGET": "10.10"
-            },
-            "environment": {
-                "CXXFLAGS": "-Werror"
-            }
-        },
-        {
-            "hidden": true,
-            "name": "ci-make-linux",
             "inherits": [
-                "ci-base",
-                "linux"
+                "base",
+                "macos",
+                "release"
             ],
             "environment": {
                 "CXXFLAGS": "-Werror"
@@ -143,52 +173,52 @@
         },
         {
             "hidden": true,
-            "name": "ci-make-linux-debug",
-            "inherits": "ci-make-linux",
-            "cacheVariables": {
-                "SIMBODY_COVERAGE": true,
-                "CMAKE_BUILD_TYPE": "Debug"
+            "name": "ci-linux",
+            "inherits": [
+                "base",
+                "linux"
+            ],
+            "environment": {
+                "CXXFLAGS": "-Werror"
             }
         },
         {
             "name": "ci-make-clang-linux-release",
             "displayName": "Configure Linux CI (Make, Clang, Release)",
             "description": "CI configuration for Linux (Make, Clang, Release)",
-            "inherits": "ci-make-linux",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++"
-            }
+            "inherits": [
+                "ci-linux",
+                "clang"
+            ]
         },
         {
             "name": "ci-make-clang-linux-debug",
             "displayName": "Configure Linux CI (Make, Clang, Debug)",
             "description": "CI configuration for Linux (Make, Clang, Debug)",
-            "inherits": "ci-make-linux-debug",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "clang",
-                "CMAKE_CXX_COMPILER": "clang++"
-            }
+            "inherits": [
+                "clang",
+                "ci-linux",
+                "debug"
+            ]
         },
         {
             "name": "ci-make-gcc-linux-release",
             "displayName": "Configure Linux CI (Make, GCC, Release)",
             "description": "CI configuration for Linux (Make, GCC, Release)",
-            "inherits": "ci-make-linux",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++"
-            }
+            "inherits": [
+                "ci-linux",
+                "gcc"
+            ]
         },
         {
             "name": "ci-make-gcc-linux-debug",
             "displayName": "Configure Linux CI (Make, GCC, Debug)",
             "description": "CI configuration for Linux (Make, GCC, Debug)",
-            "inherits": "ci-make-linux-debug",
-            "cacheVariables": {
-                "CMAKE_C_COMPILER": "gcc",
-                "CMAKE_CXX_COMPILER": "g++"
-            }
+            "inherits": [
+                "gcc",
+                "ci-linux",
+                "debug"
+            ]
         }
     ],
     "buildPresets": [
@@ -202,6 +232,24 @@
             }
         },
         {
+            "hidden": true,
+            "name": "windows",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "hidden": true,
+            "name": "macos",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            }
+        },
+        {
             "name": "default",
             "configurePreset": "default"
         },
@@ -212,41 +260,25 @@
         {
             "name": "msvc-default",
             "configurePreset": "msvc-default",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            },
+            "inherits": "windows",
             "configuration": "Release"
         },
         {
             "name": "msvc-dev-default",
             "configurePreset": "msvc-dev-default",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            },
+            "inherits": "windows",
             "configuration": "RelWithDebInfo"
         },
         {
             "name": "ci-msvc-windows-release",
             "configurePreset": "ci-msvc-windows-release",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            },
+            "inherits": "windows",
             "configuration": "Release"
         },
         {
             "name": "ci-make-macos-release",
             "configurePreset": "ci-make-macos-release",
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Darwin"
-            }
+            "inherits": "macos"
         },
         {
             "name": "ci-make-clang-linux-release",
@@ -299,6 +331,31 @@
             }
         },
         {
+            "hidden": true,
+            "name": "windows",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Windows"
+            }
+        },
+        {
+            "hidden": true,
+            "name": "macos",
+            "condition": {
+                "type": "equals",
+                "lhs": "${hostSystemName}",
+                "rhs": "Darwin"
+            }
+        },
+        {
+            "name": "default",
+            "configurePreset": "default",
+            "inherits": [
+                "base"
+            ]
+        },
+        {
             "name": "dev-default",
             "configurePreset": "dev-default",
             "inherits": [
@@ -309,33 +366,26 @@
             "name": "msvc-dev-default",
             "configurePreset": "msvc-dev-default",
             "inherits": [
-                "base"
+                "base",
+                "windows"
             ]
         },
         {
             "name": "ci-msvc-windows-release",
             "configurePreset": "ci-msvc-windows-release",
             "inherits": [
-                "base"
+                "base",
+                "windows"
             ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Windows"
-            },
             "configuration": "Release"
         },
         {
             "name": "ci-make-macos-release",
             "configurePreset": "ci-make-macos-release",
             "inherits": [
-                "base"
-            ],
-            "condition": {
-                "type": "equals",
-                "lhs": "${hostSystemName}",
-                "rhs": "Darwin"
-            }
+                "base",
+                "macos"
+            ]
         },
         {
             "name": "ci-make-clang-linux-release",


### PR DESCRIPTION
~~(Attempt # 1; don't have an Apple computer to test locally)~~

Fixes incorrect int pointer declaration in the test compile code and adds (dev only) debug logs for the failed output of the `try_compile` test.

Also switches `LAPACK_PLATFORM_DEFAULT` definition to use the IMPORTED targets defined by FindBLAS
and FindLAPACK. (More idiomatic; not sure why I didn't do this originally; there may have been a reason I
have since forgotten.)

Additionally, the CMake presets have been simplified (duplicated settings separated into
hidden presets that are inherited). This makes the user/developing facing preset definitions
simpler and more approachable. ~~(Presets refactoring included here due to an expectation that
the MacOS presets may need updating if the first bugfix attempt doesn't work.)~~ (I can split this into a separate PR if desired.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/796)
<!-- Reviewable:end -->
