### PR TITLE
Implement fix so that `CPodesIntegrator` correctly returns `EndOfSimulation` status after repeated calls to `stepTo()`

### DIFF
--- a/SimTKmath/Integrators/src/CPodesIntegrator.cpp
+++ b/SimTKmath/Integrators/src/CPodesIntegrator.cpp
@@ -309,9 +309,9 @@ stepTo(Real reportTime, Real scheduledEventTime) {
     const Real finalTime = (userFinalTime == -1.0 ? Infinity : userFinalTime);
     if (getStepCommunicationStatus() == StepHasBeenReturnedNoEvent) {
         // Using getAdvancedTime() will trigger the end of a simulation too
-        // early if the advanced state time is greater than any remaining 
-        // scheduled events (which can happen if CPodes steps beyond tMax). 
-        // Instead, use the time from getState(), which returns the interpolated 
+        // early if the advanced state time is greater than any remaining
+        // scheduled events (which can happen if CPodes steps beyond tMax).
+        // Instead, use the time from getState(), which returns the interpolated
         // state if it was set in a previous step.
         if (getState().getTime() >= finalTime) {
             setUseInterpolatedState(false);
@@ -320,7 +320,7 @@ stepTo(Real reportTime, Real scheduledEventTime) {
             return Integrator::EndOfSimulation;
         }
     }
-    
+
     // If this is the start of a continuous interval, return immediately so
     // the current state will be seen as part of the trajectory.
     if (startOfContinuousInterval) {

--- a/SimTKmath/tests/IntegratorTestFramework.h
+++ b/SimTKmath/tests/IntegratorTestFramework.h
@@ -270,7 +270,7 @@ void testIntegrator (Integrator& integ, PendulumSystem& sys, Real accuracy=1e-4)
     ASSERT(DiscontinuousReporter::eventCount == (int) (ts.getTime()/2.0));
 
     // Try stepping directly to final time, should report ReachedReportTime.
-    
+
     resetHandlersAndReporters();
     ts.initialize(sys.getDefaultState());
     auto status = ts.stepTo(tFinal);


### PR DESCRIPTION
## Summary
Implements a fix for the issue described in #824. Updated `IntegratorTestFramework.h` to ensure expected behavior is consistent across all integrators.

## Looking for feedback

This was a bit confusing to debug until I realized that `CPodes` may step beyond the specified maximum time. In other words, `tret` can be greater than `tMax` here:

https://github.com/simbody/simbody/blob/abcc29202a8697ad53ef3296919fc0f1e7848de1/SimTKmath/Integrators/src/CPodesIntegrator.cpp#L393

which is explained in `cpodes.h`:

https://github.com/simbody/simbody/blob/abcc29202a8697ad53ef3296919fc0f1e7848de1/SimTKmath/Integrators/src/CPodes/sundials/include/cpodes/cpodes.h#L962-L975

This makes me wonder if the advanced state should instead be set to `tMax` instead of `tret`, since the returned `yout` is really `y(tout = tMax)`. Although, this only may be valid in the case when using the `CP_NORMAL` mode. It looks like the advanced state is properly backed up to the event time here:

https://github.com/simbody/simbody/blob/abcc29202a8697ad53ef3296919fc0f1e7848de1/SimTKmath/Integrators/src/CPodesIntegrator.cpp#L478-L491

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/825)
<!-- Reviewable:end -->
