### PR TITLE
Set default build type to RelWithDebInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ endif()
 
 if(NOT MSVC AND NOT XCODE AND NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
-	"Debug, RelWithDebInfo (recommended), or Release build" FORCE)
+        "Debug, RelWithDebInfo (recommended), or Release build" FORCE)
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,8 +276,7 @@ endif()
 
 if(NOT MSVC AND NOT XCODE AND NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
-        "Debug, RelWithDebInfo (recommended), or Release build"
-        )
+	"Debug, RelWithDebInfo (recommended), or Release build" FORCE)
 endif()
 
 


### PR DESCRIPTION
A recent change to the top-level CMakeLists.txt left CMAKE_BUILD_TYPE unspecified so it defaulted to "Debug" on Linux!! That's _very_ slow. The default should be "RelWithDebInfo".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/812)
<!-- Reviewable:end -->
