### PR TITLE
Implement `realizeSubsystemPosition` and `realizeSubsystemVelocityImpl()` for `CableSubsystem`

### DIFF
--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -1522,6 +1522,21 @@ public:
         }
     }
 
+    void realizeModel(State& state) const
+    {
+        // No choices at the moment.
+    }
+
+    void realizeInstance(const State& state) const
+    {
+        // Nothing to compute here yet.
+    }
+
+    void realizeTime(const State& state) const
+    {
+        // Nothing to compute here yet.
+    }
+
     void realizePosition(const State& state) const
     {
         if (getSubsystem().isCacheValueRealized(state, m_indexDataPos)) {
@@ -1539,6 +1554,21 @@ public:
         }
         calcDataVel(state, updDataVel(state));
         getSubsystem().markCacheValueRealized(state, m_indexDataVel);
+    }
+
+    void realizeDynamics(const State& state) const
+    {
+        // Nothing to compute here yet.
+    }
+
+    void realizeAcceleration(const State& state) const
+    {
+        // Nothing to compute here yet.
+    }
+
+    void realizeReport(const State& state) const
+    {
+        // Nothing to compute here yet.
     }
 
     const CableSpanData::Position& getDataPos(const State& state) const
@@ -3640,19 +3670,28 @@ int CableSubsystem::Impl::realizeSubsystemTopologyImpl(State& state) const
 
 int CableSubsystem::Impl::realizeSubsystemModelImpl(State& state) const
 {
-    // No choices at the moment.
+    for (CableSpanIndex ix(0); ix < cables.size(); ++ix) {
+        getCable(ix).getImpl().realizeModel(state);
+    }
+
     return 0;
 }
 
 int CableSubsystem::Impl::realizeSubsystemInstanceImpl(const State& state) const
 {
-    // Nothing to compute here.
+    for (CableSpanIndex ix(0); ix < cables.size(); ++ix) {
+        getCable(ix).getImpl().realizeInstance(state);
+    }
+
     return 0;
 }
 
 int CableSubsystem::Impl::realizeSubsystemTimeImpl(const State& state) const
 {
-    // Nothing to compute here.
+    for (CableSpanIndex ix(0); ix < cables.size(); ++ix) {
+        getCable(ix).getImpl().realizeTime(state);
+    }
+
     return 0;
 }
 
@@ -3676,20 +3715,29 @@ int CableSubsystem::Impl::realizeSubsystemVelocityImpl(const State& state) const
 
 int CableSubsystem::Impl::realizeSubsystemDynamicsImpl(const State& state) const
 {
-    // Nothing to compute here.
+    for (CableSpanIndex ix(0); ix < cables.size(); ++ix) {
+        getCable(ix).getImpl().realizeDynamics(state);
+    }
+
     return 0;
 }
 
 int 
 CableSubsystem::Impl::realizeSubsystemAccelerationImpl(const State& state) const
 {
-    // Nothing to compute here.
+    for (CableSpanIndex ix(0); ix < cables.size(); ++ix) {
+        getCable(ix).getImpl().realizeAcceleration(state);
+    }
+
     return 0;
 }
 
 int CableSubsystem::Impl::realizeSubsystemReportImpl(const State& state) const
 {
-    // Nothing to compute here.
+    for (CableSpanIndex ix(0); ix < cables.size(); ++ix) {
+        getCable(ix).getImpl().realizeReport(state);
+    }
+
     return 0;
 }
 

--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -583,9 +583,21 @@ private:
 
     int realizeSubsystemTopologyImpl(State& state) const override;
 
+    int realizeSubsystemModelImpl(State& state) const override;
+
+    int realizeSubsystemInstanceImpl(const State& state) const override;
+
+    int realizeSubsystemTimeImpl(const State& state) const override;
+
     int realizeSubsystemPositionImpl(const State& state) const override;
 
     int realizeSubsystemVelocityImpl(const State& state) const override;
