### PR TITLE
Ensure loadVtpFile works when the vtp file doesn't have a <PointData>…

### DIFF
--- a/SimTKcommon/Geometry/src/PolygonalMesh.cpp
+++ b/SimTKcommon/Geometry/src/PolygonalMesh.cpp
@@ -482,31 +482,33 @@ void PolygonalMesh::loadVtpFile(const String& pathname) {
     // EDIT: We actually don't use this variable. Leaving for reference.
     // TODO const int firstVertex = getNumVertices();
 
-    // Read the normals
-    Xml::Element piecePointData = piece.getRequiredElement("PointData");
-    Array_<Xml::Element>  pointDataElements = piecePointData.getAllElements("DataArray");
-    const String normalsString =
-        piecePointData.getOptionalAttributeValue("Normals");
-
-    bool hasNormals = (normalsString == "Normals");
-
-    const String textureCoordinatesString =
-        piecePointData.getOptionalAttributeValue("TCoords");
-
-    bool hasTextureCoordinates =
-        (textureCoordinatesString == "TextureCoordinates");
-
+    // Read the normals/texture coords (optional)
     Vector_<Vec3> normals;
+    bool hasNormals = false;
     Vector_<Vec2> textureCoordinates;
+    bool hasTextureCoordinates = false;
+    if (piece.hasElement("PointData")) {  // legacy VTP files may not contain a <PointData> block
+        Xml::Element piecePointData = piece.getRequiredElement("PointData");
+        Array_<Xml::Element>  pointDataElements = piecePointData.getAllElements("DataArray");
+        const String normalsString =
+            piecePointData.getOptionalAttributeValue("Normals");
 
-    for (auto dataArray : pointDataElements) {
-        auto name = dataArray.getRequiredAttributeValue("Name");
-        if (name=="Normals")
-            dataArray.getValueAs(normals);
-        else if (name == "TextureCoordinates")
-            dataArray.getValueAs(textureCoordinates);
+        hasNormals = (normalsString == "Normals");
+
+        const String textureCoordinatesString =
+            piecePointData.getOptionalAttributeValue("TCoords");
+
+        hasTextureCoordinates =
+            (textureCoordinatesString == "TextureCoordinates");
+
+        for (auto dataArray : pointDataElements) {
+            auto name = dataArray.getRequiredAttributeValue("Name");
+            if (name=="Normals")
+                dataArray.getValueAs(normals);
+            else if (name == "TextureCoordinates")
+                dataArray.getValueAs(textureCoordinates);
+        }
     }
-    
     // The lone DataArray element in the Points element contains the points'
     // coordinates. Read it in as a Vector of Vec3s.
     Xml::Element pointData = points.getRequiredElement("DataArray");

--- a/SimTKcommon/tests/TestPolygonalMesh.cpp
+++ b/SimTKcommon/tests/TestPolygonalMesh.cpp
@@ -500,6 +500,74 @@ void testLoadVtpFileNoNormals() {
     ASSERT(mesh.hasTextureCoordinatesAtVertices())
 }
 
+static void testLoadVtpNoNormalsNoTextureCoords() {
+
+    // This example was copied from OpenSim's legacy geometry directory,
+    // which can be found at `github.com/opensim-org/opensim-models/Geometry/anchor1.vtp`
+    constexpr auto anchor1VTP = R"(
+        <?xml version="1.0"?>
+        <VTKFile type="PolyData" version="0.1" byte_order="LittleEndian" compressor="vtkZLibDataCompressor">
+          <PolyData>
+            <Piece NumberOfPoints="24" NumberOfVerts="0" NumberOfLines="0" NumberOfStrips="0" NumberOfPolys="6">
+              <Points>
+                <DataArray type="Float32" NumberOfComponents="3" format="ascii">
+           -0.2500         0    0.3000
+           -0.2500         0    0.4000
+           -0.2500    0.1000    0.3000
+           -0.2500    0.1000    0.4000
+            0.2500         0    0.3000
+            0.2500         0    0.4000
+            0.2500    0.1000    0.3000
+            0.2500    0.1000    0.4000
+           -0.2500         0    0.3000
+           -0.2500         0    0.4000
+            0.2500         0    0.3000
+            0.2500         0    0.4000
+           -0.2500    0.1000    0.3000
+           -0.2500    0.1000    0.4000
+            0.2500    0.1000    0.3000
+            0.2500    0.1000    0.4000
+           -0.2500         0    0.3000
+            0.2500         0    0.3000
+           -0.2500    0.1000    0.3000
+            0.2500    0.1000    0.3000
+           -0.2500         0    0.4000
+            0.2500         0    0.4000
+           -0.2500    0.1000    0.4000
+            0.2500    0.1000    0.4000
+                </DataArray>
+              </Points>
+              <Polys>
+                <DataArray type="Int32" Name="connectivity" format="ascii">
+                  0 1 3 2 4 6
+                  7 5 8 10 11 9
+                  12 13 15 14 16 18
+                  19 17 20 21 23 22
+                </DataArray>
+                <DataArray type="Int32" Name="offsets" format="ascii">
+                  4 8 12 16 20 24
+                </DataArray>
+              </Polys>
+            </Piece>
+          </PolyData>
+        </VTKFile>
+    )";
+
+    // write vtp content to a file (API requirement)
+    {
+        std::ofstream ofs;
+        ofs.exceptions(std::ios::badbit | std::ios::failbit);
+        ofs.open("anchor1.vtp", std::ios::out);
+        ofs << anchor1VTP;
+    }
+
+    PolygonalMesh mesh;
+    mesh.loadVtpFile("anchor1.vtp");
+    ASSERT(mesh.getNumVertices() == 24);
+    ASSERT(!mesh.hasNormals());
+    ASSERT(!mesh.hasTextureCoordinates());
+}
+
 int main() {
     try {
         testCreateMesh();
@@ -508,6 +576,7 @@ int main() {
         testConvertObjFileToVisualizationFormat();
         testLoadVtpFile();
         testLoadVtpFileNoNormals();
+        testLoadVtpNoNormalsNoTextureCoords();
     } catch(const std::exception& e) {
         cout << "exception: " << e.what() << endl;
         return 1;


### PR DESCRIPTION
Related #807 #798

The latest vtp parser is unable to parse the VTP files contained in this directory:

- https://github.com/opensim-org/opensim-models/tree/master/Geometry

Because the files don't contain a `<PointData>` block, which is what the new parser now requires in order to process texture coordinates and normals.

@aymanhab @nickbianco

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/809)
<!-- Reviewable:end -->
