### PR TITLE
Fix failure to find transitive BLAS/LAPACK dependencies in downstream libraries (aka OpenSim)

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           cmake --build --preset ci-make-${{ matrix.compiler }}-linux-${{ matrix.build_type }} --target doxygen
           cmake --install $GITHUB_WORKSPACE/out/build/ci-make-${{ matrix.compiler }}-linux-${{ matrix.build_type }}
-          mv $GITHUB_WORKSPACE/out/build/ci-make-${{ matrix.compiler }}-linux-${{ matrix.build_type }} simbody-${{ steps.commithash.outputs.hash }}
+          mv $GITHUB_WORKSPACE/out/install/ci-make-${{ matrix.compiler }}-linux-${{ matrix.build_type }} simbody-${{ steps.commithash.outputs.hash }}
           zip --symlinks --recurse-paths --quiet simbody-${{ steps.commithash.outputs.hash }}.zip simbody-${{ steps.commithash.outputs.hash }}
 
       - name: Upload

--- a/cmake/SimbodyConfig.cmake.in
+++ b/cmake/SimbodyConfig.cmake.in
@@ -71,53 +71,60 @@ endif()
 include("${CMAKE_CURRENT_LIST_DIR}/SimbodyTargets.cmake")
 
 
-# Create "fake" IMPORTED targets to represent the pre-built platform libraries
-# that Simbody usually carries along on Windows.
-# When CMake sees that a target links to, e.g., the blas target, CMake will
-# use the appropriate library paths below.
 set(SIMBODY_WAS_BUILT_USING_OTHER_LAPACK "@BUILD_USING_OTHER_LAPACK@")
-if(WIN32 AND NOT SIMBODY_WAS_BUILT_USING_OTHER_LAPACK)
+if(NOT SIMBODY_WAS_BUILT_USING_OTHER_LAPACK)
+    if(WIN32)
+        # Create "fake" IMPORTED targets to represent the pre-built platform libraries
+        # that Simbody usually carries along on Windows.
+        # When CMake sees that a target links to, e.g., the blas target, CMake will
+        # use the appropriate library paths below.
+        # declare transitive dependencies for blas/lapack (see simbody/simbody#771)
+        #
+        # the transitive dependencies don't, themselves, have IMPLIBs, because
+        # they have already been linked by blas/lapack. However, cmake can become
+        # confused when it sees a library with no IMPLIB, so we include blas's
+        # here to satisfy cmake
+        #
+        # (if you link to blas or lapack, you're going to link to the blas IMPLIB
+        # anyway, so it makes no difference)
+        add_library(libgcc_s_sjlj-1 SHARED IMPORTED)
+        set_target_properties(libgcc_s_sjlj-1 PROPERTIES
+            IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
+            IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libgcc_s_sjlj-1.dll"
+            )
+        add_library(libgfortran-3 SHARED IMPORTED)
+        set_target_properties(libgfortran-3 PROPERTIES
+            IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
+            IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libgfortran-3.dll"
+            )
+        add_library(libquadmath-0 SHARED IMPORTED)
+        set_target_properties(libquadmath-0 PROPERTIES
+            IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
+            IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libquadmath-0.dll"
+            )
 
-    # declare transitive dependencies for blas/lapack (see simbody/simbody#771)
-    #
-    # the transitive dependencies don't, themselves, have IMPLIBs, because
-    # they have already been linked by blas/lapack. However, cmake can become
-    # confused when it sees a library with no IMPLIB, so we include blas's
-    # here to satisfy cmake
-    #
-    # (if you link to blas or lapack, you're going to link to the blas IMPLIB
-    # anyway, so it makes no difference)
-    add_library(libgcc_s_sjlj-1 SHARED IMPORTED)
-    set_target_properties(libgcc_s_sjlj-1 PROPERTIES
-        IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
-        IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libgcc_s_sjlj-1.dll"
-        )
-    add_library(libgfortran-3 SHARED IMPORTED)
-    set_target_properties(libgfortran-3 PROPERTIES
-        IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
-        IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libgfortran-3.dll"
-        )
-    add_library(libquadmath-0 SHARED IMPORTED)
-    set_target_properties(libquadmath-0 PROPERTIES
-        IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
-        IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libquadmath-0.dll"
-        )
+        add_library(blas SHARED IMPORTED)
+        set_target_properties(blas PROPERTIES
+            IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
+            IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libblas.dll"
+            )
+        # link to transitive dependencies
+        target_link_libraries(blas INTERFACE libgcc_s_sjlj-1 libgfortran-3 libquadmath-0)
 
-    add_library(blas SHARED IMPORTED)
-    set_target_properties(blas PROPERTIES
-        IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/libblas.lib"
-        IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/libblas.dll"
-        )
-    # link to transitive dependencies
-    target_link_libraries(blas INTERFACE libgcc_s_sjlj-1 libgfortran-3 libquadmath-0)
+        add_library(lapack SHARED IMPORTED)
+        set_target_properties(lapack PROPERTIES
+            IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/liblapack.lib"
+            IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/liblapack.dll"
+            # lapack depends on blas:
+            INTERFACE_LINK_LIBRARIES blas
+            )
+    else()
+        include(CMakeFindDependencyMacro)
 
-    add_library(lapack SHARED IMPORTED)
-    set_target_properties(lapack PROPERTIES
-        IMPORTED_IMPLIB "@PACKAGE_CMAKE_INSTALL_LIBDIR@/liblapack.lib"
-        IMPORTED_LOCATION "@PACKAGE_CMAKE_INSTALL_BINDIR@/liblapack.dll"
-        # lapack depends on blas:
-        INTERFACE_LINK_LIBRARIES blas
-        )
+        find_dependency(BLAS QUIET REQUIRED)
+        find_dependency(LAPACK QUIET REQUIRED)
+    endif()
+# else the BLAS/LAPACK interface_link_libraries are given explicitly by BUILD_USING_OTHER_LAPACK
 endif()
 
 


### PR DESCRIPTION
The previous change here https://github.com/simbody/simbody/blob/aff36c1c4b4c6020866d3a4c66471e037fcb1ce2/CMakeLists.txt#L541 to using the IMPORTED libraries created by `FindBLAS` and `FindLAPACK` calls caused a missing target error.

To resolve this, we need to add `find_dependency` calls for BLAS and LAPACK in the SimbodyConfig.cmake file.

Passing CI in this PR is irrelevant since the SimbodyConfig.cmake file is a build output and isn't tested. I manually tested this on Linux by building OpenSim and setting the `SIMBODY_HOME` variable to the install folder (e.g. CI artifacts) from this PR/branch. OpenSim successfully configured and built with this branch, demonstrating that the (previously) missing IMPORTED `BLAS::BLAS` and `LAPACK::LAPACK` targets were now being found.