+
+    int realizeSubsystemDynamicsImpl(const State& state) const override;
+
+    int realizeSubsystemAccelerationImpl(const State& state) const override;
+
+    int realizeSubsystemReportImpl(const State& state) const override;
 
     int calcDecorativeGeometryAndAppendImpl(
         const State& state,
@@ -3626,6 +3638,24 @@ int CableSubsystem::Impl::realizeSubsystemTopologyImpl(State& state) const
     return 0;
 }
 
+int CableSubsystem::Impl::realizeSubsystemModelImpl(State& state) const
+{
+    // No choices at the moment.
+    return 0;
+}
+
+int CableSubsystem::Impl::realizeSubsystemInstanceImpl(const State& state) const
+{
+    // Nothing to compute here.
+    return 0;
+}
+
+int CableSubsystem::Impl::realizeSubsystemTimeImpl(const State& state) const
+{
+    // Nothing to compute here.
+    return 0;
+}
+
 int CableSubsystem::Impl::realizeSubsystemPositionImpl(const State& state) const
 {
     for (CableSpanIndex ix(0); ix < cables.size(); ++ix) {
@@ -3641,6 +3671,25 @@ int CableSubsystem::Impl::realizeSubsystemVelocityImpl(const State& state) const
         getCable(ix).getImpl().realizeVelocity(state);
     }
 
+    return 0;
+}
+
+int CableSubsystem::Impl::realizeSubsystemDynamicsImpl(const State& state) const
+{
+    // Nothing to compute here.
+    return 0;
+}
+
+int 
+CableSubsystem::Impl::realizeSubsystemAccelerationImpl(const State& state) const
+{
+    // Nothing to compute here.
+    return 0;
+}
+
+int CableSubsystem::Impl::realizeSubsystemReportImpl(const State& state) const
+{
+    // Nothing to compute here.
     return 0;
 }
 


### PR DESCRIPTION
### Summary
This change implements the `Subsystem` virtual methods `realizesSubsystemPositionImpl` and `realizeSubsystemVelcoityImpl` to fix `CableSpan` behavior during time-stepping integration.  

Previously, `CableSpan` would exhibit the behavior described in #831, where the path would jump around and find invalid configurations during a simulation. After implementing the `Subsystem` realization interface, the behavior improves. Here is the result with `SemiExplicitEuler2Integrator`:

https://github.com/user-attachments/assets/7904fdce-98eb-4187-a783-865c0715f76c

Note that if simulating this double pendulum example with higher-order integrators that take larger steps sizes (e.g., `RungeKuttaMersonIntegrator`), an upper bound on the maximum step size will need to be set, otherwise the path may "step through" the wrap cylinder during the simulation. This seems to be the same behavior as the "path escaping the torus" example described in [the original `CableSpan` PR](https://github.com/simbody/simbody/pull/791).

### `CurveSegment` cache access

To implement the `Subsystem` realization interface, I needed to replace usages of `CurveSegment::getDataPos` with `CurveSegment::updDataPos` in any place that they appeared within a call stack originating from `CableSpan::Impl::calcDataPos`. This is because the `State` provided to `realizesSubsystemPositionImpl` will only be realized to `Stage::Time`, and so the position-level cache entries of `CurveSegment` are only accessible via `updCacheEntry` and not `getCacheEntry`.

However, I'm not sure this is the ideal solution. It's a bit of an odd situation, since `CurveSegment` will calculate position-level information internally that is then used by `CableSpan::Impl` to perform its own position-level calculations. It makes sense that the `CurveSegment` information should be fixed within `CableSpan::Impl` calculations, but both will share a `State` at the same `Stage`, which leads to the issue I encountered. I suppose an alternative would be lower the "earliest" `Stage` set by `allocateCacheEntry` for `CurveSegmentData::Position` to `Stage::Time`. I'm not sure which is preferred here.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/832)
<!-- Reviewable:end -->
