### PR TITLE
CableSpan: Via points

### DIFF
--- a/Simbody/include/simbody/internal/CableSpan.h
+++ b/Simbody/include/simbody/internal/CableSpan.h
@@ -125,17 +125,17 @@ class CableSubsystemTestHelper;
 
 //==============================================================================
 /** This class represents the path of a frictionless cable from an origin point
-fixed to a body, over geometric obstacles and through via points fixed to other 
+fixed to a body, over geometric obstacles and through via points fixed to other
 bodies, to a final termination point.
 
 The CableSpan's path can be seen as consisting of straight line segments and
 curved line segments: A curved segment over each obstacle, and straight segments
-connecting them to each other and to via points and the end points. Each curved 
-segment is computed as a geodesic to give (in some sense) a shortest path over 
-the surface. During a simulation the cable can slide freely over the obstacle 
-surfaces. It can lose contact with a surface and miss that obstacle in a 
-straight line. Similarly the cable can touchdown on the obstacle if the surface 
-obstructs the straight line segment again. The cable will always slide freely 
+connecting them to each other and to via points and the end points. Each curved
+segment is computed as a geodesic to give (in some sense) a shortest path over
+the surface. During a simulation the cable can slide freely over the obstacle
+surfaces. It can lose contact with a surface and miss that obstacle in a
+straight line. Similarly the cable can touchdown on the obstacle if the surface
+obstructs the straight line segment again. The cable will always slide freely
 through any via points present in the path.
 
 The path is computed as an optimization problem using the previous optimal path
@@ -163,11 +163,11 @@ then the third. If the first obstacle spatially collides with the path twice it
 will not actually wrap over it twice. Use CablePath if this is not the desired
 behavior.
 
-When via points are present in the cable, the cable is internally divided into 
-cable segments separated by the via points. Obstacles separated by via points 
+When via points are present in the cable, the cable is internally divided into
+cable segments separated by the via points. Obstacles separated by via points
 have no interaction when geodesic corrections are applied during optimization,
-and therefore the path for each cable segment is solved independently. This 
-approach is advantageous since cable segments with different sets of wrap 
+and therefore the path for each cable segment is solved independently. This
+approach is advantageous since cable segments with different sets of wrap
 obstacles may require a different number of optimization iterations to converge.
 
 Note that a CableSpan is a geometric object, not a force or constraint element.
@@ -250,7 +250,7 @@ public:
     @param station_B The via point's station in body fixed coordinates.
     @return The index of the added via point in this cable. **/
     CableSpanViaPointIndex addViaPoint(
-        MobilizedBodyIndex viaPointBody, 
+        MobilizedBodyIndex viaPointBody,
         const Vec3& station_B);
 
     /** Get the number of via points added to the path. **/
@@ -301,7 +301,7 @@ public:
     ground frame). The force can be obtained by multiplying the result by the
     cable tension. State must be realized to Stage::Position.
     @param state State of the system.
