### PR TITLE
Add `const` qualification to `calcBodyMomentumAboutBodyOriginInGround()`

### DIFF
--- a/Simbody/include/simbody/internal/MobilizedBody.h
+++ b/Simbody/include/simbody/internal/MobilizedBody.h
@@ -1260,7 +1260,7 @@ Inertia calcBodyInertiaAboutAnotherBodyStation
 
 /** Calculate body B's momentum (angular, linear) measured and expressed in 
 Ground, but taken about the body origin Bo. **/
-SpatialVec calcBodyMomentumAboutBodyOriginInGround(const State& state) {
+SpatialVec calcBodyMomentumAboutBodyOriginInGround(const State& state) const {
     const MassProperties M_Bo_G = expressMassPropertiesInGroundFrame(state);
     const SpatialVec&    V_GB   = getBodyVelocity(state);
     return M_Bo_G.toSpatialMat() * V_GB;


### PR DESCRIPTION
While writing wrapper functions in OpenSim for accessing body momentum calculations from Simbody, I noticed that `calcBodyMomentumAboutBodyOriginInGround()` was not `const` qualified. 

Opening the PR since I don't see any reason why it shouldn't be, and I receive no compiler errors when adding it in.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/803)
<!-- Reviewable:end -->
