### PR TITLE
Handle vtp files without normals

### DIFF
--- a/SimTKcommon/Geometry/src/PolygonalMesh.cpp
+++ b/SimTKcommon/Geometry/src/PolygonalMesh.cpp
@@ -486,11 +486,8 @@ void PolygonalMesh::loadVtpFile(const String& pathname) {
     Xml::Element piecePointData = piece.getRequiredElement("PointData");
     Array_<Xml::Element>  pointDataElements = piecePointData.getAllElements("DataArray");
     const String normalsString =
-        piecePointData.getRequiredAttributeValue("Normals");
-    SimTK_ERRCHK1_ALWAYS(
-        piecePointData.getRequiredAttributeValue("Normals") == "Normals",
-        method, "VTP file missing normals info.",
-        piecePointData.getRequiredAttributeValue("Normals").c_str());
+        piecePointData.getOptionalAttributeValue("Normals");
+
     bool hasNormals = (normalsString == "Normals");
 
     const String textureCoordinatesString =

--- a/SimTKcommon/tests/TestPolygonalMesh.cpp
+++ b/SimTKcommon/tests/TestPolygonalMesh.cpp
@@ -406,6 +406,100 @@ void testLoadVtpFile() {
     ASSERT(mesh.hasTextureCoordinatesAtVertices())
 }
 
+void testLoadVtpFileNoNormals() {
+    PolygonalMesh mesh;
+    string fileContent;
+    fileContent += "<?xml version='1.0'?>";
+    fileContent +=
+        "<VTKFile type='PolyData' version='0.1' byte_order='LittleEndian' "
+        "compressor='vtkZLibDataCompressor'>";
+    fileContent += "<PolyData>";
+    fileContent +=
+        "<Piece NumberOfPoints='4' NumberOfVerts='0' NumberOfLines='0' "
+        "NumberOfStrips='0' NumberOfPolys='1'>";
+    fileContent += "<PointData TCoords='TextureCoordinates'>";
+    fileContent +=
+        "<DataArray type='Float32' Name='TextureCoordinates' "
+        "NumberOfComponents='2' format='ascii' RangeMin='0' "
+        "RangeMax='1.4142135624'>";
+    fileContent += "    0 0 1 0 0 1";
+    fileContent += "    1 1";
+    fileContent += "</DataArray>";
+    fileContent += "</PointData>";
+    fileContent += "<CellData>";
+    fileContent += "</CellData>";
+    fileContent += "<Points>";
+    fileContent +=
+        "<DataArray type='Float32' Name='Array 0476C968' "
+        "NumberOfComponents='3' format='ascii' RangeMin='0.70710678119' "
+        "RangeMax='0.70710678119'>";
+    fileContent += "    -0.5 -0.5 0 0.5 -0.5 0";
+    fileContent += "    -0.5 0.5 0 0.5 0.5 0";
+    fileContent += "</DataArray>";
+    fileContent += "</Points>";
+    fileContent += "<Verts>";
+    fileContent +=
+        "<DataArray type='Int32' Name='connectivity' format='ascii' "
+        "RangeMin='1e+299' RangeMax='-1e+299'>";
+    fileContent += "</DataArray>";
+    fileContent +=
+        "<DataArray type='Int32' Name='offsets' format='ascii' "
+        "RangeMin='1e+299' RangeMax='-1e+299'>";
+    fileContent += "</DataArray>";
+    fileContent += "</Verts>";
+    fileContent += "<Lines>";
+    fileContent +=
+        "<DataArray type='Int32' Name='connectivity' format='ascii' "
+        "RangeMin='1e+299' RangeMax='-1e+299'>";
+    fileContent += "</DataArray>";
+    fileContent +=
+        "<DataArray type='Int32' Name='offsets' format='ascii' "
+        "RangeMin='1e+299' RangeMax='-1e+299'>";
+    fileContent += "</DataArray>";
+    fileContent += "</Lines>";
+    fileContent += "<Strips>";
+    fileContent +=
+        "<DataArray type='Int32' Name='connectivity' format='ascii' "
+        "RangeMin='1e+299' RangeMax='-1e+299'>";
+    fileContent += "</DataArray>";
+    fileContent +=
+        "<DataArray type='Int32' Name='offsets' format='ascii' "
+        "RangeMin='1e+299' RangeMax='-1e+299'>";
+    fileContent += "</DataArray>";
+    fileContent += "</Strips>";
+    fileContent += "<Polys>";
+    fileContent +=
+        "<DataArray type='Int32' Name='connectivity' format='ascii' "
+        "RangeMin='1e+299' RangeMax='-1e+299'>";
+    fileContent += "    0 1 3 2";
+    fileContent += "</DataArray>";
+    fileContent +=
+        "<DataArray type='Int32' Name='offsets' format='ascii' "
+        "RangeMin='1e+299' RangeMax='-1e+299'>";
+    fileContent += "    4";
+    fileContent += "</DataArray>";
+    fileContent += "</Polys>";
+    fileContent += "</Piece>";
+    fileContent += "</PolyData>";
+    fileContent += "</VTKFile>";
+
+    std::ofstream filePtr("planeNoNormals.vtp", std::ios::out);
+    filePtr << fileContent;
+    filePtr.close();
+
+    mesh.loadVtpFile("planeNoNormals.vtp");
+    // verts = -0.5 -0.5 0, 0.5 -0.5 0, -0.5 0.5 0,  0.5 0.5 0
+    // Normals = 0 0 1, 0 0 1,0 0 1, 0 0 1
+    std::array<Vec3, 4> verts = {Vec3{-.5, -.5, .0}, Vec3{.5, -.5, .0},
+                                 Vec3{-.5, .5, .0}, Vec3{.5, .5, .0}};
+    ASSERT(mesh.getNumVertices() == 4);
+    ASSERT(mesh.getNumFaces() == 1);
+    for (int v = 0; v < verts.size(); ++v) {
+        ASSERT(mesh.getVertexPosition(v) == verts[v]);
+    }
+    ASSERT(!mesh.hasNormals())
+    ASSERT(mesh.hasTextureCoordinatesAtVertices())
+}
 
 int main() {
     try {
@@ -414,6 +508,7 @@ int main() {
         testLoadObjFileWithNormalsTexture();
         testConvertObjFileToVisualizationFormat();
         testLoadVtpFile();
+        testLoadVtpFileNoNormals();
     } catch(const std::exception& e) {
         cout << "exception: " << e.what() << endl;
         return 1;

--- a/SimTKcommon/tests/TestPolygonalMesh.cpp
+++ b/SimTKcommon/tests/TestPolygonalMesh.cpp
@@ -489,7 +489,6 @@ void testLoadVtpFileNoNormals() {
 
     mesh.loadVtpFile("planeNoNormals.vtp");
     // verts = -0.5 -0.5 0, 0.5 -0.5 0, -0.5 0.5 0,  0.5 0.5 0
-    // Normals = 0 0 1, 0 0 1,0 0 1, 0 0 1
     std::array<Vec3, 4> verts = {Vec3{-.5, -.5, .0}, Vec3{.5, -.5, .0},
                                  Vec3{-.5, .5, .0}, Vec3{.5, .5, .0}};
     ASSERT(mesh.getNumVertices() == 4);


### PR DESCRIPTION
The last PR that enabled reading normals and texture coordinates, mistakenly required vtp files to contain normals. While true for visualization files, this is not always the case. This PR fixes this assumption and adds a test case to verify proper handling

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/807)
<!-- Reviewable:end -->
