### PR TITLE
Remove legacy operators that are causing problems to swig

### DIFF
--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -635,6 +635,7 @@ struct Segment {
 
 // With compiler support for <=> operator these four methods below don't
 // need to be manually defined. (from gcc 10, clang 10 & msvc 19.22)
+// also exclude if SWIG_PYTHON is defined to build python bindings in OpenSim
 #if !defined(__cpp_lib_three_way_comparison) && !defined SWIG_PYTHON
 // These next four methods supply the missing relational operators for any
 // types L and R where L==R and L<R have been defined. This is like the

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -635,7 +635,7 @@ struct Segment {
 
 // With compiler support for <=> operator these four methods below don't
 // need to be manually defined. (from gcc 10, clang 10 & msvc 19.22)
-#if 0
+#if !defined(__cpp_lib_three_way_comparison) && !defined SWIG_PYTHON
 // These next four methods supply the missing relational operators for any
 // types L and R where L==R and L<R have been defined. This is like the
 // operators in the std::rel_ops namespace, except that those require both

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -635,7 +635,7 @@ struct Segment {
 
 // With compiler support for <=> operator these four methods below don't
 // need to be manually defined. (from gcc 10, clang 10 & msvc 19.22)
-#if !defined(__cpp_lib_three_way_comparison)
+#if 0
 // These next four methods supply the missing relational operators for any
 // types L and R where L==R and L<R have been defined. This is like the
 // operators in the std::rel_ops namespace, except that those require both


### PR DESCRIPTION
These operators are within ifdef that suggest all modern compilers don't need them, so this likely has no effect on simbody clients, except that using these headers to generate bindings in swig causes problems as swig 4.2+ generates new types and code that fails to resolve these operators. 
I will remove the ifdef block completely before merging if approved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/815)
<!-- Reviewable:end -->
