### PR TITLE
Fix STL parser memory usage growing quadratically

### DIFF
--- a/SimTKcommon/Geometry/src/PolygonalMesh.cpp
+++ b/SimTKcommon/Geometry/src/PolygonalMesh.cpp
@@ -922,7 +922,7 @@ void STLFile::loadStlBinaryFile(PolygonalMesh& mesh) {
             const Vec3 vertex((Real)vbuf[0], (Real)vbuf[1], (Real)vbuf[2]);
             int vertIndex = getVertex(vertex, mesh);
             vertices[vx] = vertIndex;
-            normalIndices.push_back(normalIndex);
+            normalIndices[vx] = normalIndex;
         }
         mesh.addFaceWithNormals(vertices, normalIndices);
         // Now read and toss the "attribute byte count".


### PR DESCRIPTION
Found downstream:

- https://github.com/ComputationalBiomechanicsLab/opensim-creator/issues/987

The new additions to the STL parser for handling normals was incorrectly using `push_back` rather than assigning the normals over the same array. This results in `normals^2` memory usage, which means loading a model that uses STLs with the new parser can consume **a lot** of memory (e.g. jumped from 0.2 -> 14 GB on my machine). @aymanhab

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/811)
<!-- Reviewable:end -->
