### PR TITLE
Fix Race Condition in simbody-visualizer

### DIFF
--- a/Simbody/Visualizer/simbody-visualizer/simbody-visualizer.cpp
+++ b/Simbody/Visualizer/simbody-visualizer/simbody-visualizer.cpp
@@ -1570,7 +1570,8 @@ static void redrawDisplay() {
     renderScene(&screenText);
 
     {
-        std::unique_lock<std::mutex> lock(sceneMutex); //------- LOCK SCENE -------
+        //------- LOCK SCENE --------
+        std::unique_lock<std::mutex> lock(sceneMutex);
         // Draw menus.
         // ------------------------------------------------------------
         glDisable(GL_BLEND);
@@ -1595,7 +1596,7 @@ static void redrawDisplay() {
         int slidery = viewHeight-35;
         for (int i = 0; i < (int) sliders.size(); i++)
             slidery = sliders[i].draw(slidery);
-    } /// ------------- UNLOCK SCENE ------------------
+    } // ------------- UNLOCK SCENE ------------------
 
     // Draw the "heads-up" display.
     // ------------------------------------------------------------

--- a/Simbody/Visualizer/simbody-visualizer/simbody-visualizer.cpp
+++ b/Simbody/Visualizer/simbody-visualizer/simbody-visualizer.cpp
@@ -1569,29 +1569,33 @@ static void redrawDisplay() {
     std::vector<string> screenText;
     renderScene(&screenText);
 
-    // Draw menus.
-    // ------------------------------------------------------------
-    glDisable(GL_BLEND);
-    glDepthMask(GL_TRUE);
-    glMatrixMode(GL_PROJECTION);
-    glPushMatrix();
-    glLoadIdentity();
-    gluOrtho2D(0, viewWidth, 0, viewHeight);
-    glScalef(1, -1, 1);
-    glTranslatef(0, GLfloat(-viewHeight), 0);
-    glMatrixMode(GL_MODELVIEW);
-    glLoadIdentity();
-    glDisable(GL_LIGHTING);
-    glDisable(GL_DEPTH_TEST);
-    int menux = 10;
-    for (int i = 0; i < (int) menus.size(); i++)
-        menux += menus[i].draw(menux, viewHeight-10);
+    {
+        std::unique_lock<std::mutex> lock(sceneMutex); //------- LOCK SCENE -------
+        // Draw menus.
+        // ------------------------------------------------------------
+        glDisable(GL_BLEND);
+        glDepthMask(GL_TRUE);
+        glMatrixMode(GL_PROJECTION);
+        glPushMatrix();
+        glLoadIdentity();
+        gluOrtho2D(0, viewWidth, 0, viewHeight);
+        glScalef(1, -1, 1);
+        glTranslatef(0, GLfloat(-viewHeight), 0);
+        glMatrixMode(GL_MODELVIEW);
+        glLoadIdentity();
+        glDisable(GL_LIGHTING);
+        glDisable(GL_DEPTH_TEST);
+        int menux = 10;
+        for (int i = 0; i < (int) menus.size(); i++) {
+            menux += menus[i].draw(menux, viewHeight-10);
+        }
 
-    // Draw sliders.
-    // ------------------------------------------------------------
-    int slidery = viewHeight-35;
-    for (int i = 0; i < (int) sliders.size(); i++)
-        slidery = sliders[i].draw(slidery);
+        // Draw sliders.
+        // ------------------------------------------------------------
+        int slidery = viewHeight-35;
+        for (int i = 0; i < (int) sliders.size(); i++)
+            slidery = sliders[i].draw(slidery);
+    } /// ------------- UNLOCK SCENE ------------------
 
     // Draw the "heads-up" display.
     // ------------------------------------------------------------


### PR DESCRIPTION
In rare circumstances (it happened to me on one of two machines), the simbody-visualizer would not run with OpenSim examples (I was testing against the [checkEnvironment](https://github.com/opensim-org/opensim-core/tree/main/OpenSim/Examples/checkEnvironment) example). The sympton was that simbody-visualizer would shortly show up, but crash immediately. 

I figured out this is due to a race condition in `simbody-visualizer.cpp`:

It can happen that during the rendering of the menus or the sliders a new command is for adding another menu is received. In this case, the `menus` vector can become reallocated, making the current object invalid.

This commit puts the scene lock around rendering the menus and sliders, to ensure that a menu is either added or drawn.

The bug also exists in the official apt-packages for libsimbody3.7.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/838)
<!-- Reviewable:end -->
