### PR TITLE
Add missing Doxygen section closing brace in `CableSpan`

### DIFF
--- a/Simbody/include/simbody/internal/CableSpan.h
+++ b/Simbody/include/simbody/internal/CableSpan.h
@@ -601,6 +601,7 @@ public:
         CableSpanObstacleIndex ix,
         SpatialVec& unitForce_G) const;
 
+    ///@}
 
     /** @name Via point computations */
     ///@{


### PR DESCRIPTION
This change adds a missing brace to close the Doxygen section "Curve segment computations" in `CableSpan` that was lost amidst the recent changes adding via point support.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/837)
<!-- Reviewable:end -->
