### PR TITLE
Set rpaths for the examples and visualizer executable on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,11 +308,7 @@ endif()
 # RPATH
 # -----
 set(SIMBODY_USE_INSTALL_RPATH FALSE)
-if(APPLE)
-    # This variable gets used when configuring the Info.plist for
-    # simbody-visualizer.app; see cmake/MacOSXBundleInfo.plist.in.
-    set(MACOSX_BUNDLE_HIGH_RESOLUTION_CAPABLE "false")
-
+if(UNIX)
     # CMake 2.8.12 introduced the ability to set RPATH for shared libraries on
     # OSX. This helps executables find the libraries they depend on without
     # having to set the DYLD_LIBRARY_PATH environment variable.
@@ -330,11 +326,18 @@ if(APPLE)
     # RPATH) that can be baked into the executable just after compiling or any
     # time before running the executable (using the executable
     # "install_name_tool"). The RPATH stored in executables can also contain
-    # "@executable_path", etc.
+    # "@executable_path", etc. On Linux, rather than "@executable_path", we 
+    # must use "$ORIGIN" to find the location of the executable.
 
-    # Set the install name of libraries to contain "@rpath".
-    # This allows clients of our libraries to point to them however they wish.
-    set(CMAKE_MACOSX_RPATH ON)
+    if(APPLE)
+        # This variable gets used when configuring the Info.plist for
+        # simbody-visualizer.app; see cmake/MacOSXBundleInfo.plist.in.
+        set(MACOSX_BUNDLE_HIGH_RESOLUTION_CAPABLE "false")
+
+        # Set the install name of libraries to contain "@rpath".
+        # This allows clients of our libraries to point to them however they wish.
+        set(CMAKE_MACOSX_RPATH ON)
+    endif() 
 
     # We only need to set RPATH in executables if the libraries are installed
     # into directories that are not already searched by the linker.

--- a/Simbody/Visualizer/simbody-visualizer/CMakeLists.txt
+++ b/Simbody/Visualizer/simbody-visualizer/CMakeLists.txt
@@ -75,13 +75,10 @@ set_target_properties(${GUI_NAME} PROPERTIES
         PROJECT_LABEL "Code - ${GUI_NAME}"
         DEBUG_OUTPUT_NAME ${GUI_NAME}${CMAKE_DEBUG_POSTFIX})
 
-# On OSX, bake the relative path to the Simbody libraries into the visualizer
-# executable. Then there's no need to set `DYLD_LIBRARY_PATH` to find the
-# libraries when using the visualizer.
+# On OSX and Linux systems, bake the relative path to the Simbody libraries into 
+# the visualizer executable. Then there's no need to set `DYLD_LIBRARY_PATH` (or
+# `LD_LIBRARY_PATH` on Linux) to find the libraries when using the visualizer.
 if(${SIMBODY_USE_INSTALL_RPATH})
-    # @executable_path only makes sense on OSX, so if we use RPATH on
-    # Linux we'll have to revisit.
-
     # vis_dir_to_install_dir is most likely "../"
     if (APPLE)
         set(vis_install_dir
@@ -93,9 +90,15 @@ if(${SIMBODY_USE_INSTALL_RPATH})
             "${vis_install_dir}"
             "${CMAKE_INSTALL_PREFIX}")
     set(vis_dir_to_lib_dir "${vis_dir_to_install_dir}${CMAKE_INSTALL_LIBDIR}")
-    set_target_properties(${GUI_NAME} PROPERTIES
-        INSTALL_RPATH "\@executable_path/${vis_dir_to_lib_dir}"
+    if(APPLE)
+        set_target_properties(${GUI_NAME} PROPERTIES
+            INSTALL_RPATH "@executable_path/${vis_dir_to_lib_dir}"
         )
+    elseif(UNIX AND NOT APPLE)
+        set_target_properties(${GUI_NAME} PROPERTIES
+            INSTALL_RPATH "\$ORIGIN/${vis_dir_to_lib_dir}"
+        )
+    endif()
 endif()
 
 if(BUILD_DYNAMIC_LIBRARIES)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -86,7 +86,11 @@ if(${SIMBODY_USE_INSTALL_RPATH})
     set(exbin_dir_to_lib_dir
         "${exbin_dir_to_install_dir}${CMAKE_INSTALL_LIBDIR}")
     if(${SIMBODY_USE_INSTALL_RPATH})
-        set(CMAKE_INSTALL_RPATH "\@executable_path/${exbin_dir_to_lib_dir}")
+        if(APPLE)
+            set(CMAKE_INSTALL_RPATH "@executable_path/${exbin_dir_to_lib_dir}")
+        elseif(UNIX AND NOT APPLE)
+            set(CMAKE_INSTALL_RPATH "\$ORIGIN/${exbin_dir_to_lib_dir}")
+        endif()
     endif()
 endif()
 


### PR DESCRIPTION
This change adds rpaths to the Simbody visualizer and example executables on Linux using the `$ORIGIN` token (i.e., the Linux equivalent to `@executable_path`). Should make development on Linux for downstream applications (e.g., OpenSim) a bit more convenient: no need to set `$LD_LIBRARY_PATH` to launch the visualizer located in the install directory.