-    @param[out] unitForce_G The resulting unit spatial force in ground frame. 
+    @param[out] unitForce_G The resulting unit spatial force in ground frame.
     **/
     void calcOriginUnitForce(
         const State& state,
@@ -311,7 +311,7 @@ public:
     (in ground frame). The force can be obtained by multiplying the result by
     the cable tension. State must be realized to Stage::Position.
     @param state State of the system.
-    @param[out] unitForce_G The resulting unit spatial force in ground frame. 
+    @param[out] unitForce_G The resulting unit spatial force in ground frame.
     **/
     void calcTerminationUnitForce(
         const State& state,
@@ -390,7 +390,7 @@ public:
 
     /** Get the index of the mobilized body that the via point is attached to.
     @param ix The index of the via point in this CableSpan.
-    @return The index of the mobilized body that the via point is attached to. 
+    @return The index of the mobilized body that the via point is attached to.
     **/
     const MobilizedBodyIndex& getViaPointMobilizedBodyIndex(
         CableSpanViaPointIndex ix) const;
@@ -413,7 +413,7 @@ public:
     @param station_B The station of the via point in body fixed coordinates. **/
     void setViaPointStation(
         CableSpanViaPointIndex ix,
-        const Vec3& station_B); 
+        const Vec3& station_B);
 
     ///@}
 
@@ -611,7 +611,7 @@ public:
     @param ix The index of the via point in this CableSpan.
     @return The location of the via point in the ground frame. **/
     Vec3 calcViaPointLocation(
-        const State& state, 
+        const State& state,
         CableSpanViaPointIndex ix) const;
 
     /** Calculate the unit force exerted by the cable at the specified via point

--- a/Simbody/include/simbody/internal/MultibodySystem.h
+++ b/Simbody/include/simbody/internal/MultibodySystem.h
@@ -35,7 +35,7 @@ class SimbodyMatterSubsystem;
 class ForceSubsystem;
 class DecorationSubsystem;
 class GeneralContactSubsystem;
-
+class CableSubsystem;
 
 /** The job of the MultibodySystem class is to coordinate the activities of 
 various subsystems which can be part of a multibody system. We insist on 
@@ -68,6 +68,10 @@ public:
     GeneralContactSubsystem&       updContactSubsystem();
     bool hasContactSubsystem() const;
 
+    int setCableSubsystem(CableSubsystem&);
+    const CableSubsystem& getCableSubsystem() const;
+    CableSubsystem&       updCableSubsystem();
+    bool hasCableSubsystem() const;
 
     /// Calculate the total potential energy of the system.  The state must
     /// be at Dynamics stage or later.

--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -28,7 +28,7 @@
 using namespace SimTK;
 
 // Define a unique index for cable segments.
-namespace { 
+namespace {
 SimTK_DEFINE_UNIQUE_INDEX_TYPE(CableSegmentIndex);
 }
 
@@ -625,7 +625,7 @@ private:
 };
 
 //==============================================================================
-//                          Struct Curve Segment
+//                               Curve Segment
 //==============================================================================
 /* The CableSpan's path consists of straight line segments between obstacles and
 via points, and curved segments over the obstacles. This struct represents the
@@ -810,23 +810,21 @@ public:
 
     const CableSubsystem& getSubsystem() const
     {
-        if (!m_subsystem) {
-            SimTK_ERRCHK_ALWAYS(
-                m_subsystem,
-                "CurveSegment::getSubsystem()",
-                "CableSpan not yet adopted by any CableSubsystem");
-        }
+        SimTK_ERRCHK_ALWAYS(
+            m_subsystem,
+            "CurveSegment::getSubsystem()",
+            "CableSpan not yet adopted by any CableSubsystem");
+
         return *m_subsystem;
     }
 
     CableSubsystem& updSubsystem()
     {
-        if (!m_subsystem) {
-            SimTK_ERRCHK_ALWAYS(
-                m_subsystem,
-                "CurveSegment::updSubsystem()",
-                "CableSpan not yet adopted by any CableSubsystem");
-        }
+        SimTK_ERRCHK_ALWAYS(
+            m_subsystem,
+            "CurveSegment::updSubsystem()",
+            "CableSpan not yet adopted by any CableSubsystem");
+
         return *m_subsystem;
     }
 
@@ -868,7 +866,7 @@ public:
             getDataInst(state).X_SQ.p());
     }
 
-    bool isInContactWithSurface(const State& state) const 
+    bool isInContactWithSurface(const State& state) const
     {
         const CurveSegmentData::Instance& dataInst = getDataInst(state);
         return dataInst.wrappingStatus ==
@@ -883,11 +881,11 @@ public:
     // contact with the cable.
 
     // Find the first obstacle before this segment that is in contact with the
-    // cable. Returns an invalid index if there is none, e.g., the previous 
+    // cable. Returns an invalid index if there is none, e.g., the previous
     // point in the path is a via point or the path origin.
     ObstacleIndex findPrevObstacleInContactWithCable(const State& state) const;
     // Find the first obstacle after this segment that is in contact with the
-    // cable. Returns an invalid index if there is none, e.g., the next point 
+    // cable. Returns an invalid index if there is none, e.g., the next point
     // in the path is a via point or the path termination.
     ObstacleIndex findNextObstacleInContactWithCable(const State& state) const;
 
@@ -921,7 +919,7 @@ public:
             "CurveSegment::Impl::assertSurfaceBounds",
             "Next point lies inside the surface");
         return nextPoint_S;
-    } 
+    }
 
     //--------------------------------------------------------------------------
     //  Updating CurveSegmentData::Instance Helpers
@@ -1456,7 +1454,7 @@ private:
     ObstacleIndex m_obstacleIndex = ObstacleIndex::Invalid();
 
     // MobilizedBody that the curve segment is attached to.
-    MobilizedBodyIndex m_body;
+    MobilizedBodyIndex m_body = MobilizedBodyIndex::Invalid();
     // Surface to body transform.
     Transform m_X_BS;
 
@@ -1476,7 +1474,7 @@ private:
 };
 
 //==============================================================================
-//                          Struct Via Point
+//                                 Via Point
 //==============================================================================
 /* This struct represents a zero-length cable segment associated with a via
 point in the path. It manages the cached data such as the position of the via
@@ -1495,7 +1493,7 @@ public:
         CableSpanIndex cableIndex,
         ViaPointIndex viaPointIndex,
         MobilizedBodyIndex body,
-        Vec3 station_B) :
+        const Vec3& station_B) :
         m_subsystem(subsystem),
         m_cableIndex(cableIndex),
         m_viaPointIndex(viaPointIndex),
@@ -1514,17 +1512,17 @@ public:
             state,
             Stage::Position,
             Stage::Infinity,
-            new Value<Vec3>());
+            new Value<Vec3>(Vec3(0.)));
         m_indexIncomingDirection = updSubsystem().allocateCacheEntry(
             state,
             Stage::Position,
             Stage::Infinity,
-            new Value<UnitVec3>());
+            new Value<UnitVec3>(UnitVec3(NaN)));
         m_indexOutgoingDirection = updSubsystem().allocateCacheEntry(
             state,
             Stage::Position,
             Stage::Infinity,
-            new Value<UnitVec3>());
+            new Value<UnitVec3>(UnitVec3(NaN)));
     }
 
     void invalidateDirectionCacheEntries(const State& state) const
@@ -1548,7 +1546,7 @@ public:
     }
 
     void setIncomingDirection(
-        const State& state, 
+        const State& state,
         const UnitVec3& direction_G) const
     {
         updIncomingDirection(state) = direction_G;
@@ -1562,7 +1560,7 @@ public:
     }
 
     void setOutgoingDirection(
-        const State& state, 
+        const State& state,
         const UnitVec3& direction_G) const
     {
         updOutgoingDirection(state) = direction_G;
@@ -1593,23 +1591,21 @@ public:
 
     const CableSubsystem& getSubsystem() const
     {
-        if (!m_subsystem) {
-            SimTK_ERRCHK_ALWAYS(
-                m_subsystem,
-                "ViaPoint::getSubsystem()",
-                "CableSpan not yet adopted by any CableSubsystem");
-        }
+        SimTK_ERRCHK_ALWAYS(
+            m_subsystem,
+            "ViaPoint::getSubsystem()",
+            "CableSpan not yet adopted by any CableSubsystem");
+
         return *m_subsystem;
     }
 
     CableSubsystem& updSubsystem()
     {
-        if (!m_subsystem) {
-            SimTK_ERRCHK_ALWAYS(
-                m_subsystem,
-                "ViaPoint::updSubsystem()",
-                "CableSpan not yet adopted by any CableSubsystem");
-        }
+        SimTK_ERRCHK_ALWAYS(
+            m_subsystem,
+            "ViaPoint::updSubsystem()",
+            "CableSpan not yet adopted by any CableSubsystem");
+
         return *m_subsystem;
     }
 
@@ -1636,7 +1632,7 @@ public:
     //--------------------------------------------------------------------------
     // Computing cached data
     //--------------------------------------------------------------------------
-    
+
     const Vec3& calcStation_G(const State& state) const
     {
         Vec3& station_G = updStation_G(state);
@@ -1690,9 +1686,9 @@ private:
     ViaPointIndex m_viaPointIndex = ViaPointIndex::Invalid();
 
     // MobilizedBody that the via point is attached to.
-    MobilizedBodyIndex m_body;
+    MobilizedBodyIndex m_body = MobilizedBodyIndex::Invalid();
     // The position of the via point in the body frame.
-    Vec3 m_station_B;
+    Vec3 m_station_B{NaN};
 
     // Topology cache.
     CacheEntryIndex m_indexStation_G = CacheEntryIndex::Invalid();
@@ -1701,13 +1697,13 @@ private:
 };
 
 //==============================================================================
-//                          Struct Cable Segment
+//                              Cable Segment
 //==============================================================================
 /* This is a helper struct for managing segments of the cable path that are
-separated by via points. It stores an ordered list of the obstacle indexes 
+separated by via points. It stores an ordered list of the obstacle indexes
 associated with this segment and indexes to the initial and final via points, if
-they exist. An invalid initial via point index indicates that the segemnt begins
-with the cable origin point. Similarly, an invalid final via point index 
+they exist. An invalid initial via point index indicates that the segment begins
+with the cable origin point. Similarly, an invalid final via point index
 indicates that the segment ends with the cable termination point. **/
 class CableSegment {
 public:
@@ -1724,23 +1720,21 @@ public:
 
     const CableSubsystem& getSubsystem() const
     {
-        if (!m_subsystem) {
-            SimTK_ERRCHK_ALWAYS(
-                m_subsystem,
-                "CableSegment::getSubsystem()",
-                "CableSpan not yet adopted by any CableSubsystem");
-        }
+        SimTK_ERRCHK_ALWAYS(
+            m_subsystem,
+            "CableSegment::getSubsystem()",
+            "CableSpan not yet adopted by any CableSubsystem");
+
         return *m_subsystem;
     }
 
     CableSubsystem& updSubsystem()
     {
-        if (!m_subsystem) {
-            SimTK_ERRCHK_ALWAYS(
-                m_subsystem,
-                "CableSegment::updSubsystem()",
-                "CableSpan not yet adopted by any CableSubsystem");
-        }
+        SimTK_ERRCHK_ALWAYS(
+            m_subsystem,
+            "CableSegment::updSubsystem()",
+            "CableSpan not yet adopted by any CableSubsystem");
+
         return *m_subsystem;
     }
 
@@ -1796,7 +1790,7 @@ private:
     CableSpanIndex m_cableIndex = CableSpanIndex::Invalid();
     // The index of this CableSegment in the CableSpan.
     CableSegmentIndex m_index = CableSegmentIndex::Invalid();
-    
+
     // The indexes to the wrap obstacles belonging to this segment.
     Array_<ObstacleIndex> m_obstacleIndexes;
 
@@ -1953,27 +1947,27 @@ public:
 
     const CurveSegment& getObstacleCurveSegment(ObstacleIndex ix) const
     {
-        return m_curveSegments[ix];
+        return m_curveSegments.at(ix);
     }
 
     CurveSegment& updObstacleCurveSegment(ObstacleIndex ix)
     {
-        return m_curveSegments[ix];
+        return m_curveSegments.at(ix);
     }
 
     const ViaPoint& getViaPoint(ViaPointIndex ix) const
     {
-        return m_viaPoints[ix];
+        return m_viaPoints.at(ix);
     }
 
     ViaPoint& updViaPoint(ViaPointIndex ix)
     {
-        return m_viaPoints[ix];
+        return m_viaPoints.at(ix);
     }
 
     const CableSegment& getCableSegment(CableSegmentIndex ix) const
     {
-        return m_cableSegments[ix];
+        return m_cableSegments.at(ix);
     }
 
     CableSpanParameters& updParameters()
@@ -2043,20 +2037,20 @@ public:
     // Helper functions: CableSegment initial and final points.
     //--------------------------------------------------------------------------
 
-    Vec3 calcInitialCableSegmentPointInGround(const State& s, 
+    Vec3 calcInitialCableSegmentPointInGround(const State& s,
         const CableSegment& cableSegment) const
     {
-        if (cableSegment.getInitialViaPointIndex().isValid()) { 
+        if (cableSegment.getInitialViaPointIndex().isValid()) {
             return getViaPoint(cableSegment.getInitialViaPointIndex())
                                 .getStation_G(s);
         }
         return calcOriginPointInGround(s);
     }
 
-    Vec3 calcFinalCableSegmentPointInGround(const State& s, 
+    Vec3 calcFinalCableSegmentPointInGround(const State& s,
         const CableSegment& cableSegment) const
     {
-        if (cableSegment.getFinalViaPointIndex().isValid()) {   
+        if (cableSegment.getFinalViaPointIndex().isValid()) {
             return getViaPoint(cableSegment.getFinalViaPointIndex())
                                 .getStation_G(s);
         }
@@ -2067,7 +2061,7 @@ public:
     // Helper functions: ViaPoint direction cache entries.
     //--------------------------------------------------------------------------
 
-    void invalidateViaPointDirectionCacheEntries(const State& s, 
+    void invalidateViaPointDirectionCacheEntries(const State& s,
         const CableSegment& cableSegment) const
     {
         if (cableSegment.getInitialViaPointIndex().isValid()) {
@@ -2092,6 +2086,11 @@ public:
     {
         invalidateTopology();
 
+        SimTK_ASSERT(
+            !m_cableSegments.empty(),
+            "No cable segments found. An initial cable segment should have "
+            "been added by the CableSpan constructor.");
+
         ObstacleIndex obstacleIx(m_curveSegments.size());
 
         m_curveSegments.push_back(CurveSegment(
@@ -2111,10 +2110,15 @@ public:
     }
 
     ViaPointIndex addViaPoint(
-        MobilizedBodyIndex viaPointBody, 
+        MobilizedBodyIndex viaPointBody,
         const Vec3& station_B)
     {
         invalidateTopology();
+
+        SimTK_ASSERT(
+            !m_cableSegments.empty(),
+            "No cable segments found. An initial cable segment should have "
+            "been added by the CableSpan constructor.");
 
         ViaPointIndex viaPointIx(m_viaPoints.size());
 
@@ -2122,7 +2126,7 @@ public:
             m_subsystem,
             getIndex(),
             viaPointIx,
-            viaPointBody, 
+            viaPointBody,
             station_B));
 
         // Mark the end of the last CableSegment with this ViaPoint.
@@ -2468,14 +2472,14 @@ private:
                     const MobilizedBody& mobod = curve.getMobilizedBody();
                     const CurveSegmentData::Position& curveDataPos =
                         curve.getDataPos(s);
-    
+
                     // Ending point and velocity of straight line segment.
                     const Vec3 x_GP = curveDataPos.X_GP.p();
                     const Vec3 v_GP = CalcPointVelocityInGround(mobod, x_GP);
-    
+
                     // Compute the lengthening.
                     lengthDot += dot(UnitVec3(x_GP - x_GQ), v_GP - v_GQ);
-    
+
                     // Set the next straight line starting point and velocity.
                     x_GQ = curveDataPos.X_GQ.p();
                     v_GQ = CalcPointVelocityInGround(mobod, x_GQ);
@@ -2568,13 +2572,22 @@ ObstacleIndex CurveSegment::findPrevObstacleInContactWithCable(
     const CableSpan::Impl& cable = getCable();
     const CableSegment& cableSegment = cable.getCableSegment(
         getCableSegmentIndex());
+    const Array_<ObstacleIndex, ObstacleIndex>& obstacleIndexes =
+        cableSegment.getObstacleIndexes();
+
+    // If there are no obstacles in this cable segment, there can't be any
+    // previous obstacles in contact.
+    if (obstacleIndexes.empty()) {
+        return ObstacleIndex::Invalid();
+    }
 
     // Find the first obstacle that makes contact before this curve segment
     // in the current cable segment.
-    for (ObstacleIndex ix(m_obstacleIndex); 
-            ix > cableSegment.getObstacleIndexes().front(); --ix) {
+    for (ObstacleIndex ix(m_obstacleIndex);
+            ix > obstacleIndexes.front(); --ix) {
         ObstacleIndex prevIx(ix - 1);
-        const CurveSegment& curveSegment = cable.getObstacleCurveSegment(prevIx);
+        const CurveSegment& curveSegment =
+            cable.getObstacleCurveSegment(prevIx);
         if (curveSegment.isInContactWithSurface(state)) {
             return prevIx;
         }
@@ -2590,11 +2603,19 @@ ObstacleIndex CurveSegment::findNextObstacleInContactWithCable(
     const CableSpan::Impl& cable = getCable();
     const CableSegment& cableSegment = cable.getCableSegment(
         getCableSegmentIndex());
-    
+    const Array_<ObstacleIndex, ObstacleIndex>& obstacleIndexes =
+        cableSegment.getObstacleIndexes();
+
+    // If there are no obstacles in this cable segment, there can't be any
+    // next obstacles in contact.
+    if (obstacleIndexes.empty()) {
+        return ObstacleIndex::Invalid();
+    }
+
     // Find the first active obstacle after this curve segment in the current
     // cable segment.
-    for (ObstacleIndex ix(m_obstacleIndex + 1); 
-            ix < cableSegment.getObstacleIndexes().back()+1; ++ix) {
+    for (ObstacleIndex ix(m_obstacleIndex + 1);
+            ix < obstacleIndexes.back()+1; ++ix) {
         const CurveSegment& curveSegment = cable.getObstacleCurveSegment(ix);
         if (curveSegment.isInContactWithSurface(state)) {
             return ix;
@@ -2610,15 +2631,20 @@ Vec3 CurveSegment::findPrevPathPoint_G(const State& state) const
     const CableSpan::Impl& cable = getCable();
     const CableSegment& cableSegment = cable.getCableSegment(
         getCableSegmentIndex());
-    
+    const Array_<ObstacleIndex, ObstacleIndex>& obstacleIndexes =
+        cableSegment.getObstacleIndexes();
+
     // Check if there is a curve segment preceding this curve segment in the
     // current cable segment.
-    for (ObstacleIndex ix(m_obstacleIndex); 
-            ix > cableSegment.getObstacleIndexes().front(); --ix) {
-        ObstacleIndex prevIx(ix - 1);
-        const CurveSegment& curveSegment = cable.getObstacleCurveSegment(prevIx);
-        if (curveSegment.isInContactWithSurface(state)) {
-            return curveSegment.calcFinalContactPoint_G(state);
+    if (!obstacleIndexes.empty()) {
+        for (ObstacleIndex ix(m_obstacleIndex);
+                ix > obstacleIndexes.front(); --ix) {
+            ObstacleIndex prevIx(ix - 1);
+            const CurveSegment& curveSegment =
+                cable.getObstacleCurveSegment(prevIx);
+            if (curveSegment.isInContactWithSurface(state)) {
+                return curveSegment.calcFinalContactPoint_G(state);
+            }
         }
     }
 
@@ -2642,14 +2668,18 @@ Vec3 CurveSegment::findNextPathPoint_G(const State& state) const
     const CableSpan::Impl& cable = getCable();
     const CableSegment& cableSegment = cable.getCableSegment(
         getCableSegmentIndex());
+    const Array_<ObstacleIndex, ObstacleIndex>& obstacleIndexes =
+        cableSegment.getObstacleIndexes();
 
-    // Check if there is a curve segment following this curve segment in the 
+    // Check if there is a curve segment following this curve segment in the
     // current cable segment.
-    for (ObstacleIndex ix(m_obstacleIndex + 1); 
-            ix < cableSegment.getObstacleIndexes().back()+1; ++ix) {
-        const CurveSegment& curveSegment = cable.getObstacleCurveSegment(ix);
-        if (curveSegment.isInContactWithSurface(state)) {
-            return curveSegment.calcInitialContactPoint_G(state);
+    if (!obstacleIndexes.empty()) {
+        for (ObstacleIndex ix(m_obstacleIndex + 1);
+                ix < obstacleIndexes.back()+1; ++ix) {
+            const CurveSegment& curveSegment = cable.getObstacleCurveSegment(ix);
+            if (curveSegment.isInContactWithSurface(state)) {
+                return curveSegment.calcInitialContactPoint_G(state);
+            }
         }
     }
 
@@ -2710,7 +2740,7 @@ void calcUnitForceExertedByViaPoint(
     const UnitVec3& outgoingDirection_G = viaPoint.getOutgoingDirection(s);
 
     // The via point moment arm in ground.
-    const Vec3& r_G = viaPoint.getStation_G(s) - x_GB;
+    const Vec3 r_G = viaPoint.getStation_G(s) - x_GB;
 
     // The incoming direction is along the negative force direction, while the
     // outgoing direction is along the force direction:
@@ -2894,7 +2924,7 @@ void calcLineSegments(
     }
 
     // Compute the last line segment.
-    lines.emplace_back(prevPathPoint, 
+    lines.emplace_back(prevPathPoint,
         cable.calcFinalCableSegmentPointInGround(s, cableSegment));
 }
 
@@ -3419,7 +3449,7 @@ void CableSpan::Impl::calcSolverStep(
         data.lineSegments);
 
     data.maxPathError = 0.; // Reset the max path error field.
-    // Only compute the path errors if there are obstacles in contact with the 
+    // Only compute the path errors if there are obstacles in contact with the
     // cable.
     if (data.numObstaclesInContact > 0) {
         calcPathErrorVector<1>(
@@ -3530,7 +3560,7 @@ void CableSpan::Impl::calcSolverStep(
         Matrix& V     = data.rightSingularValues;
 
         // Compute the normal path error jacobian.
-        calcPathErrorJacobian<1>(cableSegment, s, data.lineSegments, 
+        calcPathErrorJacobian<1>(cableSegment, s, data.lineSegments,
             {NormalAxis}, J);
 
         // Compute the gradient and Hessian of the cable length.
@@ -3604,26 +3634,27 @@ const CableSpanData::Position& CableSpan::Impl::calcDataPos(
     // This helper function will extract the useful information from the path
     // solver output, and write to the cached CableSpanData.
     auto updDataPosFromSolverResult =
-        [&](const State& s, const CableSegment& cableSegment,
+        [&](const State& s,
+            const CableSegment& cableSegment,
             const MatrixWorkspace& workspace,
             int solverLoopCount)
     {
         dataPos.cableLength += calcCableSegmentLength(
             s, cableSegment, workspace.lineSegments);
-        dataPos.smoothness = std::max(workspace.maxPathError, 
+        dataPos.smoothness = std::max(workspace.maxPathError,
             dataPos.smoothness);
         dataPos.loopIter += solverLoopCount;
 
         // An invalid initial via point index indicates that the segment begins
         // with the cable origin point.
-        ViaPointIndex initialViaPointIndex = 
+        ViaPointIndex initialViaPointIndex =
             cableSegment.getInitialViaPointIndex();
         if (initialViaPointIndex.isValid()) {
             const ViaPoint& viaPoint = getViaPoint(initialViaPointIndex);
-            viaPoint.setOutgoingDirection(s, 
+            viaPoint.setOutgoingDirection(s,
                 workspace.lineSegments.front().direction);
         } else {
-            dataPos.originTangent_G = 
+            dataPos.originTangent_G =
                 workspace.lineSegments.front().direction;
         }
 
@@ -3632,10 +3663,10 @@ const CableSpanData::Position& CableSpan::Impl::calcDataPos(
         ViaPointIndex finalViaPointIndex = cableSegment.getFinalViaPointIndex();
         if (finalViaPointIndex.isValid()) {
             const ViaPoint& viaPoint = getViaPoint(finalViaPointIndex);
-            viaPoint.setIncomingDirection(s, 
+            viaPoint.setIncomingDirection(s,
                 workspace.lineSegments.back().direction);
         } else {
-            dataPos.terminationTangent_G = 
+            dataPos.terminationTangent_G =
                 workspace.lineSegments.back().direction;
         }
     };
@@ -3651,7 +3682,7 @@ const CableSpanData::Position& CableSpan::Impl::calcDataPos(
     // with each.
     for (CableSegmentIndex cix(0); cix < getNumCableSegments(); ++cix) {
         const CableSegment& cableSegment = getCableSegment(cix);
-        Array_<ObstacleIndex> obstacleIndexes = 
+        const Array_<ObstacleIndex>& obstacleIndexes =
             cableSegment.getObstacleIndexes();
 
         // Start the solver loop for the sub-problem associated with this
@@ -3666,16 +3697,15 @@ const CableSpanData::Position& CableSpan::Impl::calcDataPos(
             // This will transform all last computed geodesics to Ground frame,
             // and will update each curve's WrappingStatus.
             for (ObstacleIndex ix : obstacleIndexes) {
-                const CurveSegment& curveSegment = getObstacleCurveSegment(ix);
-                curveSegment.calcDataPos(s);
-            } 
-            
+                getObstacleCurveSegment(ix).calcDataPos(s);
+            }
+
             // Grab the matrix workspace used by the solver.
             MatrixWorkspace& workspace = updDataInst(s).updOrInsert(
                 countActive(s, cableSegment));
 
             // Compute the path corrections required to reach the optimal path.
-            calcSolverStep(s, cableSegment, getParameters().algorithm, 
+            calcSolverStep(s, cableSegment, getParameters().algorithm,
                 workspace);
 
             // Check if we should stop iterating on this sub-problem.
@@ -3686,7 +3716,7 @@ const CableSpanData::Position& CableSpan::Impl::calcDataPos(
                 break;
             }
 
-            // Apply the corrections to each CurveSegment to reduce the path 
+            // Apply the corrections to each CurveSegment to reduce the path
             // error.
             const Vector& pathCorrection = workspace.pathCorrection;
             int activeCurveIx = 0; // Index of curve in all that are in contact.
@@ -3705,10 +3735,9 @@ const CableSpanData::Position& CableSpan::Impl::calcDataPos(
             // The applied corrections have changed the path: invalidate each
             // curve segment's cache for this cable segment.
             for (ObstacleIndex ix : obstacleIndexes) {
-                const CurveSegment& curve = getObstacleCurveSegment(ix);
                 // Also invalidate non-active segments: They might touchdown
                 // again.
-                curve.invalidatePosEntry(s);
+                getObstacleCurveSegment(ix).invalidatePosEntry(s);
             }
             // The path corrections only invalidate the direction cache entries,
             // not the station cache entry.
@@ -3799,7 +3828,7 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
 
         // Run the perturbation test for each cable segment.
         for (CableSegmentIndex ix(0); ix < cable.getNumCableSegments(); ++ix) {
-            testReport << "Testing CableSegment " << ix + 1 << " of " 
+            testReport << "Testing CableSegment " << ix + 1 << " of "
                        << cable.getNumCableSegments() << "\n";
 
             // Get the cable segment.
@@ -3818,13 +3847,13 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
                 continue;
             }
 
-            // Apply a small perturbation to each of the curve segments in the 
-            // form of a geodesic correction. There are 4 DOF for each geodesic, 
-            // and just to be sure we apply a negative and positive perturbation 
+            // Apply a small perturbation to each of the curve segments in the
+            // form of a geodesic correction. There are 4 DOF for each geodesic,
+            // and just to be sure we apply a negative and positive perturbation
             // along each DOF of each geodesic.
             Real perturbation = m_perturbationTestParameters.perturbation;
             for (int i = 0; i < c_GeodesicDOF * 2 * nActive + 1; ++i) {
-                // We do not want to mess with the actual state, so we make a 
+                // We do not want to mess with the actual state, so we make a
                 // copy.
                 const State sCopy = state;
                 cableSegment.getSubsystem().getMultibodySystem().realize(
@@ -3832,23 +3861,23 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
 
                 // Trigger realizing position level cache, resetting the
                 // configuration.
-                const CableSpanData::Position& dataPos = 
+                const CableSpanData::Position& dataPos =
                     cableSegment.getCable().getDataPos(sCopy);
 
-                // The wrapping status of each obstacle is reset after copying 
-                // the state. The matrix sizes are no longer compatible if this 
-                // results in a change in wrapping status (if we are touching 
-                // down during this realization for example). We can only test 
-                // the Jacobian if the wrapping status of all obstacles remains 
+                // The wrapping status of each obstacle is reset after copying
+                // the state. The matrix sizes are no longer compatible if this
+                // results in a change in wrapping status (if we are touching
+                // down during this realization for example). We can only test
+                // the Jacobian if the wrapping status of all obstacles remains
                 // the same.
                 if (cable.countActive(sCopy, cableSegment) != nActive) {
-                    testReport << 
+                    testReport <<
                         "Cable wrapping status changed after cloning the state: "
                         "Skipping perturbation test\n";
                     break;
                 }
 
-                // Compute the path error vector and Jacobian, before the 
+                // Compute the path error vector and Jacobian, before the
                 // applied perturbation.
                 std::vector<LineSegment> lineSegments(nActive + 1);
 
@@ -3883,11 +3912,11 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
                     {NormalAxis, BinormalAxis},
                     pathErrorJacobian);
 
-                length = calcCableSegmentLength(sCopy, cableSegment, 
+                length = calcCableSegmentLength(sCopy, cableSegment,
                     lineSegments);
-                calcLengthGradient(sCopy, cableSegment, lineSegments, 
+                calcLengthGradient(sCopy, cableSegment, lineSegments,
                     lengthGradient);
-                calcLengthHessian(sCopy, cableSegment, lineSegments, 
+                calcLengthHessian(sCopy, cableSegment, lineSegments,
                     lengthHessian);
 
                 // Define the perturbation we will use for testing the Jacobian.
@@ -3908,7 +3937,7 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
                 // Store the wrapping status before applying the perturbation.
                 std::vector<ObstacleWrappingStatus> prevWrappingStatus;
                 for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
-                    const CurveSegment& curve = 
+                    const CurveSegment& curve =
                         cable.getObstacleCurveSegment(ix);
                     prevWrappingStatus.push_back(
                         curve.getDataInst(sCopy).wrappingStatus);
@@ -3917,7 +3946,7 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
                 // Apply the perturbation.
                 int activeCurveIx = 0; // Index of curves that are in contact.
                 for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
-                    const CurveSegment& curve = 
+                    const CurveSegment& curve =
                         cable.getObstacleCurveSegment(ix);
                     if (curve.isInContactWithSurface(sCopy)) {
                         curve.applyGeodesicCorrection(
@@ -3930,15 +3959,15 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
                 }
 
                 for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
-                    const CurveSegment& curve = 
+                    const CurveSegment& curve =
                         cable.getObstacleCurveSegment(ix);
                     curve.invalidatePosEntry(sCopy);
                 }
-                cable.invalidateViaPointDirectionCacheEntries(sCopy, 
+                cable.invalidateViaPointDirectionCacheEntries(sCopy,
                     cableSegment);
 
                 for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
-                    const CurveSegment& curve = 
+                    const CurveSegment& curve =
                         cable.getObstacleCurveSegment(ix);
                     curve.calcDataPos(sCopy);
                 }
@@ -3963,11 +3992,11 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
                     {NormalAxis, BinormalAxis},
                     pathErrorJacobian);
 
-                length = calcCableSegmentLength(sCopy, cableSegment, 
+                length = calcCableSegmentLength(sCopy, cableSegment,
                     lineSegments);
-                calcLengthGradient(sCopy, cableSegment, lineSegments, 
+                calcLengthGradient(sCopy, cableSegment, lineSegments,
                     lengthGradient);
-                calcLengthHessian(sCopy, cableSegment, lineSegments, 
+                calcLengthHessian(sCopy, cableSegment, lineSegments,
                     lengthHessian);
 
                 // The curve lengths are clipped at zero, which distorts the
@@ -3980,12 +4009,12 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
 
                 // We can only use the path error Jacobian if the small
                 // perturbation did not trigger any liftoff or touchdown on any
-                // obstacles. If any CurveSegment's WrappingStatus has changed, 
+                // obstacles. If any CurveSegment's WrappingStatus has changed,
                 // we will not continue with the test. Since the perturbation is
                 // small, this is unlikely to happen often.
                 std::vector<ObstacleWrappingStatus> nextWrappingStatus;
                 for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
-                    const CurveSegment& curve = 
+                    const CurveSegment& curve =
                         cable.getObstacleCurveSegment(ix);
                     nextWrappingStatus.push_back(
                         curve.getDataInst(sCopy).wrappingStatus);
@@ -4029,7 +4058,7 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
                 }
                 // Evaluate the length gradient.
                 {
-                    const Real predictionError = 
+                    const Real predictionError =
                         std::abs(predictedLength - length);
                     bool passedTest =
                         std::abs(predictionError / perturbation) <= tolerance;
@@ -4063,9 +4092,9 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
                         testReport << "FAILED length Hessian perturbation test for correction = "
                                    << pathCorrection << "\n";
                         testReport << "length gradient after perturbation:\n";
-                        testReport << "    Got        : " 
+                        testReport << "    Got        : "
                                    << lengthGradient << "\n";
-                        testReport << "    Predicted  : " 
+                        testReport << "    Predicted  : "
                                    << predictedLengthGradient << "\n";
                         testReport << "    Difference : "
                                    << predictionError / perturbation
@@ -4083,7 +4112,7 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
                     success = success && passedTest;
                 }
             }
-        }        
+        }
     }
 
     // Flush all info to the report, in case we throw an exception.
@@ -4619,7 +4648,7 @@ int CableSpan::getNumObstacles() const
 }
 
 ViaPointIndex CableSpan::addViaPoint(
-    MobilizedBodyIndex viaPointBody, 
+    MobilizedBodyIndex viaPointBody,
     const Vec3& station_B)
 {
     return updImpl().addViaPoint(viaPointBody, station_B);
@@ -4688,7 +4717,7 @@ void CableSpan::setObstacleContactPointHint(
 const MobilizedBodyIndex& CableSpan::getViaPointMobilizedBodyIndex(
     ViaPointIndex ix) const
 {
-    return getImpl().getViaPoint(ix).getMobilizedBodyIndex();   
+    return getImpl().getViaPoint(ix).getMobilizedBodyIndex();
 }
 
 void CableSpan::setViaPointMobilizedBodyIndex(

--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -1508,21 +1508,23 @@ public:
     // Allocate the cache entries.
     void realizeTopology(State& state)
     {
+        const Vec3 initVec3{0.};
+        const UnitVec3 initUnitVec3; // internally initializes to all-NaN.
         m_indexStation_G = updSubsystem().allocateCacheEntry(
             state,
             Stage::Position,
             Stage::Infinity,
-            new Value<Vec3>(Vec3(0.)));
+            new Value<Vec3>(initVec3));
         m_indexIncomingDirection = updSubsystem().allocateCacheEntry(
             state,
             Stage::Position,
             Stage::Infinity,
-            new Value<UnitVec3>(UnitVec3(NaN)));
+            new Value<UnitVec3>(initUnitVec3));
         m_indexOutgoingDirection = updSubsystem().allocateCacheEntry(
             state,
             Stage::Position,
             Stage::Infinity,
-            new Value<UnitVec3>(UnitVec3(NaN)));
+            new Value<UnitVec3>(initUnitVec3));
     }
 
     void invalidateDirectionCacheEntries(const State& state) const

--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -4490,7 +4490,6 @@ int CableSubsystem::Impl::calcDecorativeGeometryAndAppendImpl(
 CableSubsystem::CableSubsystem(MultibodySystem& mbs)
 {
     adoptSubsystemGuts(new Impl());
-    mbs.adoptSubsystem(*this);
     mbs.setCableSubsystem(*this);
 }
 

--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -309,9 +309,11 @@ struct CableSpanData {
         // Tangent vector to the cable at the termination point, in the ground
         // frame.
         UnitVec3 terminationTangent_G{NaN, NaN, NaN};
-        // Tangent vectors incoming to the via points, in the ground frame.
+        // Tangent vectors to the cable segments incoming to (i.e., immediately
+        // prior to) each via point in the path, in the ground frame.
         Array_<UnitVec3, ViaPointIndex> viaPointInTangents_G;
-        // Tangent vectors outgoing from the via points, in the ground frame.
+        // Tangent vectors to the cable segments outgoing from (i.e.,
+        // immediately following) each via point in the path, in the ground frame.
         Array_<UnitVec3, ViaPointIndex> viaPointOutTangents_G;
         // The total cable length.
         Real cableLength = NaN;
@@ -1647,12 +1649,12 @@ private:
 //==============================================================================
 //                              Cable Segment
 //==============================================================================
-/* This is a helper struct for managing segments of the cable path that are
+/* This is a helper class for managing segments of the cable path that are
 separated by via points. It stores an ordered list of the obstacle indexes
 associated with this segment and indexes to the initial and final via points, if
 they exist. An invalid initial via point index indicates that the segment begins
 with the cable origin point. Similarly, an invalid final via point index
-indicates that the segment ends with the cable termination point. **/
+indicates that the segment ends with the cable termination point. */
 class CableSegment {
 public:
     CableSegment() = default;
@@ -1742,7 +1744,8 @@ private:
     // The indexes to the wrap obstacles belonging to this segment.
     Array_<ObstacleIndex> m_obstacleIndexes;
 
-    // The indexes to the initial and final via points belonging to this segment.
+    // The indexes to the initial and final via points belonging to this
+    // segment.
     ViaPointIndex m_initialViaPointIndex = ViaPointIndex::Invalid();
     ViaPointIndex m_finalViaPointIndex = ViaPointIndex::Invalid();
 
@@ -2552,7 +2555,7 @@ ObstacleIndex CurveSegment::findNextObstacleInContactWithCable(
     // Find the first active obstacle after this curve segment in the current
     // cable segment.
     for (ObstacleIndex ix(m_obstacleIndex + 1);
-            ix < obstacleIndexes.back()+1; ++ix) {
+            ix <= obstacleIndexes.back(); ++ix) {
         const CurveSegment& curveSegment = cable.getObstacleCurveSegment(ix);
         if (curveSegment.isInContactWithSurface(state)) {
             return ix;
@@ -2612,7 +2615,7 @@ Vec3 CurveSegment::findNextPathPoint_G(const State& state) const
     // current cable segment.
     if (!obstacleIndexes.empty()) {
         for (ObstacleIndex ix(m_obstacleIndex + 1);
-                ix < obstacleIndexes.back()+1; ++ix) {
+                ix <= obstacleIndexes.back(); ++ix) {
             const CurveSegment& curveSegment = cable.getObstacleCurveSegment(ix);
             if (curveSegment.isInContactWithSurface(state)) {
                 return curveSegment.calcInitialContactPoint_G(state);

--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -18,6 +18,7 @@
 
 #include "CableSpan_SubsystemTestHelper_Impl.h"
 
+#include "simbody/internal/common.h"
 #include "simbody/internal/CableSpan.h"
 #include "simbody/internal/MultibodySystem.h"
 #include "simbody/internal/SimbodyMatterSubsystem.h"
@@ -26,8 +27,14 @@
 
 using namespace SimTK;
 
+// Define a unique index for cable segments.
+namespace { 
+SimTK_DEFINE_UNIQUE_INDEX_TYPE(CableSegmentIndex);
+}
+
 // For convenience.
 using ObstacleIndex = CableSpanObstacleIndex;
+using ViaPointIndex = CableSpanViaPointIndex;
 
 //==============================================================================
 //                            Data Structures
@@ -124,13 +131,13 @@ struct MatrixWorkspace {
     explicit MatrixWorkspace(int problemSize)
     {
         // Total number of obstacles in contact with cable.
-        const int n = problemSize;
+        numObstaclesInContact = problemSize;
         // Dimension of the free variable vector: all geodesic corrections.
-        const int nQ = n * c_GeodesicDOF;
+        const int nQ = numObstaclesInContact * c_GeodesicDOF;
         // Total number of constraints (2 per obstacle).
-        const int nC = n * 2;
+        const int nC = numObstaclesInContact * 2;
 
-        lineSegments.resize(n + 1);
+        lineSegments.resize(numObstaclesInContact + 1);
         pathCorrection = Vector(nQ, 0.);
 
         normalPathError   = Vector(nC, 0.);
@@ -167,6 +174,8 @@ struct MatrixWorkspace {
             pathCorrection[eltIx + 3]};
     }
 
+    /* The number of obstacles in contact with the cable. */
+    int numObstaclesInContact;
     /* All straight line segments in the current path. */
     std::vector<LineSegment> lineSegments;
     /* The path correction vector contains the NaturalGeodesicCorrection
@@ -618,8 +627,8 @@ private:
 //==============================================================================
 //                          Struct Curve Segment
 //==============================================================================
-/* The CableSpan's path consists of straight line segments between the
-obstacles, and curved segments over the obstacles. This struct represents the
+/* The CableSpan's path consists of straight line segments between obstacles and
+via points, and curved segments over the obstacles. This struct represents the
 curve segment related to an obstacle in the path. It manages the cached data
 related to that obstacle such as the WrappingStatus, the geodesic in local
 coordinates, and the contact points in Ground frame coordinates. */
@@ -634,14 +643,18 @@ public:
     CurveSegment(
         CableSubsystem* subsystem,
         CableSpanIndex cableIndex,
+        CableSegmentIndex cableSegmentIndex,
         ObstacleIndex obstacleIndex,
         MobilizedBodyIndex obstacleBody,
         Transform X_BS,
         std::shared_ptr<const ContactGeometry> obstacleGeometry,
         const Vec3& contactPointHint_S) :
         m_subsystem(subsystem),
-        m_cableIndex(cableIndex), m_obstacleIndex(obstacleIndex),
-        m_body(obstacleBody), m_X_BS(std::move(X_BS)),
+        m_cableIndex(cableIndex),
+        m_cableSegmentIndex(cableSegmentIndex),
+        m_obstacleIndex(obstacleIndex),
+        m_body(obstacleBody),
+        m_X_BS(std::move(X_BS)),
         m_geometry(std::move(obstacleGeometry)),
         m_contactPointHint_S(contactPointHint_S)
     {}
@@ -732,9 +745,9 @@ public:
             getSubsystem().updCacheEntry(state, m_indexDataPos));
     }
 
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
     // Model configuration accessors.
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
     // Set the user defined point that controls the initial wrapping path.
     // Point is in surface coordinates.
@@ -826,11 +839,17 @@ public:
     {
         return getSubsystem().getImpl().getCableImpl(m_cableIndex);
     }
+
+    CableSegmentIndex getCableSegmentIndex() const
+    {
+        return m_cableSegmentIndex;
+    }
+
     const IntegratorTolerances& getIntegratorTolerances() const;
 
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
     // Utility functions.
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
     Transform calcSurfaceFrameInGround(const State& state) const
     {
@@ -849,7 +868,7 @@ public:
             getDataInst(state).X_SQ.p());
     }
 
-    bool isInContactWithSurface(const State& state) const
+    bool isInContactWithSurface(const State& state) const 
     {
         const CurveSegmentData::Instance& dataInst = getDataInst(state);
         return dataInst.wrappingStatus ==
@@ -857,16 +876,19 @@ public:
                dataInst.wrappingStatus == ObstacleWrappingStatus::InitialGuess;
     }
 
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
     //  Helper Functions: Finding next and previous CurveSegments
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
     // The functions below essentially filter any obstacles that are not in
     // contact with the cable.
 
     // Find the first obstacle before this segment that is in contact with the
-    // cable. Returns an invalid index if there is none.
+    // cable. Returns an invalid index if there is none, e.g., the previous 
+    // point in the path is a via point or the path origin.
     ObstacleIndex findPrevObstacleInContactWithCable(const State& state) const;
-    // Similarly find the first obstacle after this segment that is in contact.
+    // Find the first obstacle after this segment that is in contact with the
+    // cable. Returns an invalid index if there is none, e.g., the next point 
+    // in the path is a via point or the path termination.
     ObstacleIndex findNextObstacleInContactWithCable(const State& state) const;
 
     // Find the last path point before this segment, in ground frame
@@ -899,11 +921,11 @@ public:
             "CurveSegment::Impl::assertSurfaceBounds",
             "Next point lies inside the surface");
         return nextPoint_S;
-    }
+    } 
 
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
     //  Updating CurveSegmentData::Instance Helpers
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
     // Compute a new geodesic from provided initial conditions.
     void shootNewGeodesic(
@@ -1181,9 +1203,9 @@ public:
         liftCurveFromSurface(dataInst.X_SP.p(), updDataInst(state));
     }
 
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
     //  Computing cached data
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
     // Apply the correction to the initial condition of the geodesic, and
     // shoot a new geodesic, updating the cache variable.
@@ -1272,7 +1294,7 @@ public:
         // Update the Stage::Position level cache.
         CurveSegmentData::Position& dataPos = updDataPos(state);
 
-        // Store tramsform from local surface frame to ground.
+        // Store transform from local surface frame to ground.
         dataPos.X_GS = calcSurfaceFrameInGround(state);
 
         // Check if the obstacle is in contact with the cable.
@@ -1340,9 +1362,9 @@ public:
         return dataPos;
     }
 
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
     //  Generating Geodesic Points For Visualization
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
     void calcDecorativePathPoints(
         const State& state,
@@ -1422,16 +1444,18 @@ public:
 private:
     //------------------------------------------------------------------------------
     // Data
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
     // Subsystem info.
     CableSubsystem* m_subsystem = nullptr;
     // The index of this CurveSegment's cable in the CableSubsystem.
     CableSpanIndex m_cableIndex = CableSpanIndex::Invalid();
+    // The index of the CableSegment that this CurveSegment belongs to.
+    CableSegmentIndex m_cableSegmentIndex = CableSegmentIndex::Invalid();
     // The index of this CurveSegment's obstacle in the cable.
     ObstacleIndex m_obstacleIndex = ObstacleIndex::Invalid();
 
-    // MobilizedBody that surface is attached to.
+    // MobilizedBody that the curve segment is attached to.
     MobilizedBodyIndex m_body;
     // Surface to body transform.
     Transform m_X_BS;
@@ -1446,7 +1470,341 @@ private:
     // Initial contact point hint used to setup the initial path.
     Vec3 m_contactPointHint_S{NaN, NaN, NaN};
 
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    // Helper class for unit tests.
+    friend CableSubsystemTestHelper;
+};
+
+//==============================================================================
+//                          Struct Via Point
+//==============================================================================
+/* This struct represents a zero-length cable segment associated with a via
+point in the path. It manages the cached data such as the position of the via
+point in the ground frame and the direction of the incoming and outgoing line
+segments. */
+class ViaPoint final {
+public:
+    //--------------------------------------------------------------------------
+    // Constructors.
+    //--------------------------------------------------------------------------
+
+    ViaPoint() = default;
+
+    ViaPoint(
+        CableSubsystem* subsystem,
+        CableSpanIndex cableIndex,
+        ViaPointIndex viaPointIndex,
+        MobilizedBodyIndex body,
+        Vec3 station_B) :
+        m_subsystem(subsystem),
+        m_cableIndex(cableIndex),
+        m_viaPointIndex(viaPointIndex),
+        m_body(body),
+        m_station_B(station_B)
+    {}
+
+    //--------------------------------------------------------------------------
+    // Realizing and cache access.
+    //--------------------------------------------------------------------------
+
+    // Allocate the cache entries.
+    void realizeTopology(State& state)
+    {
+        m_indexStation_G = updSubsystem().allocateCacheEntry(
+            state,
+            Stage::Position,
+            Stage::Infinity,
+            new Value<Vec3>());
+        m_indexIncomingDirection = updSubsystem().allocateCacheEntry(
+            state,
+            Stage::Position,
+            Stage::Infinity,
+            new Value<UnitVec3>());
+        m_indexOutgoingDirection = updSubsystem().allocateCacheEntry(
+            state,
+            Stage::Position,
+            Stage::Infinity,
+            new Value<UnitVec3>());
+    }
+
+    void invalidateDirectionCacheEntries(const State& state) const
+    {
+        getSubsystem().markCacheValueNotRealized(
+            state, m_indexIncomingDirection);
+        getSubsystem().markCacheValueNotRealized(
+            state, m_indexOutgoingDirection);
+    }
+
+    const Vec3& getStation_G(const State& state) const
+    {
+        return Value<Vec3>::downcast(
+            getSubsystem().getCacheEntry(state, m_indexStation_G));
+    }
+
+    const UnitVec3& getIncomingDirection(const State& state) const
+    {
+        return Value<UnitVec3>::downcast(
+            getSubsystem().getCacheEntry(state, m_indexIncomingDirection));
+    }
+
+    void setIncomingDirection(
+        const State& state, 
+        const UnitVec3& direction_G) const
+    {
+        updIncomingDirection(state) = direction_G;
+        getSubsystem().markCacheValueRealized(state, m_indexIncomingDirection);
+    }
+
+    const UnitVec3& getOutgoingDirection(const State& state) const
+    {
+        return Value<UnitVec3>::downcast(
+            getSubsystem().getCacheEntry(state, m_indexOutgoingDirection));
+    }
+
+    void setOutgoingDirection(
+        const State& state, 
+        const UnitVec3& direction_G) const
+    {
+        updOutgoingDirection(state) = direction_G;
+        getSubsystem().markCacheValueRealized(state, m_indexOutgoingDirection);
+    }
+
+    //--------------------------------------------------------------------------
+    // Model configuration accessors.
+    //--------------------------------------------------------------------------
+
+    const MobilizedBody& getMobilizedBody() const
+    {
+        return getSubsystem()
+            .getMultibodySystem()
+            .getMatterSubsystem()
+            .getMobilizedBody(m_body);
+    }
+
+    const MobilizedBodyIndex& getMobilizedBodyIndex() const
+    {
+        return m_body;
+    }
+
+    void setMobilizedBodyIndex(MobilizedBodyIndex body)
+    {
+        m_body = body;
+    }
+
+    const CableSubsystem& getSubsystem() const
+    {
+        if (!m_subsystem) {
+            SimTK_ERRCHK_ALWAYS(
+                m_subsystem,
+                "ViaPoint::getSubsystem()",
+                "CableSpan not yet adopted by any CableSubsystem");
+        }
+        return *m_subsystem;
+    }
+
+    CableSubsystem& updSubsystem()
+    {
+        if (!m_subsystem) {
+            SimTK_ERRCHK_ALWAYS(
+                m_subsystem,
+                "ViaPoint::updSubsystem()",
+                "CableSpan not yet adopted by any CableSubsystem");
+        }
+        return *m_subsystem;
+    }
+
+    void setSubsystem(CableSubsystem& subsystem)
+    {
+        m_subsystem = &subsystem;
+    }
+
+    const CableSpan::Impl& getCable() const
+    {
+        return getSubsystem().getImpl().getCableImpl(m_cableIndex);
+    }
+
+    const Vec3& getStation_B() const
+    {
+        return m_station_B;
+    }
+
+    void setStation_B(const Vec3& station_B)
+    {
+        m_station_B = station_B;
+    }
+
+    //--------------------------------------------------------------------------
+    // Computing cached data
+    //--------------------------------------------------------------------------
+    
+    const Vec3& calcStation_G(const State& state) const
+    {
+        Vec3& station_G = updStation_G(state);
+        station_G = getMobilizedBody().getBodyTransform(
+            state).shiftFrameStationToBase(m_station_B);
+        getSubsystem().markCacheValueRealized(state, m_indexStation_G);
+        return station_G;
+    }
+
+    //--------------------------------------------------------------------------
+    // Helper function: via point visualization
+    //--------------------------------------------------------------------------
+
+    void calcDecorativePathPoints(
+        const State& state,
+        const std::function<void(Vec3 point_G)>& sink) const
+    {
+        sink(getStation_G(state));
+    }
+
+private:
+    //--------------------------------------------------------------------------
+    // Private Cache Access.
+    //--------------------------------------------------------------------------
+    Vec3& updStation_G(const State& state) const
+    {
+        return Value<Vec3>::updDowncast(
+            getSubsystem().updCacheEntry(state, m_indexStation_G));
+    }
+
+    UnitVec3& updIncomingDirection(const State& state) const
+    {
+        return Value<UnitVec3>::updDowncast(
+            getSubsystem().updCacheEntry(state, m_indexIncomingDirection));
+    }
+
+    UnitVec3& updOutgoingDirection(const State& state) const
+    {
+        return Value<UnitVec3>::updDowncast(
+            getSubsystem().updCacheEntry(state, m_indexOutgoingDirection));
+    }
+
+    //--------------------------------------------------------------------------
+    // Data
+    //--------------------------------------------------------------------------
+    // Subsystem info.
+    CableSubsystem* m_subsystem = nullptr;
+    // The index of this ViaPoint's cable in the CableSubsystem.
+    CableSpanIndex m_cableIndex = CableSpanIndex::Invalid();
+    // The index of this ViaPoint in the CableSpan.
+    ViaPointIndex m_viaPointIndex = ViaPointIndex::Invalid();
+
+    // MobilizedBody that the via point is attached to.
+    MobilizedBodyIndex m_body;
+    // The position of the via point in the body frame.
+    Vec3 m_station_B;
+
+    // Topology cache.
+    CacheEntryIndex m_indexStation_G = CacheEntryIndex::Invalid();
+    CacheEntryIndex m_indexIncomingDirection = CacheEntryIndex::Invalid();
+    CacheEntryIndex m_indexOutgoingDirection = CacheEntryIndex::Invalid();
+};
+
+//==============================================================================
+//                          Struct Cable Segment
+//==============================================================================
+/* This is a helper struct for managing segments of the cable path that are
+separated by via points. It stores an ordered list of the obstacle indexes 
+associated with this segment and indexes to the initial and final via points, if
+they exist. An invalid initial via point index indicates that the segemnt begins
+with the cable origin point. Similarly, an invalid final via point index 
+indicates that the segment ends with the cable termination point. **/
+class CableSegment {
+public:
+    CableSegment() = default;
+
+    CableSegment(
+        CableSubsystem* subsystem,
+        CableSpanIndex cableIndex,
+        CableSegmentIndex index) :
+        m_subsystem(subsystem),
+        m_cableIndex(cableIndex),
+        m_index(index)
+    {}
+
+    const CableSubsystem& getSubsystem() const
+    {
+        if (!m_subsystem) {
+            SimTK_ERRCHK_ALWAYS(
+                m_subsystem,
+                "CableSegment::getSubsystem()",
+                "CableSpan not yet adopted by any CableSubsystem");
+        }
+        return *m_subsystem;
+    }
+
+    CableSubsystem& updSubsystem()
+    {
+        if (!m_subsystem) {
+            SimTK_ERRCHK_ALWAYS(
+                m_subsystem,
+                "CableSegment::updSubsystem()",
+                "CableSpan not yet adopted by any CableSubsystem");
+        }
+        return *m_subsystem;
+    }
+
+    void setSubsystem(CableSubsystem& subsystem)
+    {
+        m_subsystem = &subsystem;
+    }
+
+    const CableSpan::Impl& getCable() const
+    {
+        return getSubsystem().getImpl().getCableImpl(m_cableIndex);
+    }
+
+    CableSegmentIndex getIndex() const
+    {
+        return m_index;
+    }
+
+    void addObstacleIndex(ObstacleIndex obstacleIndex)
+    {
+        m_obstacleIndexes.push_back(obstacleIndex);
+    }
+
+    const Array_<ObstacleIndex>& getObstacleIndexes() const
+    {
+        return m_obstacleIndexes;
+    }
+
+    void setInitialViaPointIndex(ViaPointIndex viaPointIndex)
+    {
+        m_initialViaPointIndex = viaPointIndex;
+    }
+
+    ViaPointIndex getInitialViaPointIndex() const
+    {
+        return m_initialViaPointIndex;
+    }
+
+    void setFinalViaPointIndex(ViaPointIndex viaPointIndex)
+    {
+        m_finalViaPointIndex = viaPointIndex;
+    }
+
+    ViaPointIndex getFinalViaPointIndex() const
+    {
+        return m_finalViaPointIndex;
+    }
+
+private:
+    // Subsystem info.
+    CableSubsystem* m_subsystem = nullptr;
+    // The index of this CableSegment's cable in the CableSubsystem.
+    CableSpanIndex m_cableIndex = CableSpanIndex::Invalid();
+    // The index of this CableSegment in the CableSpan.
+    CableSegmentIndex m_index = CableSegmentIndex::Invalid();
+    
+    // The indexes to the wrap obstacles belonging to this segment.
+    Array_<ObstacleIndex> m_obstacleIndexes;
+
+    // The indexes to the initial and final via points belonging to this segment.
+    ViaPointIndex m_initialViaPointIndex = ViaPointIndex::Invalid();
+    ViaPointIndex m_finalViaPointIndex = ViaPointIndex::Invalid();
+
+    //--------------------------------------------------------------------------
     // Helper class for unit tests.
     friend CableSubsystemTestHelper;
 };
@@ -1512,6 +1870,10 @@ public:
 
         for (CurveSegment& segment : m_curveSegments) {
             segment.realizeTopology(state);
+        }
+
+        for (ViaPoint& viaPoint : m_viaPoints) {
+            viaPoint.realizeTopology(state);
         }
     }
 
@@ -1599,6 +1961,21 @@ public:
         return m_curveSegments[ix];
     }
 
+    const ViaPoint& getViaPoint(ViaPointIndex ix) const
+    {
+        return m_viaPoints[ix];
+    }
+
+    ViaPoint& updViaPoint(ViaPointIndex ix)
+    {
+        return m_viaPoints[ix];
+    }
+
+    const CableSegment& getCableSegment(CableSegmentIndex ix) const
+    {
+        return m_cableSegments[ix];
+    }
+
     CableSpanParameters& updParameters()
     {
         return m_parameters;
@@ -1645,20 +2022,62 @@ public:
     }
 
     //--------------------------------------------------------------------------
-    // Helper function
+    // Helper function: Counting active curve segments.
     //--------------------------------------------------------------------------
 
     // Count the number of CurveSegments that are in contact with the obstacle's
-    // surface.
-    int countActive(const State& s) const
+    // surface for a given cable segment.
+    int countActive(const State& s, const CableSegment& cableSegment) const
     {
         int counter = 0;
-        for (const CurveSegment& curve : m_curveSegments) {
+        for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
+            const CurveSegment& curve = getObstacleCurveSegment(ix);
             if (curve.isInContactWithSurface(s)) {
                 ++counter;
             }
         }
         return counter;
+    }
+
+    //--------------------------------------------------------------------------
+    // Helper functions: CableSegment initial and final points.
+    //--------------------------------------------------------------------------
+
+    Vec3 calcInitialCableSegmentPointInGround(const State& s, 
+        const CableSegment& cableSegment) const
+    {
+        if (cableSegment.getInitialViaPointIndex().isValid()) { 
+            return getViaPoint(cableSegment.getInitialViaPointIndex())
+                                .getStation_G(s);
+        }
+        return calcOriginPointInGround(s);
+    }
+
+    Vec3 calcFinalCableSegmentPointInGround(const State& s, 
+        const CableSegment& cableSegment) const
+    {
+        if (cableSegment.getFinalViaPointIndex().isValid()) {   
+            return getViaPoint(cableSegment.getFinalViaPointIndex())
+                                .getStation_G(s);
+        }
+        return calcTerminationPointInGround(s);
+    }
+
+    //--------------------------------------------------------------------------
+    // Helper functions: ViaPoint direction cache entries.
+    //--------------------------------------------------------------------------
+
+    void invalidateViaPointDirectionCacheEntries(const State& s, 
+        const CableSegment& cableSegment) const
+    {
+        if (cableSegment.getInitialViaPointIndex().isValid()) {
+            getViaPoint(cableSegment.getInitialViaPointIndex())
+                        .invalidateDirectionCacheEntries(s);
+        }
+        if (cableSegment.getFinalViaPointIndex().isValid()) {
+            getViaPoint(cableSegment.getFinalViaPointIndex())
+                        .invalidateDirectionCacheEntries(s);
+        }
     }
 
     //--------------------------------------------------------------------------
@@ -1678,13 +2097,46 @@ public:
         m_curveSegments.push_back(CurveSegment(
             m_subsystem,
             getIndex(),
+            m_cableSegments.back().getIndex(),
             obstacleIx,
             obstacleBody,
             X_BS,
             std::move(obstacleGeometry),
             contactPointHint_S));
 
+        // Add the obstacle to the current CableSegment.
+        m_cableSegments.back().addObstacleIndex(obstacleIx);
+
         return obstacleIx;
+    }
+
+    ViaPointIndex addViaPoint(
+        MobilizedBodyIndex viaPointBody, 
+        const Vec3& station_B)
+    {
+        invalidateTopology();
+
+        ViaPointIndex viaPointIx(m_viaPoints.size());
+
+        m_viaPoints.push_back(ViaPoint(
+            m_subsystem,
+            getIndex(),
+            viaPointIx,
+            viaPointBody, 
+            station_B));
+
+        // Mark the end of the last CableSegment with this ViaPoint.
+        m_cableSegments.back().setFinalViaPointIndex(viaPointIx);
+
+        // Add a new CableSegment.
+        CableSegmentIndex segmentIx(m_cableSegments.size());
+        m_cableSegments.push_back(CableSegment(
+            m_subsystem,
+            getIndex(),
+            segmentIx));
+        m_cableSegments.back().setInitialViaPointIndex(viaPointIx);
+
+        return viaPointIx;
     }
 
     MobilizedBodyIndex getOriginBodyIndex() const
@@ -1732,6 +2184,16 @@ public:
         return m_curveSegments.size();
     }
 
+    int getNumViaPoints() const
+    {
+        return m_viaPoints.size();
+    }
+
+    int getNumCableSegments() const
+    {
+        return m_cableSegments.size();
+    }
+
     void applyBodyForces(
         const State& state,
         Real tension,
@@ -1747,9 +2209,23 @@ public:
         const CableSpanData::Position& dataPos = getDataPos(state);
         sink(dataPos.originPoint_G);
 
-        // Write path points along each of the curves.
-        for (const CurveSegment& curve : m_curveSegments) {
-            curve.calcDecorativePathPoints(state, sink);
+        // Write the path points for each cable segment.
+        for (CableSegmentIndex ix(0); ix < getNumCableSegments(); ++ix) {
+            const CableSegment& cableSegment = getCableSegment(ix);
+
+            // Write the path points for each obstacle in the cable segment.
+            for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
+                const CurveSegment& curve = getObstacleCurveSegment(ix);
+                curve.calcDecorativePathPoints(state, sink);
+            }
+
+            // Write the path points for the final via point in the cable
+            // segment.
+            if (cableSegment.getFinalViaPointIndex().isValid()) {
+                const ViaPoint& viaPoint = getViaPoint(
+                    cableSegment.getFinalViaPointIndex());
+                viaPoint.calcDecorativePathPoints(state, sink);
+            }
         }
 
         // Write the path's termination point.
@@ -1872,6 +2348,9 @@ private:
         for (CurveSegment& curve : m_curveSegments) {
             curve.setSubsystem(subsystem);
         }
+        for (ViaPoint& viaPoint : m_viaPoints) {
+            viaPoint.setSubsystem(subsystem);
+        }
     }
 
     CableSubsystem& updSubsystem()
@@ -1915,9 +2394,21 @@ private:
             getSubsystem().updCacheEntry(state, m_indexDataVel));
     }
 
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
+    //  Helper function: Creating the first CableSegment
+    //--------------------------------------------------------------------------
+
+    void createFirstCableSegment()
+    {
+        m_cableSegments.push_back(CableSegment(
+            m_subsystem,
+            getIndex(),
+            CableSegmentIndex(0)));
+    }
+
+    //--------------------------------------------------------------------------
     //  Computing cached data
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
     /* Computes a single correction step for driving the path errors to zero.
     This correction can be computed using different algorithms. The resulting
@@ -1925,6 +2416,7 @@ private:
     MatrixWorkspace data output. */
     void calcSolverStep(
         const State& s,
+        const CableSegment& cableSegment,
         CableSpanAlgorithm algorithm,
         MatrixWorkspace& data) const;
 
@@ -1964,23 +2456,49 @@ private:
         Vec3 v_GQ =
             getOriginBody().findStationVelocityInGround(s, m_originStation);
 
-        for (const CurveSegment& curve : m_curveSegments) {
-            if (curve.isInContactWithSurface(s)) {
-                const MobilizedBody& mobod = curve.getMobilizedBody();
-                const CurveSegmentData::Position& curveDataPos =
-                    curve.getDataPos(s);
+        // Compute the lengthening speed contributed by each cable segment.
+        for (CableSegmentIndex ix(0); ix < getNumCableSegments(); ++ix) {
+            const CableSegment& cableSegment = getCableSegment(ix);
+
+            // Add the lengthening speed contributed by each obstacle in the
+            // cable segment.
+            for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
+                const CurveSegment& curve = getObstacleCurveSegment(ix);
+                if (curve.isInContactWithSurface(s)) {
+                    const MobilizedBody& mobod = curve.getMobilizedBody();
+                    const CurveSegmentData::Position& curveDataPos =
+                        curve.getDataPos(s);
+    
+                    // Ending point and velocity of straight line segment.
+                    const Vec3 x_GP = curveDataPos.X_GP.p();
+                    const Vec3 v_GP = CalcPointVelocityInGround(mobod, x_GP);
+    
+                    // Compute the lengthening.
+                    lengthDot += dot(UnitVec3(x_GP - x_GQ), v_GP - v_GQ);
+    
+                    // Set the next straight line starting point and velocity.
+                    x_GQ = curveDataPos.X_GQ.p();
+                    v_GQ = CalcPointVelocityInGround(mobod, x_GQ);
+                }
+            }
+
+            // Add the lengthening speed contributed by each via point in the
+            // cable segment.
+            if (cableSegment.getFinalViaPointIndex().isValid()) {
+                const ViaPoint& viaPoint = getViaPoint(
+                    cableSegment.getFinalViaPointIndex());
+                const MobilizedBody& mobod = viaPoint.getMobilizedBody();
 
                 // Ending point and velocity of straight line segment.
-                const Vec3 x_GP = curveDataPos.X_GP.p();
-                const Vec3 v_GP =
-                    CalcPointVelocityInGround(mobod, curveDataPos.X_GP.p());
+                const Vec3& x_GP = viaPoint.getStation_G(s);
+                const Vec3 v_GP = CalcPointVelocityInGround(mobod, x_GP);
 
                 // Compute the lengthening.
                 lengthDot += dot(UnitVec3(x_GP - x_GQ), v_GP - v_GQ);
 
                 // Set the next straight line starting point and velocity.
-                x_GQ = curveDataPos.X_GQ.p();
-                v_GQ = CalcPointVelocityInGround(mobod, curveDataPos.X_GQ.p());
+                x_GQ = x_GP;
+                v_GQ = v_GP;
             }
         }
 
@@ -1995,9 +2513,9 @@ private:
         lengthDot += dot(UnitVec3(x_GP - x_GQ), v_GP - v_GQ);
     }
 
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
     // Data
-    //------------------------------------------------------------------------------
+    //--------------------------------------------------------------------------
 
     // Reference back to the subsystem.
     CableSubsystem* m_subsystem = nullptr;
@@ -2018,6 +2536,12 @@ private:
 
     // Path CurveSegments over the obstacles.
     Array_<CurveSegment, ObstacleIndex> m_curveSegments;
+
+    // Path ViaPoints.
+    Array_<ViaPoint, ViaPointIndex> m_viaPoints;
+
+    // Path CableSegments separated by via points.
+    Array_<CableSegment, CableSegmentIndex> m_cableSegments;
 
     // All configuration parameters.
     CableSpanParameters m_parameters{};
@@ -2042,15 +2566,21 @@ ObstacleIndex CurveSegment::findPrevObstacleInContactWithCable(
     const State& state) const
 {
     const CableSpan::Impl& cable = getCable();
-    // Find the first obstacle that makes contact before this CurveSegment.
-    for (ObstacleIndex ix(m_obstacleIndex); ix > 0; --ix) {
+    const CableSegment& cableSegment = cable.getCableSegment(
+        getCableSegmentIndex());
+
+    // Find the first obstacle that makes contact before this curve segment
+    // in the current cable segment.
+    for (ObstacleIndex ix(m_obstacleIndex); 
+            ix > cableSegment.getObstacleIndexes().front(); --ix) {
         ObstacleIndex prevIx(ix - 1);
-        if (cable.getObstacleCurveSegment(prevIx).isInContactWithSurface(
-                state)) {
+        const CurveSegment& curveSegment = cable.getObstacleCurveSegment(prevIx);
+        if (curveSegment.isInContactWithSurface(state)) {
             return prevIx;
         }
     }
-    // No obstacles in contact before this segment.
+
+    // No active obstacles before this segment.
     return ObstacleIndex::Invalid();
 }
 
@@ -2058,31 +2588,49 @@ ObstacleIndex CurveSegment::findNextObstacleInContactWithCable(
     const State& state) const
 {
     const CableSpan::Impl& cable = getCable();
-    // Find the first obstacle that makes contact after this CurveSegment.
-    for (ObstacleIndex ix(m_obstacleIndex + 1); ix < cable.getNumObstacles();
-         ++ix) {
-        if (cable.getObstacleCurveSegment(ix).isInContactWithSurface(state)) {
+    const CableSegment& cableSegment = cable.getCableSegment(
+        getCableSegmentIndex());
+    
+    // Find the first active obstacle after this curve segment in the current
+    // cable segment.
+    for (ObstacleIndex ix(m_obstacleIndex + 1); 
+            ix < cableSegment.getObstacleIndexes().back()+1; ++ix) {
+        const CurveSegment& curveSegment = cable.getObstacleCurveSegment(ix);
+        if (curveSegment.isInContactWithSurface(state)) {
             return ix;
         }
     }
-    // No obstacles in contact after this segment.
+
+    // No active obstacles after this curve segment.
     return ObstacleIndex::Invalid();
 }
 
 Vec3 CurveSegment::findPrevPathPoint_G(const State& state) const
 {
-    // Check if there is a curve segment preceding given obstacle.
-    const ObstacleIndex prevObstacle =
-        findPrevObstacleInContactWithCable(state);
-    if (prevObstacle.isValid()) {
-        // The previous point is the final contact point of the previous curve.
-        return getCable()
-            .getObstacleCurveSegment(prevObstacle)
-            .calcFinalContactPoint_G(state);
-    }
-    // There are no curve segments before given obstacle: the previous point
-    // is the path's origin point.
     const CableSpan::Impl& cable = getCable();
+    const CableSegment& cableSegment = cable.getCableSegment(
+        getCableSegmentIndex());
+    
+    // Check if there is a curve segment preceding this curve segment in the
+    // current cable segment.
+    for (ObstacleIndex ix(m_obstacleIndex); 
+            ix > cableSegment.getObstacleIndexes().front(); --ix) {
+        ObstacleIndex prevIx(ix - 1);
+        const CurveSegment& curveSegment = cable.getObstacleCurveSegment(prevIx);
+        if (curveSegment.isInContactWithSurface(state)) {
+            return curveSegment.calcFinalContactPoint_G(state);
+        }
+    }
+
+    // Check to see if this cable segment starts with a via point.
+    if (cableSegment.getInitialViaPointIndex().isValid()) {
+        const ViaPoint& viaPoint = cable.getViaPoint(
+            cableSegment.getInitialViaPointIndex());
+        return viaPoint.getStation_G(state);
+    }
+
+    // There is no via point at the start of this cable segment: the previous
+    // point is the path's origin point.
     return getCable()
         .getOriginBody()
         .getBodyTransform(state)
@@ -2091,18 +2639,29 @@ Vec3 CurveSegment::findPrevPathPoint_G(const State& state) const
 
 Vec3 CurveSegment::findNextPathPoint_G(const State& state) const
 {
-    // Check if there is a curve segment after given obstacle.
-    const ObstacleIndex nextObstacle =
-        findNextObstacleInContactWithCable(state);
-    if (nextObstacle.isValid()) {
-        // The next point is the initial contact point of the next curve.
-        return getCable()
-            .getObstacleCurveSegment(nextObstacle)
-            .calcInitialContactPoint_G(state);
-    };
-    // There are no curve segments following given obstacle: the next point
-    // is the path's termination point.
     const CableSpan::Impl& cable = getCable();
+    const CableSegment& cableSegment = cable.getCableSegment(
+        getCableSegmentIndex());
+
+    // Check if there is a curve segment following this curve segment in the 
+    // current cable segment.
+    for (ObstacleIndex ix(m_obstacleIndex + 1); 
+            ix < cableSegment.getObstacleIndexes().back()+1; ++ix) {
+        const CurveSegment& curveSegment = cable.getObstacleCurveSegment(ix);
+        if (curveSegment.isInContactWithSurface(state)) {
+            return curveSegment.calcInitialContactPoint_G(state);
+        }
+    }
+
+    // Check to see if this cable segment ends in a via point.
+    if (cableSegment.getFinalViaPointIndex().isValid()) {
+        const ViaPoint& viaPoint = cable.getViaPoint(
+            cableSegment.getFinalViaPointIndex());
+        return viaPoint.getStation_G(state);
+    }
+
+    // There is no via point at the end of this cable segment: the next point
+    // is the path's termination point.
     return cable.getTerminationBody()
         .getBodyTransform(state)
         .shiftFrameStationToBase(cable.getTerminationStation());
@@ -2139,6 +2698,24 @@ void calcUnitForceExertedByCurve(
     // force direction:
     unitForce_G[0] = r_Q % t_Q - r_P % t_P;
     unitForce_G[1] = t_Q - t_P;
+}
+
+void calcUnitForceExertedByViaPoint(
+    const ViaPoint& viaPoint,
+    const State& s,
+    SpatialVec& unitForce_G)
+{
+    const Vec3& x_GB = viaPoint.getMobilizedBody().getBodyOriginLocation(s);
+    const UnitVec3& incomingDirection_G = viaPoint.getIncomingDirection(s);
+    const UnitVec3& outgoingDirection_G = viaPoint.getOutgoingDirection(s);
+
+    // The via point moment arm in ground.
+    const Vec3& r_G = viaPoint.getStation_G(s) - x_GB;
+
+    // The incoming direction is along the negative force direction, while the
+    // outgoing direction is along the force direction:
+    unitForce_G[0] = r_G % outgoingDirection_G - r_G % incomingDirection_G;
+    unitForce_G[1] = outgoingDirection_G - incomingDirection_G;
 }
 
 /* Computes the unit force exerted by the cable at the cable origin, on the
@@ -2213,6 +2790,15 @@ void CableSpan::Impl::applyBodyForces(
             bodyForcesInG);
     }
 
+    // Forces applied to each via point.
+    for (const ViaPoint& viaPoint : m_viaPoints) {
+        calcUnitForceExertedByViaPoint(viaPoint, s, unitForce_G);
+        viaPoint.getMobilizedBody().applyBodyForce(
+            s,
+            unitForce_G * tension,
+            bodyForcesInG);
+    }
+
     // Force applied at cable termination point.
     {
         calcUnitForceAtCableTermination(*this, s, unitForce_G);
@@ -2251,6 +2837,12 @@ Real CableSpan::Impl::calcCablePower(const State& state, Real tension) const
         unitPower += ~unitForce_G * v;
     }
 
+    for (const ViaPoint& viaPoint : m_viaPoints) {
+        calcUnitForceExertedByViaPoint(viaPoint, state, unitForce_G);
+        SpatialVec v = viaPoint.getMobilizedBody().getBodyVelocity(state);
+        unitPower += ~unitForce_G * v;
+    }
+
     {
         calcUnitForceAtCableTermination(*this, state, unitForce_G);
         SpatialVec v = getTerminationBody().getBodyVelocity(state);
@@ -2272,20 +2864,20 @@ geodesic variations" by Andreas Scholz et al (Scholz2015). */
 namespace
 {
 
-/* Compute the straight line segments in between the obstacles.
+/* Compute the straight line segments in between the obstacles and via points.
 
 Denoted by "e^i" and "e^{i+1} in Scholz2015 Fig 1. */
 void calcLineSegments(
-    const CableSpan::Impl& cable,
+    const CableSegment& cableSegment,
     const State& s,
-    const Vec3& pathOriginPoint,
-    const Vec3& pathTerminationPoint,
     std::vector<LineSegment>& lines)
 {
     lines.clear();
-    Vec3 prevPathPoint(pathOriginPoint);
+    const CableSpan::Impl& cable = cableSegment.getCable();
+    Vec3 prevPathPoint(
+        cable.calcInitialCableSegmentPointInGround(s, cableSegment));
 
-    for (CableSpanObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
+    for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
         const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
         if (!curve.isInContactWithSurface(s)) {
             continue;
@@ -2302,7 +2894,8 @@ void calcLineSegments(
     }
 
     // Compute the last line segment.
-    lines.emplace_back(prevPathPoint, pathTerminationPoint);
+    lines.emplace_back(prevPathPoint, 
+        cable.calcFinalCableSegmentPointInGround(s, cableSegment));
 }
 
 /* Helper for computing a single element of the path error vector.
@@ -2324,7 +2917,7 @@ stack them in a vector.
 If axes = {NormalAxis, BinormalAxis} this gives equation 14 in Scholz2015 */
 template <size_t N>
 void calcPathErrorVector(
-    const CableSpan::Impl& cable,
+    const CableSegment& cableSegment,
     const State& s,
     const std::vector<LineSegment>& lines,
     std::array<CoordinateAxis, N> axes,
@@ -2338,7 +2931,8 @@ void calcPathErrorVector(
     // Index to a straight line segment.
     int lineIx = 0;
 
-    for (CableSpanObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
+    const CableSpan::Impl& cable = cableSegment.getCable();
+    for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
         // Path errors are only computed for obstacles that make contact.
         const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
         if (!curve.isInContactWithSurface(s)) {
@@ -2373,7 +2967,7 @@ NaturalGeodesicCorrections of all CurveSegments.
 When axes = {Normal, Binormal}, this equals equation 53 in Scholz2015. */
 template <size_t N>
 void calcPathErrorJacobian(
-    const CableSpan::Impl& cable,
+    const CableSegment& cableSegment,
     const State& s,
     const std::vector<LineSegment>& lines,
     std::array<CoordinateAxis, N> axes,
@@ -2399,7 +2993,8 @@ void calcPathErrorJacobian(
 
     // Index to a straight line segment.
     int lineIx = 0;
-    for (ObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
+    const CableSpan::Impl& cable = cableSegment.getCable();
+    for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
         const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
         if (!curve.isInContactWithSurface(s)) {
             continue;
@@ -2493,7 +3088,7 @@ position, and g_i is the block of the gradient related to that obstacle.
 Stacking of all blocks gives the total gradient. */
 void calcLengthGradient(
     const State& state,
-    const CableSpan::Impl& cable,
+    const CableSegment& cableSegment,
     const std::vector<LineSegment>& lines,
     Vector& gradient)
 {
@@ -2505,7 +3100,8 @@ void calcLengthGradient(
     // Index to a straight line segment.
     int lineIx = 0;
 
-    for (CableSpanObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
+    const CableSpan::Impl& cable = cableSegment.getCable();
+    for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
         // Only consider obstacles that make contact.
         const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
         if (!curve.isInContactWithSurface(state)) {
@@ -2534,7 +3130,7 @@ This function can be derived taking the Jacobian of the gradient to the
 NaturalGeodesicCorrections of all curve segments. */
 void calcLengthHessian(
     const State& state,
-    const CableSpan::Impl& cable,
+    const CableSegment& cableSegment,
     const std::vector<LineSegment>& lines,
     Matrix& hessian)
 {
@@ -2573,7 +3169,8 @@ void calcLengthHessian(
 
     // Index to a straight line segment.
     int lineIx = 0;
-    for (ObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
+    const CableSpan::Impl& cable = cableSegment.getCable();
+    for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
         const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
         if (!curve.isInContactWithSurface(state)) {
             continue;
@@ -2747,13 +3344,14 @@ void calcCurveCorrectionStepSize(
 // of the curve segments.
 Real calcPathCorrectionStepSize(
     const State& s,
-    const CableSpan::Impl& cable,
+    const CableSegment& cableSegment,
     const Vector& pathCorrection)
 {
     Real stepSize     = 1.;
     int activeCurveIx = 0; // Index of curve in all that are in contact.
-    for (ObstacleIndex obsIx(0); obsIx < cable.getNumObstacles(); ++obsIx) {
-        const CurveSegment& curve = cable.getObstacleCurveSegment(obsIx);
+    const CableSpan::Impl& cable = cableSegment.getCable();
+    for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
+        const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
         if (!curve.isInContactWithSurface(s)) {
             continue;
         }
@@ -2771,27 +3369,28 @@ Real calcPathCorrectionStepSize(
     return stepSize;
 }
 
-// Helper for computing the total cable length.
+// Helper for computing the length of a cable segment.
 // This is the sum of the lengths of all straight line segments, and all curve
-// segments.
-Real calcTotalCableLength(
+// segments comprising the cable segment.
+Real calcCableSegmentLength(
     const State& s,
-    const CableSpan::Impl& cable,
+    const CableSegment& cableSegment,
     const std::vector<LineSegment>& lineSegments)
 {
-    Real totalCableLength = 0.;
+    Real cableSegmentLength = 0.;
     // Add length of each line segment.
     for (const LineSegment& line : lineSegments) {
-        totalCableLength += line.length;
+        cableSegmentLength += line.length;
     }
     // Add length of each curve segment.
-    for (ObstacleIndex obsIx(0); obsIx < cable.getNumObstacles(); ++obsIx) {
-        const CurveSegment& curve = cable.getObstacleCurveSegment(obsIx);
+    const CableSpan::Impl& cable = cableSegment.getCable();
+    for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
+        const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
         if (curve.isInContactWithSurface(s)) {
-            totalCableLength += curve.getDataInst(s).arcLength;
+            cableSegmentLength += curve.getDataInst(s).arcLength;
         }
     }
-    return totalCableLength;
+    return cableSegmentLength;
 };
 
 } // namespace
@@ -2802,6 +3401,7 @@ Real calcTotalCableLength(
 
 void CableSpan::Impl::calcSolverStep(
     const State& s,
+    const CableSegment& cableSegment,
     CableSpanAlgorithm algorithm,
     MatrixWorkspace& data) const
 {
@@ -2814,24 +3414,22 @@ void CableSpan::Impl::calcSolverStep(
     // segments with the curve segments.
     // Start by computing the straight-line segments of this cable span.
     calcLineSegments(
-        *this,
+        cableSegment,
         s,
-        this->calcOriginPointInGround(s),
-        this->calcTerminationPointInGround(s),
         data.lineSegments);
 
     data.maxPathError = 0.; // Reset the max path error field.
-    // If there is one line segment, there are no obstacles in contact with the
-    // cable, and the path error is zero. Otherwise we compute the path errors.
-    if (data.lineSegments.size() > 1) {
+    // Only compute the path errors if there are obstacles in contact with the 
+    // cable.
+    if (data.numObstaclesInContact > 0) {
         calcPathErrorVector<1>(
-            *this,
+            cableSegment,
             s,
             data.lineSegments,
             {NormalAxis},
             data.normalPathError);
         calcPathErrorVector<1>(
-            *this,
+            cableSegment,
             s,
             data.lineSegments,
             {BinormalAxis},
@@ -2850,9 +3448,8 @@ void CableSpan::Impl::calcSolverStep(
 
     // SOLVER STEP 2: Compute the path correction step that reduces the path
     // errors.
-    const int numObstaclesInContact = static_cast<int>(data.lineSegments.size()) - 1;
     SimTK_ASSERT_ALWAYS(
-        numObstaclesInContact > 0,
+        data.numObstaclesInContact > 0,
         "No obstacles in contact with the cable: unable to compute path corrections");
     // The path corrections can be computed using different algorithms, see
     // CableSpanAlgorithm's documentation for details.
@@ -2864,23 +3461,23 @@ void CableSpan::Impl::calcSolverStep(
         // Total number of constraints per curve segment.
         static constexpr int c_NumConstraints = c_NumPathErrorConstraints + 1;
 
-        Vector b(numObstaclesInContact * c_NumConstraints, 0.);
+        Vector b(data.numObstaclesInContact * c_NumConstraints, 0.);
         Matrix A(
-            numObstaclesInContact * c_NumConstraints,
-            numObstaclesInContact * c_GeodesicDOF,
+            data.numObstaclesInContact * c_NumConstraints,
+            data.numObstaclesInContact * c_GeodesicDOF,
             0.);
         Vector& q = data.pathCorrection;
 
         // Fill the upper block of A and b with the path error jacobian and
         // vector.
         calcPathErrorVector<2>(
-            *this,
+            cableSegment,
             s,
             data.lineSegments,
             {NormalAxis, BinormalAxis},
             b);
         calcPathErrorJacobian<2>(
-            *this,
+            cableSegment,
             s,
             data.lineSegments,
             {NormalAxis, BinormalAxis},
@@ -2896,10 +3493,10 @@ void CableSpan::Impl::calcSolverStep(
         // path error. This will heavily penalize changing the length when we
         // are far from the optimal solution, and ramp up convergence as we get
         // closer.
-        for (int i = 0; i < numObstaclesInContact; ++i) {
+        for (int i = 0; i < data.numObstaclesInContact; ++i) {
             // Determine the row and column of the nonzero element in the
             // Jacobian.
-            int r = numObstaclesInContact * c_NumPathErrorConstraints + i;
+            int r = data.numObstaclesInContact * c_NumPathErrorConstraints + i;
             int c = c_GeodesicDOF * (i + 1) - 1;
             // Write the weight that will penalize changing the curve length.
             const Real weight = data.maxPathError;
@@ -2933,11 +3530,12 @@ void CableSpan::Impl::calcSolverStep(
         Matrix& V     = data.rightSingularValues;
 
         // Compute the normal path error jacobian.
-        calcPathErrorJacobian<1>(*this, s, data.lineSegments, {NormalAxis}, J);
+        calcPathErrorJacobian<1>(cableSegment, s, data.lineSegments, 
+            {NormalAxis}, J);
 
         // Compute the gradient and Hessian of the cable length.
-        calcLengthGradient(s, *this, data.lineSegments, g);
-        calcLengthHessian(s, *this, data.lineSegments, H);
+        calcLengthGradient(s, cableSegment, data.lineSegments, g);
+        calcLengthHessian(s, cableSegment, data.lineSegments, H);
 
         // Compute QInv:
         // First solve SVD of the Hessian estimate.
@@ -2988,7 +3586,7 @@ void CableSpan::Impl::calcSolverStep(
 
     // Compute the stepsize along the descending direction.
     const Real stepSize =
-        calcPathCorrectionStepSize(s, *this, data.pathCorrection);
+        calcPathCorrectionStepSize(s, cableSegment, data.pathCorrection);
     data.pathCorrection *= stepSize;
 }
 
@@ -2997,78 +3595,127 @@ const CableSpanData::Position& CableSpan::Impl::calcDataPos(
 {
     // Output of this function.
     CableSpanData::Position& dataPos = updDataPos(s);
+    dataPos.cableLength = 0.;
+    dataPos.smoothness = 0.;
+    dataPos.loopIter = 0;
+    dataPos.originPoint_G = calcOriginPointInGround(s);
+    dataPos.terminationPoint_G = calcTerminationPointInGround(s);
 
     // This helper function will extract the useful information from the path
     // solver output, and write to the cached CableSpanData.
-    auto calcDataPosFromSolverResult =
-        [&](const MatrixWorkspace& workspace,
-            int solverLoopCount) -> const CableSpanData::Position&
+    auto updDataPosFromSolverResult =
+        [&](const State& s, const CableSegment& cableSegment,
+            const MatrixWorkspace& workspace,
+            int solverLoopCount)
     {
-        dataPos.originPoint_G      = calcOriginPointInGround(s);
-        dataPos.terminationPoint_G = calcTerminationPointInGround(s);
-        dataPos.smoothness         = workspace.maxPathError;
-        dataPos.cableLength =
-            calcTotalCableLength(s, *this, workspace.lineSegments);
-        dataPos.originTangent_G      = workspace.lineSegments.front().direction;
-        dataPos.terminationTangent_G = workspace.lineSegments.back().direction;
-        dataPos.loopIter             = solverLoopCount;
+        dataPos.cableLength += calcCableSegmentLength(
+            s, cableSegment, workspace.lineSegments);
+        dataPos.smoothness = std::max(workspace.maxPathError, 
+            dataPos.smoothness);
+        dataPos.loopIter += solverLoopCount;
 
-        return dataPos;
+        // An invalid initial via point index indicates that the segment begins
+        // with the cable origin point.
+        ViaPointIndex initialViaPointIndex = 
+            cableSegment.getInitialViaPointIndex();
+        if (initialViaPointIndex.isValid()) {
+            const ViaPoint& viaPoint = getViaPoint(initialViaPointIndex);
+            viaPoint.setOutgoingDirection(s, 
+                workspace.lineSegments.front().direction);
+        } else {
+            dataPos.originTangent_G = 
+                workspace.lineSegments.front().direction;
+        }
+
+        // An invalid final via point index indicates that the segment ends
+        // with the cable termination point.
+        ViaPointIndex finalViaPointIndex = cableSegment.getFinalViaPointIndex();
+        if (finalViaPointIndex.isValid()) {
+            const ViaPoint& viaPoint = getViaPoint(finalViaPointIndex);
+            viaPoint.setIncomingDirection(s, 
+                workspace.lineSegments.back().direction);
+        } else {
+            dataPos.terminationTangent_G = 
+                workspace.lineSegments.back().direction;
+        }
     };
 
-    // Start solver loop:
-    // Essentially this loop calls calcSolverStep each iteration, and stops
-    // when converged or the max iterations was reached.
-    for (int loopIter = 0;
-         loopIter <=
-         getParameters().solverMaxIterations; // Correctly handles zero case.
-         ++loopIter) {
+    // Compute the station positions of all via points. The via point stations
+    // do not change during the solver loop, so we can compute them once here.
+    const int nViaPoints = getNumViaPoints();
+    for (ViaPointIndex ix(0); ix < nViaPoints; ++ix) {
+        getViaPoint(ix).calcStation_G(s);
+    }
 
-        // Make sure all curve segments are realized to position stage.
-        // This will transform all last computed geodesics to Ground frame, and
-        // will update each curve's WrappingStatus.
-        for (ObstacleIndex ix(0); ix < getNumObstacles(); ++ix) {
-            getObstacleCurveSegment(ix).calcDataPos(s);
-        }
+    // Iterate over all cable segments and solve the sub-problem associated
+    // with each.
+    for (CableSegmentIndex cix(0); cix < getNumCableSegments(); ++cix) {
+        const CableSegment& cableSegment = getCableSegment(cix);
+        Array_<ObstacleIndex> obstacleIndexes = 
+            cableSegment.getObstacleIndexes();
 
-        // Grab the matrix workspace used by the solver.
-        MatrixWorkspace& workspace = updDataInst(s).updOrInsert(countActive(s));
+        // Start the solver loop for the sub-problem associated with this
+        // cable segment. This loop calls calcSolverStep each iteration, and
+        // stops when converged or the max iterations was reached.
+        for (int loopIter = 0;
+            loopIter <=
+            getParameters().solverMaxIterations; // Correctly handles zero case.
+            ++loopIter) {
 
-        // Compute the path corrections required to reach the optimal path.
-        calcSolverStep(s, getParameters().algorithm, workspace);
+            // Make sure all curve segments are realized to position stage.
+            // This will transform all last computed geodesics to Ground frame,
+            // and will update each curve's WrappingStatus.
+            for (ObstacleIndex ix : obstacleIndexes) {
+                const CurveSegment& curveSegment = getObstacleCurveSegment(ix);
+                curveSegment.calcDataPos(s);
+            } 
+            
+            // Grab the matrix workspace used by the solver.
+            MatrixWorkspace& workspace = updDataInst(s).updOrInsert(
+                countActive(s, cableSegment));
 
-        // Check if we should stop iterating.
-        const bool maxIterationsReached =
+            // Compute the path corrections required to reach the optimal path.
+            calcSolverStep(s, cableSegment, getParameters().algorithm, 
+                workspace);
+
+            // Check if we should stop iterating on this sub-problem.
+            const bool maxIterationsReached =
             loopIter >= getParameters().solverMaxIterations;
-        if (workspace.converged || maxIterationsReached) {
-            // Fill in the fields of CableSpanData::Position, and stop.
-            return calcDataPosFromSolverResult(workspace, loopIter);
-        }
-
-        // Apply the corrections to each CurveSegment to reduce the path error.
-        const Vector& pathCorrection = workspace.pathCorrection;
-        int activeCurveIx = 0; // Index of curve in all that are in contact.
-        for (const CurveSegment& curve : m_curveSegments) {
-            if (curve.isInContactWithSurface(s)) {
-                curve.applyGeodesicCorrection(
-                    s,
-                    MatrixWorkspace::getCurveCorrection(
-                        pathCorrection,
-                        activeCurveIx));
-                ++activeCurveIx;
+            if (workspace.converged || maxIterationsReached) {
+                updDataPosFromSolverResult(s, cableSegment, workspace, loopIter);
+                break;
             }
-        }
 
-        // The applied corrections have changed the path: invalidate each
-        // segment's cache.
-        for (const CurveSegment& curve : m_curveSegments) {
-            // Also invalidate non-active segments: They might touchdown
-            // again.
-            curve.invalidatePosEntry(s);
+            // Apply the corrections to each CurveSegment to reduce the path 
+            // error.
+            const Vector& pathCorrection = workspace.pathCorrection;
+            int activeCurveIx = 0; // Index of curve in all that are in contact.
+            for (ObstacleIndex ix : obstacleIndexes) {
+                const CurveSegment& curve = getObstacleCurveSegment(ix);
+                if (curve.isInContactWithSurface(s)) {
+                    curve.applyGeodesicCorrection(
+                        s,
+                        MatrixWorkspace::getCurveCorrection(
+                            pathCorrection,
+                            activeCurveIx));
+                    ++activeCurveIx;
+                }
+            }
+
+            // The applied corrections have changed the path: invalidate each
+            // curve segment's cache for this cable segment.
+            for (ObstacleIndex ix : obstacleIndexes) {
+                const CurveSegment& curve = getObstacleCurveSegment(ix);
+                // Also invalidate non-active segments: They might touchdown
+                // again.
+                curve.invalidatePosEntry(s);
+            }
+            // The path corrections only invalidate the direction cache entries,
+            // not the station cache entry.
+            invalidateViaPointDirectionCacheEntries(s, cableSegment);
         }
     }
 
-    SimTK_ASSERT(false, "Internal bug: should not reach this point");
     return dataPos;
 }
 
@@ -3102,9 +3749,10 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
 
     // Helper lambda returning true if any active curve segment has zero length.
     auto anyCurveSegmentHasZeroLength =
-        [&](const State& s, const CableSpan::Impl& cable) -> bool
+        [&](const State& s, const CableSegment& cableSegment) -> bool
     {
-        for (ObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
+        const CableSpan::Impl& cable = cableSegment.getCable();
+        for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
             const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
             if (!curve.isInContactWithSurface(s)) {
                 continue;
@@ -3149,276 +3797,295 @@ void CableSubsystemTestHelper::Impl::runPerturbationTest(
             m_perturbationTestParameters.perturbation,
             m_perturbationTestParameters.tolerance);
 
-        // Axes considered when computing the path error.
-        const std::array<CoordinateAxis, 2> axes{NormalAxis, BinormalAxis};
+        // Run the perturbation test for each cable segment.
+        for (CableSegmentIndex ix(0); ix < cable.getNumCableSegments(); ++ix) {
+            testReport << "Testing CableSegment " << ix + 1 << " of " 
+                       << cable.getNumCableSegments() << "\n";
 
-        // Count the number of active curve segments.
-        const int nActive = cable.countActive(state);
+            // Get the cable segment.
+            const CableSegment& cableSegment = cable.getCableSegment(ix);
+            const int nActive = cable.countActive(state, cableSegment);
 
-        if (nActive == 0) {
-            testReport << "Cable has no active segments:";
-            testReport << "Skipping perturbation test\n";
-            continue;
-        }
-
-        if (anyCurveSegmentHasZeroLength(state, cable)) {
-            testReport << "Cable has zero-length curve segments:";
-            testReport << "Skipping perturbation test\n";
-            continue;
-        }
-
-        // Apply a small perturbation to each of the curve segments in the form
-        // of a geodesic correction. There are 4 DOF for each geodesic, and
-        // just to be sure we apply a negative and positive perturbation along
-        // each DOF of each geodesic.
-        Real perturbation = m_perturbationTestParameters.perturbation;
-        for (int i = 0; i < c_GeodesicDOF * 2 * nActive + 1; ++i) {
-            // We do not want to mess with the actual state, so we make a copy.
-            const State sCopy = state;
-            subsystem.getMultibodySystem().realize(sCopy, Stage::Position);
-
-            // Trigger realizing position level cache, resetting the
-            // configuration.
-            const CableSpanData::Position& dataPos = cable.getDataPos(sCopy);
-
-            // The wrapping status of each obstacle is reset after copying the
-            // state. The matrix sizes are no longer compatible if this results
-            // in a change in wrapping status (if we are touching down during
-            // this realization for example). We can only test the Jacobian if
-            // the wrapping status of all obstacles remains the same.
-            if (cable.countActive(sCopy) != nActive) {
-                testReport
-                    << "Cable wrapping status changed after cloning the state: "
-                       "Skipping perturbation test\n";
-                break;
-            }
-
-            // Compute the path error vector and Jacobian, before the applied
-            // perturbation.
-            std::vector<LineSegment> lineSegments(nActive);
-
-            Vector pathError(nActive * c_GeodesicDOF, NaN);
-            Matrix pathErrorJacobian(
-                nActive * c_GeodesicDOF,
-                nActive * c_GeodesicDOF,
-                NaN);
-
-            Real length = NaN;
-            Vector lengthGradient(nActive * c_GeodesicDOF, NaN);
-            Matrix lengthHessian(
-                nActive * c_GeodesicDOF,
-                nActive * c_GeodesicDOF,
-                NaN);
-
-            calcLineSegments(
-                cable,
-                sCopy,
-                dataPos.originPoint_G,
-                dataPos.terminationPoint_G,
-                lineSegments);
-
-            calcPathErrorVector<2>(
-                cable,
-                sCopy,
-                lineSegments,
-                {NormalAxis, BinormalAxis},
-                pathError);
-            calcPathErrorJacobian<2>(
-                cable,
-                sCopy,
-                lineSegments,
-                {NormalAxis, BinormalAxis},
-                pathErrorJacobian);
-
-            length = calcTotalCableLength(sCopy, cable, lineSegments);
-            calcLengthGradient(sCopy, cable, lineSegments, lengthGradient);
-            calcLengthHessian(sCopy, cable, lineSegments, lengthHessian);
-
-            // Define the perturbation we will use for testing the Jacobian.
-            Vector pathCorrection(nActive * c_GeodesicDOF, 0.);
-            if (i != 0) {
-                perturbation *= -1.;
-                pathCorrection.set((i - 1) / 2, perturbation);
-            }
-
-            // Use the Jacobian to predict the perturbed path error vector.
-            const Vector predictedPathError =
-                pathErrorJacobian * pathCorrection + pathError;
-            const Real predictedLength =
-                ~lengthGradient * pathCorrection + length;
-            const Vector predictedLengthGradient =
-                lengthHessian * pathCorrection + lengthGradient;
-
-            // Store the wrapping status before applying the perturbation.
-            std::vector<ObstacleWrappingStatus> prevWrappingStatus;
-            for (const CurveSegment& curve : cable.m_curveSegments) {
-                prevWrappingStatus.push_back(
-                    curve.getDataInst(sCopy).wrappingStatus);
-            }
-
-            // Apply the perturbation.
-            int activeCurveIx = 0; // Index of curve in all that are in contact.
-            for (ObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
-                const CurveSegment& curve = cable.getObstacleCurveSegment(ix);
-                if (curve.isInContactWithSurface(sCopy)) {
-                    curve.applyGeodesicCorrection(
-                        sCopy,
-                        MatrixWorkspace::getCurveCorrection(
-                            pathCorrection,
-                            activeCurveIx));
-                    ++activeCurveIx;
-                }
-            }
-
-            for (const CurveSegment& curve : cable.m_curveSegments) {
-                curve.invalidatePosEntry(sCopy);
-            }
-
-            for (ObstacleIndex ix(0); ix < cable.getNumObstacles(); ++ix) {
-                cable.getObstacleCurveSegment(ix).calcDataPos(sCopy);
-            }
-
-            // Compute the path error vector after having applied the
-            // perturbation.
-            calcLineSegments(
-                cable,
-                sCopy,
-                dataPos.originPoint_G,
-                dataPos.terminationPoint_G,
-                lineSegments);
-
-            calcPathErrorVector<2>(
-                cable,
-                sCopy,
-                lineSegments,
-                {NormalAxis, BinormalAxis},
-                pathError);
-            calcPathErrorJacobian<2>(
-                cable,
-                sCopy,
-                lineSegments,
-                {NormalAxis, BinormalAxis},
-                pathErrorJacobian);
-
-            length = calcTotalCableLength(sCopy, cable, lineSegments);
-            calcLengthGradient(sCopy, cable, lineSegments, lengthGradient);
-            calcLengthHessian(sCopy, cable, lineSegments, lengthHessian);
-
-            // The curve lengths are clipped at zero, which distorts the
-            // perturbation test. We simply skip these edge cases.
-            if (anyCurveSegmentHasZeroLength(sCopy, cable)) {
-                testReport << "Cable has zero-length curve segments after perturbation:";
+            if (nActive == 0) {
+                testReport << "CableSegment has no active segments:";
                 testReport << "Skipping perturbation test\n";
                 continue;
             }
 
-            // We can only use the path error Jacobian if the small
-            // perturbation did not trigger any liftoff or touchdown on any
-            // obstacles. If any CurveSegment's WrappingStatus has changed, we
-            // will not continue with the test. Since the perturbation is
-            // small, this is unlikely to happen often.
-            std::vector<ObstacleWrappingStatus> nextWrappingStatus;
-            for (const CurveSegment& curve : cable.m_curveSegments) {
-                nextWrappingStatus.push_back(
-                    curve.getDataInst(sCopy).wrappingStatus);
-            }
-            if (!isEqual(prevWrappingStatus, nextWrappingStatus)) {
-                testReport << "Wrapping status changed: Stopping test\n";
-                break;
+            if (anyCurveSegmentHasZeroLength(state, cableSegment)) {
+                testReport << "CableSegment has zero-length curve segments:";
+                testReport << "Skipping perturbation test\n";
+                continue;
             }
 
-            // Tolerance was given as a percentage, multiply by 0.01 to get the
-            // correct scale.
-            const Real tolerance =
-                m_perturbationTestParameters.tolerance * 1e-2;
-            // Evaluate the path error jacobian.
-            {
-                const Real predictionError =
-                    (predictedPathError - pathError).normInf();
-                bool passedTest =
-                    std::abs(predictionError / perturbation) <= tolerance;
-                if (!passedTest) {
-                    testReport << "FAILED path error Jacobian perturbation test for correction = "
-                               << pathCorrection << "\n";
-                    testReport << "path error after perturbation:\n";
-                    testReport << "    Got        : " << pathError << "\n";
-                    testReport << "    Predicted  : " << predictedPathError
-                               << "\n";
-                    testReport
-                        << "    Difference : "
-                        << (predictedPathError - pathError) / perturbation
-                        << "\n";
-                    testReport << "    Max diff   : "
-                               << (predictedPathError - pathError).normInf() /
-                                      perturbation
-                               << " <= " << tolerance << " = eps\n";
-                } else {
-                    testReport << "PASSED perturbation test for correction = "
-                               << pathCorrection << "\n";
-                    testReport << " ( max diff = "
-                               << (predictedPathError - pathError).normInf() /
-                                      perturbation
-                               << " <= " << tolerance << " = eps )\n";
+            // Apply a small perturbation to each of the curve segments in the 
+            // form of a geodesic correction. There are 4 DOF for each geodesic, 
+            // and just to be sure we apply a negative and positive perturbation 
+            // along each DOF of each geodesic.
+            Real perturbation = m_perturbationTestParameters.perturbation;
+            for (int i = 0; i < c_GeodesicDOF * 2 * nActive + 1; ++i) {
+                // We do not want to mess with the actual state, so we make a 
+                // copy.
+                const State sCopy = state;
+                cableSegment.getSubsystem().getMultibodySystem().realize(
+                    sCopy, Stage::Position);
+
+                // Trigger realizing position level cache, resetting the
+                // configuration.
+                const CableSpanData::Position& dataPos = 
+                    cableSegment.getCable().getDataPos(sCopy);
+
+                // The wrapping status of each obstacle is reset after copying 
+                // the state. The matrix sizes are no longer compatible if this 
+                // results in a change in wrapping status (if we are touching 
+                // down during this realization for example). We can only test 
+                // the Jacobian if the wrapping status of all obstacles remains 
+                // the same.
+                if (cable.countActive(sCopy, cableSegment) != nActive) {
+                    testReport << 
+                        "Cable wrapping status changed after cloning the state: "
+                        "Skipping perturbation test\n";
+                    break;
                 }
-                success = success && passedTest;
-            }
-            // Evaluate the length gradient.
-            {
-                const Real predictionError = std::abs(predictedLength - length);
-                bool passedTest =
-                    std::abs(predictionError / perturbation) <= tolerance;
-                if (!passedTest) {
-                    testReport << "FAILED length gradient perturbation test for correction = "
-                               << pathCorrection << "\n";
-                    testReport << "length after perturbation:\n";
-                    testReport << "    Got        : " << length << "\n";
-                    testReport << "    Predicted  : " << predictedLength
-                               << "\n";
-                    testReport << "    Difference : "
-                               << (predictedLength - length) / perturbation
-                               << "\n";
-                    testReport << "    Tolerance  : " << tolerance << "\n";
-                } else {
-                    testReport
-                        << "PASSED length perturbation test for correction = "
-                        << pathCorrection << "\n";
-                    testReport << " ( max diff = "
-                               << std::abs(predictionError / perturbation)
-                               << " <= " << tolerance << " = eps )\n";
+
+                // Compute the path error vector and Jacobian, before the 
+                // applied perturbation.
+                std::vector<LineSegment> lineSegments(nActive + 1);
+
+                Vector pathError(nActive * c_GeodesicDOF, NaN);
+                Matrix pathErrorJacobian(
+                    nActive * c_GeodesicDOF,
+                    nActive * c_GeodesicDOF,
+                    NaN);
+
+                Real length = NaN;
+                Vector lengthGradient(nActive * c_GeodesicDOF, NaN);
+                Matrix lengthHessian(
+                    nActive * c_GeodesicDOF,
+                    nActive * c_GeodesicDOF,
+                    NaN);
+
+                calcLineSegments(
+                    cableSegment,
+                    sCopy,
+                    lineSegments);
+
+                calcPathErrorVector<2>(
+                    cableSegment,
+                    sCopy,
+                    lineSegments,
+                    {NormalAxis, BinormalAxis},
+                    pathError);
+                calcPathErrorJacobian<2>(
+                    cableSegment,
+                    sCopy,
+                    lineSegments,
+                    {NormalAxis, BinormalAxis},
+                    pathErrorJacobian);
+
+                length = calcCableSegmentLength(sCopy, cableSegment, 
+                    lineSegments);
+                calcLengthGradient(sCopy, cableSegment, lineSegments, 
+                    lengthGradient);
+                calcLengthHessian(sCopy, cableSegment, lineSegments, 
+                    lengthHessian);
+
+                // Define the perturbation we will use for testing the Jacobian.
+                Vector pathCorrection(nActive * c_GeodesicDOF, 0.);
+                if (i != 0) {
+                    perturbation *= -1.;
+                    pathCorrection.set((i - 1) / 2, perturbation);
                 }
-                success = success && passedTest;
-            }
-            // Evaluate the length Hessian.
-            {
-                const Real predictionError =
-                    (predictedLengthGradient - lengthGradient).normInf();
-                bool passedTest =
-                    std::abs(predictionError / perturbation) <= tolerance;
-                if (!passedTest) {
-                    testReport << "FAILED length Hessian perturbation test for correction = "
-                               << pathCorrection << "\n";
-                    testReport << "length gradient after perturbation:\n";
-                    testReport << "    Got        : " << lengthGradient << "\n";
-                    testReport << "    Predicted  : " << predictedLengthGradient
-                               << "\n";
-                    testReport << "    Difference : "
-                               << (predictedLengthGradient - lengthGradient) /
-                                      perturbation
-                               << "\n";
-                    testReport << "    Max diff   : "
-                               << std::abs(predictionError / perturbation)
-                               << " <= " << tolerance << " = eps\n";
-                } else {
-                    testReport << "PASSED length Hessian perturbation test for correction = "
-                               << pathCorrection << "\n";
-                    testReport << " ( max diff = "
-                               << std::abs(predictionError / perturbation)
-                               << " <= " << tolerance << " = eps )\n";
+
+                // Use the Jacobian to predict the perturbed path error vector.
+                const Vector predictedPathError =
+                    pathErrorJacobian * pathCorrection + pathError;
+                const Real predictedLength =
+                    ~lengthGradient * pathCorrection + length;
+                const Vector predictedLengthGradient =
+                    lengthHessian * pathCorrection + lengthGradient;
+
+                // Store the wrapping status before applying the perturbation.
+                std::vector<ObstacleWrappingStatus> prevWrappingStatus;
+                for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
+                    const CurveSegment& curve = 
+                        cable.getObstacleCurveSegment(ix);
+                    prevWrappingStatus.push_back(
+                        curve.getDataInst(sCopy).wrappingStatus);
                 }
-                success = success && passedTest;
+
+                // Apply the perturbation.
+                int activeCurveIx = 0; // Index of curves that are in contact.
+                for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
+                    const CurveSegment& curve = 
+                        cable.getObstacleCurveSegment(ix);
+                    if (curve.isInContactWithSurface(sCopy)) {
+                        curve.applyGeodesicCorrection(
+                            sCopy,
+                            MatrixWorkspace::getCurveCorrection(
+                                pathCorrection,
+                                activeCurveIx));
+                        ++activeCurveIx;
+                    }
+                }
+
+                for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
+                    const CurveSegment& curve = 
+                        cable.getObstacleCurveSegment(ix);
+                    curve.invalidatePosEntry(sCopy);
+                }
+                cable.invalidateViaPointDirectionCacheEntries(sCopy, 
+                    cableSegment);
+
+                for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
+                    const CurveSegment& curve = 
+                        cable.getObstacleCurveSegment(ix);
+                    curve.calcDataPos(sCopy);
+                }
+
+                // Compute the path error vector after having applied the
+                // perturbation.
+                calcLineSegments(
+                    cableSegment,
+                    sCopy,
+                    lineSegments);
+
+                calcPathErrorVector<2>(
+                    cableSegment,
+                    sCopy,
+                    lineSegments,
+                    {NormalAxis, BinormalAxis},
+                    pathError);
+                calcPathErrorJacobian<2>(
+                    cableSegment,
+                    sCopy,
+                    lineSegments,
+                    {NormalAxis, BinormalAxis},
+                    pathErrorJacobian);
+
+                length = calcCableSegmentLength(sCopy, cableSegment, 
+                    lineSegments);
+                calcLengthGradient(sCopy, cableSegment, lineSegments, 
+                    lengthGradient);
+                calcLengthHessian(sCopy, cableSegment, lineSegments, 
+                    lengthHessian);
+
+                // The curve lengths are clipped at zero, which distorts the
+                // perturbation test. We simply skip these edge cases.
+                if (anyCurveSegmentHasZeroLength(sCopy, cableSegment)) {
+                    testReport << "CableSegment has zero-length curve segments after perturbation:";
+                    testReport << "Skipping perturbation test\n";
+                    continue;
+                }
+
+                // We can only use the path error Jacobian if the small
+                // perturbation did not trigger any liftoff or touchdown on any
+                // obstacles. If any CurveSegment's WrappingStatus has changed, 
+                // we will not continue with the test. Since the perturbation is
+                // small, this is unlikely to happen often.
+                std::vector<ObstacleWrappingStatus> nextWrappingStatus;
+                for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
+                    const CurveSegment& curve = 
+                        cable.getObstacleCurveSegment(ix);
+                    nextWrappingStatus.push_back(
+                        curve.getDataInst(sCopy).wrappingStatus);
+                }
+                if (!isEqual(prevWrappingStatus, nextWrappingStatus)) {
+                    testReport << "Wrapping status changed: Stopping test\n";
+                    break;
+                }
+
+                // Tolerance was given as a percentage, multiply by 0.01 to get the
+                // correct scale.
+                const Real tolerance =
+                    m_perturbationTestParameters.tolerance * 1e-2;
+                // Evaluate the path error jacobian.
+                {
+                    const Real predictionError =
+                        (predictedPathError - pathError).normInf();
+                    bool passedTest =
+                        std::abs(predictionError / perturbation) <= tolerance;
+                    if (!passedTest) {
+                        testReport << "FAILED path error Jacobian perturbation test for correction = "
+                                   << pathCorrection << "\n";
+                        testReport << "path error after perturbation:\n";
+                        testReport << "    Got        : " << pathError << "\n";
+                        testReport << "    Predicted  : " << predictedPathError
+                                   << "\n";
+                        testReport << "    Difference : "
+                                   << predictionError / perturbation
+                                   << "\n";
+                        testReport << "    Max diff   : "
+                                   << predictionError / perturbation
+                                   << " <= " << tolerance << " = eps\n";
+                    } else {
+                        testReport << "PASSED perturbation test for correction = "
+                                   << pathCorrection << "\n";
+                        testReport << " ( max diff = "
+                                   << predictionError / perturbation
+                                   << " <= " << tolerance << " = eps )\n";
+                    }
+                    success = success && passedTest;
+                }
+                // Evaluate the length gradient.
+                {
+                    const Real predictionError = 
+                        std::abs(predictedLength - length);
+                    bool passedTest =
+                        std::abs(predictionError / perturbation) <= tolerance;
+                    if (!passedTest) {
+                        testReport << "FAILED length gradient perturbation test for correction = "
+                                    << pathCorrection << "\n";
+                        testReport << "length after perturbation:\n";
+                        testReport << "    Got        : " << length << "\n";
+                        testReport << "    Predicted  : " << predictedLength
+                                   << "\n";
+                        testReport << "    Difference : "
+                                   << predictionError / perturbation
+                                   << "\n";
+                        testReport << "    Tolerance  : " << tolerance << "\n";
+                    } else {
+                        testReport << "PASSED length perturbation test for correction = "
+                                   << pathCorrection << "\n";
+                        testReport << " ( max diff = "
+                                   << std::abs(predictionError / perturbation)
+                                   << " <= " << tolerance << " = eps )\n";
+                    }
+                    success = success && passedTest;
+                }
+                // Evaluate the length Hessian.
+                {
+                    const Real predictionError =
+                        (predictedLengthGradient - lengthGradient).normInf();
+                    bool passedTest =
+                        std::abs(predictionError / perturbation) <= tolerance;
+                    if (!passedTest) {
+                        testReport << "FAILED length Hessian perturbation test for correction = "
+                                   << pathCorrection << "\n";
+                        testReport << "length gradient after perturbation:\n";
+                        testReport << "    Got        : " 
+                                   << lengthGradient << "\n";
+                        testReport << "    Predicted  : " 
+                                   << predictedLengthGradient << "\n";
+                        testReport << "    Difference : "
+                                   << predictionError / perturbation
+                                   << "\n";
+                        testReport << "    Max diff   : "
+                                   << std::abs(predictionError / perturbation)
+                                   << " <= " << tolerance << " = eps\n";
+                    } else {
+                        testReport << "PASSED length Hessian perturbation test for correction = "
+                                   << pathCorrection << "\n";
+                        testReport << " ( max diff = "
+                                   << std::abs(predictionError / perturbation)
+                                   << " <= " << tolerance << " = eps )\n";
+                    }
+                    success = success && passedTest;
+                }
             }
-        }
+        }        
     }
+
     // Flush all info to the report, in case we throw an exception.
     if (success) {
         testReport << "PASSED TEST: Jacobian perturbation test" << std::endl;
@@ -3793,6 +4460,7 @@ CableSubsystem::CableSubsystem(MultibodySystem& mbs)
 {
     adoptSubsystemGuts(new Impl());
     mbs.adoptSubsystem(*this);
+    mbs.setCableSubsystem(*this);
 }
 
 const MultibodySystem& CableSubsystem::getMultibodySystem() const
@@ -3863,6 +4531,7 @@ CableSpan::CableSpan(
 {
     CableSpanIndex ix = subsystem.updImpl().adoptCable(*this);
     updImpl().setSubsystem(subsystem, ix);
+    updImpl().createFirstCableSegment();
 }
 
 MobilizedBodyIndex CableSpan::getOriginBodyIndex() const
@@ -3905,6 +4574,20 @@ void CableSpan::setTerminationStation(const Vec3& terminationStation)
     m_impl->setTerminationStation(terminationStation);
 }
 
+void CableSpan::calcOriginUnitForce(
+    const State& state,
+    SpatialVec& unitForce_G) const
+{
+    calcUnitForceAtCableOrigin(getImpl(), state, unitForce_G);
+}
+
+void CableSpan::calcTerminationUnitForce(
+    const State& state,
+    SpatialVec& unitForce_G) const
+{
+    calcUnitForceAtCableTermination(getImpl(), state, unitForce_G);
+}
+
 ObstacleIndex CableSpan::addObstacle(
     MobilizedBodyIndex obstacleBody,
     const Transform& X_BS,
@@ -3933,6 +4616,23 @@ ObstacleIndex CableSpan::addObstacle(
 int CableSpan::getNumObstacles() const
 {
     return getImpl().getNumObstacles();
+}
+
+ViaPointIndex CableSpan::addViaPoint(
+    MobilizedBodyIndex viaPointBody, 
+    const Vec3& station_B)
+{
+    return updImpl().addViaPoint(viaPointBody, station_B);
+}
+
+int CableSpan::getNumViaPoints() const
+{
+    return getImpl().getNumViaPoints();
+}
+
+CableSpanIndex CableSpan::getIndex() const
+{
+    return getImpl().getIndex();
 }
 
 const MobilizedBodyIndex& CableSpan::getObstacleMobilizedBodyIndex(
@@ -3983,6 +4683,31 @@ void CableSpan::setObstacleContactPointHint(
 {
     updImpl().updObstacleCurveSegment(ix).setContactPointHint(
         initialContactPointHint);
+}
+
+const MobilizedBodyIndex& CableSpan::getViaPointMobilizedBodyIndex(
+    ViaPointIndex ix) const
+{
+    return getImpl().getViaPoint(ix).getMobilizedBodyIndex();   
+}
+
+void CableSpan::setViaPointMobilizedBodyIndex(
+    ViaPointIndex ix,
+    MobilizedBodyIndex body)
+{
+    updImpl().updViaPoint(ix).setMobilizedBodyIndex(body);
+}
+
+Vec3 CableSpan::getViaPointStation(ViaPointIndex ix) const
+{
+    return getImpl().getViaPoint(ix).getStation_B();
+}
+
+void CableSpan::setViaPointStation(
+    ViaPointIndex ix,
+    const Vec3& station_B)
+{
+    updImpl().updViaPoint(ix).setStation_B(station_B);
 }
 
 bool CableSpan::isInContactWithObstacle(const State& state, ObstacleIndex ix)
@@ -4097,5 +4822,30 @@ void CableSpan::calcCurveSegmentResampledPoints(
     int numSamples,
     const std::function<void(Vec3 point_G)>& sink) const
 {
-    m_impl->calcCurveSegmentResampledPoints(state, ix, numSamples, sink);
+    getImpl().calcCurveSegmentResampledPoints(state, ix, numSamples, sink);
+}
+
+void CableSpan::calcCurveSegmentUnitForce(
+    const State& state,
+    CableSpanObstacleIndex ix,
+    SpatialVec& unitForce_G) const
+{
+    const auto& curve = getImpl().getObstacleCurveSegment(ix);
+    calcUnitForceExertedByCurve(curve, state, unitForce_G);
+}
+
+Vec3 CableSpan::calcViaPointLocation(
+    const State& state,
+    CableSpanViaPointIndex ix) const
+{
+    return getImpl().getViaPoint(ix).getStation_G(state);
+}
+
+void CableSpan::calcViaPointUnitForce(
+    const State& state,
+    CableSpanViaPointIndex ix,
+    SpatialVec& unitForce_G) const
+{
+    const auto& viaPoint = getImpl().getViaPoint(ix);
+    calcUnitForceExertedByViaPoint(viaPoint, state, unitForce_G);
 }

--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -1443,6 +1443,7 @@ public:
         int numSamples,
         const std::function<void(Vec3 point_G)>& sink) const;
 
+private:
     //--------------------------------------------------------------------------
     // Data
     //--------------------------------------------------------------------------
@@ -3180,7 +3181,6 @@ void calcLengthHessian(
                 const Mat34& v_Q = cable.getObstacleCurveSegment(prevObsIx)
                                        .updDataPos(state)
                                        .v_Q;
-
                 AddBlock(-~v_P * E * v_Q, colShift);
             }
         }
@@ -3248,7 +3248,6 @@ void calcLengthHessian(
                 const Mat34& v_P = cable.getObstacleCurveSegment(nextObsIx)
                                        .updDataPos(state)
                                        .v_P;
-
                 AddBlock(-~v_Q * E * v_P, colShift);
             }
         }

--- a/Simbody/src/CableSpan_SubsystemTestHelper_Impl.cpp
+++ b/Simbody/src/CableSpan_SubsystemTestHelper_Impl.cpp
@@ -597,6 +597,12 @@ CableSubsystemTestHelper& CableSubsystemTestHelper::operator=(
     return *this = CableSubsystemTestHelper(source);
 }
 
+CableSubsystemTestHelper::CableSubsystemTestHelper(
+    CableSubsystemTestHelper&& source) noexcept = default;
+
+CableSubsystemTestHelper& CableSubsystemTestHelper::operator=(
+    CableSubsystemTestHelper&& source) noexcept = default;
+
 void CableSubsystemTestHelper::testCurrentPath(
     const State& state,
     const CableSubsystem& subsystem,

--- a/Simbody/src/CableSpan_SubsystemTestHelper_Impl.cpp
+++ b/Simbody/src/CableSpan_SubsystemTestHelper_Impl.cpp
@@ -598,10 +598,10 @@ CableSubsystemTestHelper& CableSubsystemTestHelper::operator=(
 }
 
 CableSubsystemTestHelper::CableSubsystemTestHelper(
-    CableSubsystemTestHelper&& source) noexcept = default;
+    CableSubsystemTestHelper&&) noexcept = default;
 
 CableSubsystemTestHelper& CableSubsystemTestHelper::operator=(
-    CableSubsystemTestHelper&& source) noexcept = default;
+    CableSubsystemTestHelper&&) noexcept = default;
 
 void CableSubsystemTestHelper::testCurrentPath(
     const State& state,

--- a/Simbody/src/MultibodySystem.cpp
+++ b/Simbody/src/MultibodySystem.cpp
@@ -99,6 +99,10 @@ int MultibodySystem::setContactSubsystem(GeneralContactSubsystem& m) {
     return updRep().setContactSubsystem(m);
 }
 
+int MultibodySystem::setCableSubsystem(CableSubsystem& m) {
+    return updRep().setCableSubsystem(m);
+}
+
 const SimbodyMatterSubsystem&       
 MultibodySystem::getMatterSubsystem() const {
     return getRep().getMatterSubsystem();
@@ -133,6 +137,18 @@ MultibodySystem::updContactSubsystem() {
 }
 bool MultibodySystem::hasContactSubsystem() const {
     return getRep().hasContactSubsystem();
+}
+
+const CableSubsystem&       
+MultibodySystem::getCableSubsystem() const {
+    return getRep().getCableSubsystem();
+}
+CableSubsystem&       
+MultibodySystem::updCableSubsystem() {
+    return updRep().updCableSubsystem();
+}
+bool MultibodySystem::hasCableSubsystem() const {
+    return getRep().hasCableSubsystem();
 }
 
 const Real

--- a/Simbody/src/MultibodySystem.cpp
+++ b/Simbody/src/MultibodySystem.cpp
@@ -139,11 +139,11 @@ bool MultibodySystem::hasContactSubsystem() const {
     return getRep().hasContactSubsystem();
 }
 
-const CableSubsystem&       
+const CableSubsystem&
 MultibodySystem::getCableSubsystem() const {
     return getRep().getCableSubsystem();
 }
-CableSubsystem&       
+CableSubsystem&
 MultibodySystem::updCableSubsystem() {
     return updRep().updCableSubsystem();
 }

--- a/Simbody/src/MultibodySystem.cpp
+++ b/Simbody/src/MultibodySystem.cpp
@@ -138,11 +138,11 @@ bool MultibodySystem::hasContactSubsystem() const {
     return getRep().hasContactSubsystem();
 }
 
-const CableSubsystem&       
+const CableSubsystem&
 MultibodySystem::getCableSubsystem() const {
     return getRep().getCableSubsystem();
 }
-CableSubsystem&       
+CableSubsystem&
 MultibodySystem::updCableSubsystem() {
     return updRep().updCableSubsystem();
 }
@@ -239,7 +239,7 @@ int MultibodySystemRep::realizeInstanceImpl(const State& s) const {
 
     for (int i=0; i < (int)forceSubs.size(); ++i)
         getForceSubsystem(forceSubs[i]).getRep().realizeSubsystemInstance(s);
-    
+
     if (hasDecorationSubsystem())
         getDecorationSubsystem().getGuts().realizeSubsystemInstance(s);
 

--- a/Simbody/src/MultibodySystem.cpp
+++ b/Simbody/src/MultibodySystem.cpp
@@ -98,7 +98,6 @@ int MultibodySystem::setDecorationSubsystem(DecorationSubsystem& m) {
 int MultibodySystem::setContactSubsystem(GeneralContactSubsystem& m) {
     return updRep().setContactSubsystem(m);
 }
-
 int MultibodySystem::setCableSubsystem(CableSubsystem& m) {
     return updRep().setCableSubsystem(m);
 }
@@ -139,11 +138,11 @@ bool MultibodySystem::hasContactSubsystem() const {
     return getRep().hasContactSubsystem();
 }
 
-const CableSubsystem&
+const CableSubsystem&       
 MultibodySystem::getCableSubsystem() const {
     return getRep().getCableSubsystem();
 }
-CableSubsystem&
+CableSubsystem&       
 MultibodySystem::updCableSubsystem() {
     return updRep().updCableSubsystem();
 }
@@ -200,6 +199,10 @@ int MultibodySystemRep::realizeTopologyImpl(State& s) const {
     // we don't know sizes until Model stage.
     getMatterSubsystem().getRep().realizeSubsystemTopology(s);
     getGlobalSubsystem().getRep().realizeSubsystemTopology(s);
+
+    if (hasCableSubsystem())
+        getCableSubsystem().getSubsystemGuts().realizeSubsystemTopology(s);
+
     for (int i=0; i < (int)forceSubs.size(); ++i)
         getForceSubsystem(forceSubs[i]).getRep().realizeSubsystemTopology(s);
 
@@ -215,6 +218,10 @@ int MultibodySystemRep::realizeModelImpl(State& s) const {
     // Stage::Model dimensions of the Matter subsystem.
     getMatterSubsystem().getRep().realizeSubsystemModel(s);
     getGlobalSubsystem().getRep().realizeSubsystemModel(s);
+
+    if (hasCableSubsystem())
+        getCableSubsystem().getSubsystemGuts().realizeSubsystemModel(s);
+
     for (int i=0; i < (int)forceSubs.size(); ++i)
         getForceSubsystem(forceSubs[i]).getRep().realizeSubsystemModel(s);
 
@@ -226,9 +233,13 @@ int MultibodySystemRep::realizeModelImpl(State& s) const {
 int MultibodySystemRep::realizeInstanceImpl(const State& s) const {
     getGlobalSubsystem().getRep().realizeSubsystemInstance(s);
     getMatterSubsystem().getRep().realizeSubsystemInstance(s);
+
+    if (hasCableSubsystem())
+        getCableSubsystem().getSubsystemGuts().realizeSubsystemInstance(s);
+
     for (int i=0; i < (int)forceSubs.size(); ++i)
         getForceSubsystem(forceSubs[i]).getRep().realizeSubsystemInstance(s);
-
+    
     if (hasDecorationSubsystem())
         getDecorationSubsystem().getGuts().realizeSubsystemInstance(s);
 
@@ -237,6 +248,10 @@ int MultibodySystemRep::realizeInstanceImpl(const State& s) const {
 int MultibodySystemRep::realizeTimeImpl(const State& s) const {
     getGlobalSubsystem().getRep().realizeSubsystemTime(s);
     getMatterSubsystem().getRep().realizeSubsystemTime(s);
+
+    if (hasCableSubsystem())
+        getCableSubsystem().getSubsystemGuts().realizeSubsystemTime(s);
+
     for (int i=0; i < (int)forceSubs.size(); ++i)
         getForceSubsystem(forceSubs[i]).getRep().realizeSubsystemTime(s);
 
@@ -248,6 +263,10 @@ int MultibodySystemRep::realizeTimeImpl(const State& s) const {
 int MultibodySystemRep::realizePositionImpl(const State& s) const {
     getGlobalSubsystem().getRep().realizeSubsystemPosition(s);
     getMatterSubsystem().getRep().realizeSubsystemPosition(s);
+
+    if (hasCableSubsystem())
+        getCableSubsystem().getSubsystemGuts().realizeSubsystemPosition(s);
+
     for (int i=0; i < (int)forceSubs.size(); ++i)
         getForceSubsystem(forceSubs[i]).getRep().realizeSubsystemPosition(s);
 
@@ -259,6 +278,10 @@ int MultibodySystemRep::realizePositionImpl(const State& s) const {
 int MultibodySystemRep::realizeVelocityImpl(const State& s) const {
     getGlobalSubsystem().getRep().realizeSubsystemVelocity(s);
     getMatterSubsystem().getRep().realizeSubsystemVelocity(s);
+
+    if (hasCableSubsystem())
+        getCableSubsystem().getSubsystemGuts().realizeSubsystemVelocity(s);
+
     for (int i=0; i < (int)forceSubs.size(); ++i)
         getForceSubsystem(forceSubs[i]).getRep().realizeSubsystemVelocity(s);
 
@@ -274,6 +297,9 @@ int MultibodySystemRep::realizeDynamicsImpl(const State& s) const {
 
     // This realizes the matter subsystem's dynamic operators; not yet accelerations.
     getMatterSubsystem().getRep().realizeSubsystemDynamics(s);
+
+    if (hasCableSubsystem())
+        getCableSubsystem().getSubsystemGuts().realizeSubsystemDynamics(s);
 
     // Now do forces in case any of them need dynamics-stage operators.
     for (int i=0; i < (int)forceSubs.size(); ++i)
@@ -291,6 +317,9 @@ int MultibodySystemRep::realizeAccelerationImpl(const State& s) const {
     // can depend only on force calculations at Dynamics stage.
     getMatterSubsystem().getRep().realizeSubsystemAcceleration(s);
 
+    if (hasCableSubsystem())
+        getCableSubsystem().getSubsystemGuts().realizeSubsystemAcceleration(s);
+
     // Force elements' realizeAcceleration() methods might depend on 
     // accelerations or multipliers we just calculated. For example, a friction
     // force might record normal forces to use as an initial guess in the
@@ -307,6 +336,10 @@ int MultibodySystemRep::realizeReportImpl(const State& s) const {
     getGlobalSubsystem().getRep().realizeSubsystemReport(s);
 
     getMatterSubsystem().getRep().realizeSubsystemReport(s);
+
+    if (hasCableSubsystem())
+        getCableSubsystem().getSubsystemGuts().realizeSubsystemReport(s);
+
     for (int i=0; i < (int)forceSubs.size(); ++i)
         getForceSubsystem(forceSubs[i]).getRep().realizeSubsystemReport(s);
 

--- a/Simbody/src/MultibodySystemRep.h
+++ b/Simbody/src/MultibodySystemRep.h
@@ -36,6 +36,7 @@
 #include "simbody/internal/ForceSubsystem.h"
 #include "simbody/internal/DecorationSubsystem.h"
 #include "simbody/internal/GeneralContactSubsystem.h"
+#include "simbody/internal/CableSpan.h"
 
 #include "simbody/internal/ForceSubsystemGuts.h"
 #include "SimbodyMatterSubsystemRep.h"
@@ -326,6 +327,11 @@ public:
         contactSub = adoptSubsystem(c);
         return contactSub;
     }
+    SubsystemIndex setCableSubsystem(CableSubsystem& c) {
+        assert(!cableSub.isValid());
+        cableSub = adoptSubsystem(c);
+        return cableSub;
+    }
 
     const SimbodyMatterSubsystem& getMatterSubsystem() const {
         assert(matterSub.isValid());
@@ -343,6 +349,7 @@ public:
     bool hasContactSubsystem() const {return contactSub.isValid();}
     bool hasMatterSubsystem() const {return matterSub.isValid();}
     bool hasGlobalSubsystem() const {return globalSub.isValid();}
+    bool hasCableSubsystem() const {return cableSub.isValid();}
 
     const DecorationSubsystem& getDecorationSubsystem() const {
         assert(decorationSub.isValid());
@@ -352,6 +359,11 @@ public:
     const GeneralContactSubsystem& getContactSubsystem() const {
         assert(contactSub.isValid());
         return GeneralContactSubsystem::downcast(getSubsystem(contactSub));
+    }
+
+    const CableSubsystem& getCableSubsystem() const {
+        assert(cableSub.isValid());
+        return CableSubsystem::downcast(getSubsystem(cableSub));
     }
 
     SimbodyMatterSubsystem& updMatterSubsystem() {
@@ -372,6 +384,10 @@ public:
     GeneralContactSubsystem& updContactSubsystem() {
         assert(contactSub.isValid());
         return GeneralContactSubsystem::updDowncast(updSubsystem(contactSub));
+    }
+    CableSubsystem& updCableSubsystem() {
+        assert(cableSub.isValid());
+        return CableSubsystem::updDowncast(updSubsystem(cableSub));
     }
 
     // Global state cache entries dealing with interaction between forces & 
@@ -504,6 +520,7 @@ private:
     Array_<SubsystemIndex> forceSubs;       // indices of force subsystems
     SubsystemIndex         decorationSub;   // index of DecorationSubsystem if any, else -1
     SubsystemIndex         contactSub;      // index of contact subsystem if any, else -1
+    SubsystemIndex         cableSub;        // index of cable subsystem if any, else -1
 };
 
 

--- a/Simbody/src/MultibodySystemRep.h
+++ b/Simbody/src/MultibodySystemRep.h
@@ -328,7 +328,9 @@ public:
         return contactSub;
     }
     SubsystemIndex setCableSubsystem(CableSubsystem& c) {
-        assert(!cableSub.isValid());
+        SimTK_ASSERT(!cableSub.isValid(),
+            "MultibodySystemRep::setCableSubsystem(): CableSubsystem is "
+            "invalid.");
         cableSub = adoptSubsystem(c);
         return cableSub;
     }

--- a/Simbody/tests/TestCableSpan.cpp
+++ b/Simbody/tests/TestCableSpan.cpp
@@ -1,9 +1,9 @@
 /*-----------------------------------------------------------------------------
-                Simbody(tm) Test: Cable Over Several Smooth Surfaces
+            Simbody(tm) Test: Cable Over Smooth Surfaces and Via Points
 -------------------------------------------------------------------------------
  Copyright (c) 2024 Authors.
  Authors: Pepijn van den Bos
- Contributors:
+ Contributors: Nicholas Bianco
 
  Licensed under the Apache License, Version 2.0 (the "License"); you may
  not use this file except in compliance with the License. You may obtain a
@@ -21,7 +21,8 @@
 using namespace SimTK;
 
 /**
-This file contains tests for the CableSpan's path over different obstacles.
+This file contains tests for the CableSpan's path over different obstacles and
+via points.
 **/
 
 /* A helper class for drawing interesting things of a CableSpan. */
@@ -87,6 +88,18 @@ public:
                 DecorativePoint(X_GS.shiftFrameStationToBase(x_PS))
                     .setColor(Green));
         }
+
+        for (CableSpanViaPointIndex ix(0); ix < m_cable.getNumViaPoints();
+                ++ix) {
+            // Draw the via point.
+            const Vec3 x_G = m_cable.calcViaPointLocation(state, ix);
+            decorations.push_back(
+                DecorativeSphere(0.1)
+                    .setTransform(x_G)
+                    .setRepresentation(DecorativeGeometry::DrawWireframe)
+                    .setColor(Cyan)
+                    .setOpacity(0.1));
+        }
     }
 
     MultibodySystem* m_mbs;
@@ -95,7 +108,7 @@ public:
     Array_<Transform, CableSpanObstacleIndex> m_obstacleDecorationsOffsets;
 };
 
-/** Simple CableSpon path with known solution.
+/** Simple CableSpan path with known solution.
 
 Wrap a cable over (in order):
 1. Torus
@@ -196,7 +209,7 @@ void testSimpleCable()
 
     // Compute the CableSpan's path.
     system.realize(s, Stage::Report);
-    const Real cableLength = cable.calcLength(s);
+    cable.calcLength(s);
     if (viz) {
         viz->report(s);
     }
@@ -204,6 +217,10 @@ void testSimpleCable()
     SimTK_ASSERT_ALWAYS(
         cable.getNumObstacles() == 4,
         "Invalid number of obstacles");
+
+    SimTK_ASSERT_ALWAYS(
+        cable.getNumViaPoints() == 0,
+        "Invalid number of via points");
 
     SimTK_ASSERT2_ALWAYS(
         cable.getSmoothness(s) <= cable.getSmoothnessTolerance(),
@@ -385,16 +402,156 @@ void testSimpleCable()
     }
 }
 
-/** Test computed cable path over all supported surfaces, testing geodesics,
-Jacobians, and kinematics.
+/** Simple CableSpan comprised of via points with known solution. **/
+void testViaPoints()
+{
+    const bool show = false;
+
+    // Create the system.
+    MultibodySystem system;
+    SimbodyMatterSubsystem matter(system);
+    CableSubsystem cables(system);
+
+    // A dummy body.
+    Body::Rigid aBody(MassProperties(1., Vec3(0), Inertia(1)));
+
+    // Mobilizer for path origin.
+    MobilizedBody::Translation cableOriginBody(
+        matter.Ground(),
+        Vec3(0.),
+        aBody,
+        Transform());
+
+    // Mobilizer for path termination.
+    MobilizedBody::Translation cableTerminationBody(
+        matter.Ground(),
+        Transform(Vec3(-4., 0., 0.)),
+        aBody,
+        Transform());
+
+    // Construct a new cable.
+    CableSpan cable(
+        cables,
+        cableOriginBody,
+        Vec3{0.},
+        cableTerminationBody,
+        Vec3{0.});
+
+    // First via point.
+    MobilizedBody::Translation cableViaPoint1Body(
+        matter.Ground(),
+        Transform(Vec3(0., 1.0, 0.)),
+        aBody,
+        Transform());
+    cable.addViaPoint(cableViaPoint1Body, Vec3{0.});
+
+    // Second via point.
+    MobilizedBody::Translation cableViaPoint2Body(
+        matter.Ground(),
+        Transform(Vec3(0., 1.0, 2.0)),
+        aBody,
+        Transform());
+    cable.addViaPoint(cableViaPoint2Body, Vec3{0.});
+
+    // Third via point.
+    MobilizedBody::Translation cableViaPoint3Body(
+        matter.Ground(),
+        Transform(Vec3(-4.0, 1.0, 2.0)),
+        aBody,
+        Transform());
+    cable.addViaPoint(cableViaPoint3Body, Vec3{0.});
+
+    // Optionally visualize the system.
+    system.setUseUniformBackground(true); // no ground plane in display
+    std::unique_ptr<Visualizer> viz(show ? new Visualizer(system) : nullptr);
+
+    if (viz) {
+        viz->setShowFrameNumber(true);
+        viz->addDecorationGenerator(new CableDecorator(system, cable));
+    }
+
+    // Initialize the system and state.
+    system.realizeTopology();
+    State s = system.getDefaultState();
+
+    // Compute the CableSpan's path.
+    system.realize(s, Stage::Report);
+    cable.calcLength(s);
+    if (viz) {
+        viz->report(s);
+    }
+
+    SimTK_ASSERT_ALWAYS(
+        cable.getNumObstacles() == 0,
+        "Invalid number of obstacles");
+
+    SimTK_ASSERT_ALWAYS(
+        cable.getNumViaPoints() == 3,
+        "Invalid number of via points");
+
+    // With no obstacles, the smoothness should always be zero.
+    SimTK_ASSERT1_ALWAYS(
+        cable.getSmoothness(s) == 0.,
+        "Test failed: Cable smoothness (=%e) must be zero",
+        cable.getSmoothness(s));
+
+    // Sum all straight line segment lengths.
+    const Real lengthTolerance = 1e-5;
+    const Real expectedTotalCableLength = 1. + 2. + 4. + std::sqrt(5.);
+    const Real gotTotalCableLength = cable.calcLength(s);
+    SimTK_ASSERT3_ALWAYS(
+        std::abs(expectedTotalCableLength - gotTotalCableLength) <
+            lengthTolerance,
+        "Expected cable length (=%f) does not match computed cable length (=%f), error = %e",
+        expectedTotalCableLength,
+        gotTotalCableLength,
+        expectedTotalCableLength - gotTotalCableLength);
+
+    // We have no obstacles, so this should pass since all internal tests will
+    // be skipped.
+    CableSubsystemTestHelper().testCurrentPath(s, cables, std::cout);
+
+    Vector_<SpatialVec> expectedBodyForcesInG(6, {{0., 0., 0.}, {0., 0., 0.}});
+    // Ground body.
+    expectedBodyForcesInG[0] = (SpatialVec{{0., 0., 0}, {0., 0., 0.}});
+    // Cable origin body.
+    expectedBodyForcesInG[1] = (SpatialVec{{0., 0., 0.}, {0., 1., 0.}});
+    // Cable termination body.
+    expectedBodyForcesInG[2] = 
+        (SpatialVec{{0., 0., 0.}, {0., 1./std::sqrt(5.), 2./std::sqrt(5.)}});
+    // First via point.
+    expectedBodyForcesInG[3] = (SpatialVec{{0., 0., 0.}, {0., -1., 1.}});
+    // Second via point.
+    expectedBodyForcesInG[4] = (SpatialVec{{0., 0., 0.}, {-1., 0, -1.}});
+    // Third via point.
+    expectedBodyForcesInG[5] = 
+        (SpatialVec{{0., 0., 0.}, {1., -1./std::sqrt(5.), -2./std::sqrt(5.)}});
+
+    const Real tension = Pi;
+    Vector_<SpatialVec> gotBodyForcesInG(6, {{0., 0., 0.}, {0., 0., 0.}});
+    cable.applyBodyForces(s, tension, gotBodyForcesInG);
+
+    for (int i = 0; i < gotBodyForcesInG.size(); ++i) {
+        const Real tolerance = 1e-5;
+        SimTK_ASSERT1_ALWAYS(
+            (expectedBodyForcesInG[i] * tension - gotBodyForcesInG[i]).norm() <
+                tolerance,
+            "Unexpected force applied to body %i",
+            i);
+    }
+}
+
+/** Test computed cable path over all supported surfaces and a via point, 
+testing geodesics, Jacobians, and kinematics.
 
 The cable wraps over (in order):
 1. Torus,
 2. Ellipsoid,
-3. Sphere,
-4. Cylinder,
-5. Bicubic patch,
-6. Torus.
+3. Via point,
+4. Sphere,
+5. Cylinder,
+6. Bicubic patch,
+7. Torus.
 
 The flag assertCableLengthDerivative is used to switch between verifying that
 the computed cable length derivative matches the change in length during
@@ -416,6 +573,13 @@ void testAllSurfaceKinds(bool assertCableLengthDerivative)
     MobilizedBody::Translation cableOriginBody(
         matter.Ground(),
         Vec3(-8., 0.1, 0.),
+        aBody,
+        Transform());
+
+     // Mobilizer for the path via point.
+    MobilizedBody::Translation cableViaPointBody(
+        matter.Ground(),
+        Transform(Vec3(0., 0.9, 0.5)),
         aBody,
         Transform());
 
@@ -450,6 +614,9 @@ void testAllSurfaceKinds(bool assertCableLengthDerivative)
         std::shared_ptr<ContactGeometry>(
             new ContactGeometry::Ellipsoid({1.5, 2.6, 1.})),
         {0.0, 0., 1.1});
+
+    // Add the first via point.
+    cable.addViaPoint(cableViaPointBody, Vec3{0.});
 
     // Add sphere obstacle.
     cable.addObstacle(
@@ -557,6 +724,14 @@ void testAllSurfaceKinds(bool assertCableLengthDerivative)
                 0.1 * cos(angle),
                 4. * 0.7 * cos(angle * 0.7),
                 10. * 1.3 * cos(angle * 1.3)));
+
+        // Move the via point.
+        cableViaPointBody.setQ(
+            s,
+            Vec3(0., 0.5 * cos(angle), 0.));
+        cableViaPointBody.setU(
+            s,
+            Vec3(0., 0.5 * -sin(angle), 0.));
 
         // Compute the CableSpan's path.
         system.realize(s, Stage::Report);
@@ -981,6 +1156,7 @@ void testRobustInitialPath()
 int main()
 {
     testSimpleCable();
+    testViaPoints();
     testTouchdownAndLiftoff();
     testAllSurfaceKinds(false); // Test all geodesics and Jacobians.
     testAllSurfaceKinds(true);  // Test length derivative.

--- a/Simbody/tests/TestCableSpan.cpp
+++ b/Simbody/tests/TestCableSpan.cpp
@@ -517,14 +517,14 @@ void testViaPoints()
     // Cable origin body.
     expectedBodyForcesInG[1] = (SpatialVec{{0., 0., 0.}, {0., 1., 0.}});
     // Cable termination body.
-    expectedBodyForcesInG[2] = 
+    expectedBodyForcesInG[2] =
         (SpatialVec{{0., 0., 0.}, {0., 1./std::sqrt(5.), 2./std::sqrt(5.)}});
     // First via point.
     expectedBodyForcesInG[3] = (SpatialVec{{0., 0., 0.}, {0., -1., 1.}});
     // Second via point.
     expectedBodyForcesInG[4] = (SpatialVec{{0., 0., 0.}, {-1., 0, -1.}});
     // Third via point.
-    expectedBodyForcesInG[5] = 
+    expectedBodyForcesInG[5] =
         (SpatialVec{{0., 0., 0.}, {1., -1./std::sqrt(5.), -2./std::sqrt(5.)}});
 
     const Real tension = Pi;
@@ -541,7 +541,7 @@ void testViaPoints()
     }
 }
 
-/** Test computed cable path over all supported surfaces and a via point, 
+/** Test computed cable path over all supported surfaces and a via point,
 testing geodesics, Jacobians, and kinematics.
 
 The cable wraps over (in order):

--- a/Simbody/tests/TestCableSpan.cpp
+++ b/Simbody/tests/TestCableSpan.cpp
@@ -224,7 +224,8 @@ void testSimpleCable()
 
     SimTK_ASSERT2_ALWAYS(
         cable.getSmoothness(s) <= cable.getSmoothnessTolerance(),
-        "Test failed: Cable smoothness (=%e) must be smaller than set tolerance (=%e)",
+        "Test failed: Cable smoothness (=%e) must be smaller than set "
+        "tolerance (=%e)",
         cable.getSmoothness(s),
         cable.getSmoothnessTolerance());
 
@@ -251,7 +252,8 @@ void testSimpleCable()
 
         SimTK_ASSERT4_ALWAYS(
             std::abs(gotLength - expectedLength) < lengthTolerance,
-            "%s curve segment length (=%f) does not match expected length (=%f), with error %e",
+            "%s curve segment length (=%f) does not match expected length "
+            "(=%f), with error %e",
             obsNames.at(obsIx).c_str(),
             gotLength,
             expectedLength,
@@ -272,7 +274,8 @@ void testSimpleCable()
     SimTK_ASSERT3_ALWAYS(
         std::abs(expectedTotalCableLength - gotTotalCableLength) <
             lengthTolerance,
-        "Expected cable length (=%f) does not match computed cable length (=%f), error = %e",
+        "Expected cable length (=%f) does not match computed cable length "
+        "(=%f), error = %e",
         expectedTotalCableLength,
         gotTotalCableLength,
         expectedTotalCableLength - gotTotalCableLength);
@@ -297,7 +300,8 @@ void testSimpleCable()
         SimTK_ASSERT1_ALWAYS(
             (expected_X_GP.R().asMat33() - got_X_GP.R().asMat33()).norm() <
                 frenetFrameTolerance,
-            "%s curve segment frame orientation at initial contact point incorrect",
+            "%s curve segment frame orientation at initial contact point "
+            "incorrect",
             obsNames.at(obsIx).c_str());
 
         SimTK_ASSERT1_ALWAYS(
@@ -307,7 +311,8 @@ void testSimpleCable()
         SimTK_ASSERT1_ALWAYS(
             (expected_X_GQ.R().asMat33() - got_X_GQ.R().asMat33()).norm() <
                 frenetFrameTolerance,
-            "%s curve segment frame orientation at final contact point incorrect",
+            "%s curve segment frame orientation at final contact point "
+            "incorrect",
             obsNames.at(obsIx).c_str());
     };
 
@@ -502,7 +507,8 @@ void testViaPoints()
     SimTK_ASSERT3_ALWAYS(
         std::abs(expectedTotalCableLength - gotTotalCableLength) <
             lengthTolerance,
-        "Expected cable length (=%f) does not match computed cable length (=%f), error = %e",
+        "Expected cable length (=%f) does not match computed cable length "
+        "(=%f), error = %e",
         expectedTotalCableLength,
         gotTotalCableLength,
         expectedTotalCableLength - gotTotalCableLength);
@@ -770,14 +776,16 @@ void testAllSurfaceKinds(bool assertCableLengthDerivative)
                 .norm();
         SimTK_ASSERT2_ALWAYS(
             cableLength > distanceBetweenEndPoints,
-            "Test failed: Cable length (=%f) smaller than distance between end points (=%f)",
+            "Test failed: Cable length (=%f) smaller than distance between end "
+            "points (=%f)",
             cableLength,
             distanceBetweenEndPoints);
 
         // Make sure that we acutally solved the path up to tolerance.
         SimTK_ASSERT2_ALWAYS(
             cable.getSmoothness(s) <= cable.getSmoothnessTolerance(),
-            "Test failed: Cable smoothness (=%e) must be smaller than set tolerance (=%e)",
+            "Test failed: Cable smoothness (=%e) must be smaller than set "
+            "tolerance (=%e)",
             cable.getSmoothness(s),
             cable.getSmoothnessTolerance());
 
@@ -919,7 +927,8 @@ void testTouchdownAndLiftoff()
             const bool expectedContactStatus = yCoord < 0.;
             SimTK_ASSERT4_ALWAYS(
                 gotContactStatus == expectedContactStatus,
-                "Cable %i expected contact status (=%i) does not match computed contact status (=%i) at yCoord = %f",
+                "Cable %i expected contact status (=%i) does not match "
+                "computed contact status (=%i) at yCoord = %f",
                 cableIx,
                 expectedContactStatus,
                 gotContactStatus,
@@ -1027,10 +1036,12 @@ void testSolverOptimum()
 
         SimTK_ASSERT_ALWAYS(
             (expected_p_GP - got_p_GP).norm() < 1e-6,
-            "Scholz2015 algorithm: Curve segment position at initial contact point incorrect");
+            "Scholz2015 algorithm: Curve segment position at initial contact "
+            "point incorrect");
         SimTK_ASSERT_ALWAYS(
             (expected_p_GQ - got_p_GQ).norm() < 1e-6,
-            "Scholz2015 algorithm: Curve segment position at final contact point incorrect");
+            "Scholz2015 algorithm: Curve segment position at final contact "
+            "point incorrect");
     }
 
     // MinimumLength algorithm converges to the shortest possible path as the
@@ -1067,10 +1078,12 @@ void testSolverOptimum()
 
         SimTK_ASSERT_ALWAYS(
             (expected_p_GP - got_p_GP).norm() < 1e-6,
-            "Scholz2015 algorithm: Curve segment position at initial contact point incorrect");
+            "Scholz2015 algorithm: Curve segment position at initial contact "
+            "point incorrect");
         SimTK_ASSERT_ALWAYS(
             (expected_p_GQ - got_p_GQ).norm() < 1e-6,
-            "Scholz2015 algorithm: Curve segment position at final contact point incorrect");
+            "Scholz2015 algorithm: Curve segment position at final contact "
+            "point incorrect");
     }
 }
 

--- a/Simbody/tests/TestCableSpan_Forces.cpp
+++ b/Simbody/tests/TestCableSpan_Forces.cpp
@@ -185,8 +185,8 @@ void testCableForceOnSingleObstacle()
     assertForces(system, cable, forcesExpected);
 }
 
-// This case is the same as testCableForceOnSingleObstacle, except that there is 
-// an offset between the obstacle surface frame and obstacle body, to verify the 
+// This case is the same as testCableForceOnSingleObstacle, except that there is
+// an offset between the obstacle surface frame and obstacle body, to verify the
 // generated torque.
 void testCableForceAndMomentOnSingleObstacle()
 {
@@ -240,8 +240,8 @@ void testCableForceOnSingleViaPoint()
     // attachment points.
     const Real angle = 45. / 180. * Pi;
 
-    Body::Rigid aBody(MassProperties(1., Vec3(0), Inertia(1)));
-    
+    Body::Rigid aBody(MassProperties(1., Vec3(0.), Inertia(1.)));
+
     MobilizedBody::Free viaPointBody(
         matter.Ground(),
         Vec3(0.),

--- a/examples/ExampleCableSpan.cpp
+++ b/examples/ExampleCableSpan.cpp
@@ -16,8 +16,8 @@
  limitations under the License.
  ----------------------------------------------------------------------------*/
 
-/* This example is for experimenting with a CableSpan over obstacle surfaces and 
-through via points. The via points and cable endpoints are manually repositioned 
+/* This example is for experimenting with a CableSpan over obstacle surfaces and
+through via points. The via points and cable endpoints are manually repositioned
 to control the next path solving problem. */
 
 #include "Simbody.h"


### PR DESCRIPTION
Fixes #827 

## Summary

This change adds support for including via points in a CableSpan's path. Via points can be added to a CablePath by specifying a mobilized body and a body-fixed station that define the position of the via point in the multibody system. Similarly to obstacles, via points are handled in the order that they are added to the CableSpan. Internally, via points divide the cable into segments, and a separate path optimization is performed for each segment.

Here is the result of `ExampleCableSpan.cpp`, now updated to include two via points (shown in light blue) that modify the` `CableSpan`'s path. 

https://github.com/user-attachments/assets/e9dfc198-110c-4b69-aa20-cc3d31d0706e

## Interface

`CableSpan::addViaPoint()` can be used to add a via point to the cable by specifying a `MobilizedBodyIndex` and the position of the via point on the mobilized body in body-fixed coordinates. A `CableSpanViaPointIndex` is returned, providing a unique identifier for the via point in the `CableSpan`.

```c++
// Construct a new cable.
CableSpan cable(
    cables,
    cableOriginBody,
    Vec3{0.},
    cableTerminationBody,
    Vec3{0.});

// Mobilizer for the path via point.
MobilizedBody::Translation cableViaPointBody(
    matter.Ground(),
    Transform(Vec3(0., 0.9, 0.5)),
    aBody,
    Transform());

// Add the via point.
CableSpanViaPointIndex ix = cable.addViaPoint(cableViaPointBody, Vec3{0.});
```

Accessors have been added to enable retrieving or modifying the mobilized body or via point location, and the convenience method `CableSpan::calcViaPointLocation()` is added for calculating the location of a via point in the ground frame.

## Implementation

Internally, two new classes are added to support via points in a `CableSpan` path: `ViaPoint` and `CableSegment`. `ViaPoint` caches computations relevant to via points and provides convenience methods similar to `CurveSegment` for path obstacles. `CableSegment` is added to manage groups of obstacles in the cable that are separated by via points. Within `CableSpan.cpp`, `CableSegmentIndex` provides a unique index to `CableSegement`s, and `CableSpanViaPointIndex` can be used to index into `ViaPoint`s.

A key aspect of this implementation is that the path segments associated with each `CableSegment` are optimized independently, since obstacles separated by via points have no interaction when natural geodesic corrections are applied (i.e., the path error Jacobian off-diagonal elements are structurally zero). This approach is advantageous because path segments may converge in a different number of solver iterations and any invalidated segments will not force unchanged paths to re-run the path optimization unnecessarily. 

## Testing

`TestCableSpan.cpp` has been updated to add the new subtest `testViaPoints()` and include via points in the subtest `testAllSurfaceKinds()`. `testViaPoints()` mimics `testSimpleCable()` by defining a `CableSpan` comprised only of via points from which it is easy to verify both the path geometry and applied body forces:

![TestCableSpanViaPoints](https://github.com/user-attachments/assets/6d2c69b2-54d9-4025-ad1c-166ee26cc25d)

Additionally, tests have been added to `TestCableSpan_Forces.cpp` and `TestCableSpan_LengthDot.cpp` mimicking the existing obstacle tests but instead using via points.

### CableSubsystem accessors

To help support a wrapping implementation in OpenSim based on `CableSpan`, accessors to `CableSubsystem` have been added to `MultibodySystem`. `ModelComponent` in OpenSim would now have access to `CableSubsystem` (and subsequently any underlying `CableSpan` elements) through it's stored reference to `MultibodySystem`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/828)
<!-- Reviewable:end -->
