### PR TITLE
Fix out-of-bounds accesses in Mat constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ PRs and issues that were included in a particular release.
 --------------------
 * Add LLT (Cholesky) factorization
 * Add quaternion multiplication (Hamilton product) 
+* Required C++ level was increased from C++11 to C++17
+* Fixed an out-of-bounds warning/error emitted by overloads of SimTK::Mat accessing
+  out-of-bounds rows
 
 
 3.8 (May 2025)

--- a/SimTKcommon/CMakeLists.txt
+++ b/SimTKcommon/CMakeLists.txt
@@ -145,7 +145,7 @@ target_compile_definitions(SimTKcommon
 # (maintaining intent of previous behavior, but more universally applied and effective)
 # See https://cmake.org/cmake/help/latest/manual/cmake-compile-features.7.html#language-standard-flags
 # for info re: ordering of the compiler flag(s) for language standards and CMAKE_<LANG>_FLAGS
-target_compile_features(SimTKcommon PUBLIC cxx_std_11)
+target_compile_features(SimTKcommon PUBLIC cxx_std_17)
 
 # Warning 4996 is not propagated to downstream targets
 target_compile_options(SimTKcommon INTERFACE

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
@@ -30,6 +30,9 @@
 
 #include "SimTKcommon/internal/common.h"
 
+#include <tuple>
+#include <type_traits>
+
 namespace SimTK {
 
 /** @brief This class represents a small matrix whose size is known at compile 
@@ -376,71 +379,21 @@ public:
     explicit Mat(int i) 
       { new (this) Mat(E(Precision(i))); }
 
-    // A bevy of constructors from individual exact-match elements IN ROW ORDER.
-    Mat(const E& e0,const E& e1)
-      {assert(M*N==2);d[rIx(0)]=e0;d[rIx(1)]=e1;}
-    Mat(const E& e0,const E& e1,const E& e2)
-      {assert(M*N==3);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;}
-    Mat(const E& e0,const E& e1,const E& e2,const E& e3)
-      {assert(M*N==4);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;}
-    Mat(const E& e0,const E& e1,const E& e2,const E& e3,const E& e4)
-      {assert(M*N==5);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;d[rIx(4)]=e4;}
-    Mat(const E& e0,const E& e1,const E& e2,const E& e3,const E& e4,
-        const E& e5)
-      {assert(M*N==6);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;d[rIx(4)]=e4;
-       d[rIx(5)]=e5;}
-    Mat(const E& e0,const E& e1,const E& e2,const E& e3,const E& e4,
-        const E& e5,const E& e6)
-      {assert(M*N==7);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;d[rIx(4)]=e4;
-       d[rIx(5)]=e5;d[rIx(6)]=e6;}
-    Mat(const E& e0,const E& e1,const E& e2,const E& e3,const E& e4,
-        const E& e5,const E& e6,const E& e7)
-      {assert(M*N==8);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;d[rIx(4)]=e4;
-       d[rIx(5)]=e5;d[rIx(6)]=e6;d[rIx(7)]=e7;}
-    Mat(const E& e0,const E& e1,const E& e2,const E& e3,const E& e4,
-        const E& e5,const E& e6,const E& e7,const E& e8)
-      {assert(M*N==9);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;d[rIx(4)]=e4;
-       d[rIx(5)]=e5;d[rIx(6)]=e6;d[rIx(7)]=e7;d[rIx(8)]=e8;}
-    Mat(const E& e0,const E& e1,const E& e2,const E& e3,const E& e4,
-        const E& e5,const E& e6,const E& e7,const E& e8,const E& e9)
-      {assert(M*N==10);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;d[rIx(4)]=e4;
-       d[rIx(5)]=e5;d[rIx(6)]=e6;d[rIx(7)]=e7;d[rIx(8)]=e8;d[rIx(9)]=e9;}
-    Mat(const E& e0,const E& e1,const E& e2,const E& e3,const E& e4,
-        const E& e5,const E& e6,const E& e7,const E& e8,const E& e9,
-        const E& e10)
-      {assert(M*N==11);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;d[rIx(4)]=e4;
-       d[rIx(5)]=e5;d[rIx(6)]=e6;d[rIx(7)]=e7;d[rIx(8)]=e8;d[rIx(9)]=e9;d[rIx(10)]=e10;}
-    Mat(const E& e0,const E& e1,const E& e2,const E& e3,const E& e4,
-        const E& e5,const E& e6,const E& e7,const E& e8,const E& e9,
-        const E& e10, const E& e11)
-      {assert(M*N==12);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;d[rIx(4)]=e4;
-       d[rIx(5)]=e5;d[rIx(6)]=e6;d[rIx(7)]=e7;d[rIx(8)]=e8;d[rIx(9)]=e9;d[rIx(10)]=e10;
-       d[rIx(11)]=e11;}
-    Mat(const E& e0,const E& e1,const E& e2,const E& e3,const E& e4,
-        const E& e5,const E& e6,const E& e7,const E& e8,const E& e9,
-        const E& e10, const E& e11, const E& e12)
-      {assert(M*N==13);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;d[rIx(4)]=e4;
-       d[rIx(5)]=e5;d[rIx(6)]=e6;d[rIx(7)]=e7;d[rIx(8)]=e8;d[rIx(9)]=e9;d[rIx(10)]=e10;
-       d[rIx(11)]=e11;d[rIx(12)]=e12;}
-    Mat(const E& e0,const E& e1,const E& e2,const E& e3,const E& e4,
-        const E& e5,const E& e6,const E& e7,const E& e8,const E& e9,
-        const E& e10, const E& e11, const E& e12, const E& e13)
-      {assert(M*N==14);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;d[rIx(4)]=e4;
-       d[rIx(5)]=e5;d[rIx(6)]=e6;d[rIx(7)]=e7;d[rIx(8)]=e8;d[rIx(9)]=e9;d[rIx(10)]=e10;
-       d[rIx(11)]=e11;d[rIx(12)]=e12;d[rIx(13)]=e13;}
-    Mat(const E& e0,const E& e1,const E& e2,const E& e3,const E& e4,
-        const E& e5,const E& e6,const E& e7,const E& e8,const E& e9,
-        const E& e10, const E& e11, const E& e12, const E& e13, const E& e14)
-      {assert(M*N==15);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;d[rIx(4)]=e4;
-       d[rIx(5)]=e5;d[rIx(6)]=e6;d[rIx(7)]=e7;d[rIx(8)]=e8;d[rIx(9)]=e9;d[rIx(10)]=e10;
-       d[rIx(11)]=e11;d[rIx(12)]=e12;d[rIx(13)]=e13;d[rIx(14)]=e14;}
-    Mat(const E& e0,const E& e1,const E& e2,const E& e3,const E& e4,
-        const E& e5,const E& e6,const E& e7,const E& e8,const E& e9,
-        const E& e10, const E& e11, const E& e12, const E& e13, const E& e14, 
-        const E& e15)
-      {assert(M*N==16);d[rIx(0)]=e0;d[rIx(1)]=e1;d[rIx(2)]=e2;d[rIx(3)]=e3;d[rIx(4)]=e4;
-       d[rIx(5)]=e5;d[rIx(6)]=e6;d[rIx(7)]=e7;d[rIx(8)]=e8;d[rIx(9)]=e9;d[rIx(10)]=e10;
-       d[rIx(11)]=e11;d[rIx(12)]=e12;d[rIx(13)]=e13;d[rIx(14)]=e14;d[rIx(15)]=e15;}
+    // Constructs a `Mat` from individual exact-match elements IN ROW ORDER.
+    template<
+        typename... Elements,
+        typename = std::enable_if_t<
+            (M*N==sizeof...(Elements)) &&
+            (std::is_convertible_v<Elements&&, const E&> && ...)
+        >
+    >
+    Mat(Elements&&... elementsRowByRow)
+    {
+        assignDataRowByRow(
+            std::forward_as_tuple(elementsRowByRow...),
+            std::make_integer_sequence<int, sizeof...(Elements)>{}
+        );
+    }
 
     // Construction from 1-6 *exact match* Rows
     explicit Mat(const TRow& r0)
@@ -1237,6 +1190,12 @@ private:
         const int row = k / N;
         const int col = k % N; // that's modulus, not cross product!
         return row*RS + col*CS;
+    }
+
+    template<typename ElementsRowByRowTuple, int... Idx>
+    void assignDataRowByRow(ElementsRowByRowTuple&& els, std::integer_sequence<int, Idx...>)
+    {
+        ((d[rIx(Idx)] = std::get<Idx>(els)) , ...);
     }
 };
 

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Row.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Row.h
@@ -160,7 +160,7 @@ public:
         NRows               = 1,
         NCols               = N,
         NPackedElements     = N,
-        NActualElements     = N * STRIDE,   // includes trailing gap
+        NActualElements     = (N-1)*STRIDE + 1,  // no trailing gap
         NActualScalars      = CNT<E>::NActualScalars * NActualElements,
         RowSpacing          = NActualElements,
         ColSpacing          = STRIDE,

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
@@ -239,7 +239,7 @@ public:
         NRows               = M,
         NCols               = 1,
         NPackedElements     = M,
-        NActualElements     = M * STRIDE,   // includes trailing gap
+        NActualElements     = (M-1)*STRIDE + 1,  // no trailing gap
         NActualScalars      = CNT<E>::NActualScalars * NActualElements,
         RowSpacing          = STRIDE,
         ColSpacing          = NActualElements,


### PR DESCRIPTION
Fixes a potential out-of-bounds error that more modern compilers (e.g. gcc13) have started to warn about.

---

One warning is related to `NActualElements`. The original implementation puts a trailing gap on each `Row` element, for ease-of-access, but this means that `Row`s that are `reinterpret_cast`ed from arrays of `Element`s (e.g. in `Mat`) create an object with a representation that is out-of-bounds of the array, triggering a compiler warning.

The solution is to calculate the actual number of elements in the representation without any trailing elements.

---

Another warning is that the `Mat` elements-row-by-row overloads are out-of-bounds if the number of elements in the constructor exceeds the number of elements in the matrix. (e.g. if you write something like `Mat22{a,b,c,d,e,f}`). The original implementation works around this problem with a runtime `assert` but modern compilers still spot it as a potential issue - even if the overload is never used.

The solution is to use `enable_if` to only enable overloads that are valid for the given matrix. This informs the compiler that the overload is only valid if that precondition is met.

It would be very very ugly to write `std::enable_if` logic for the 15 or so overloads of this function. Fortunately, varadaic template packs make it possible to write a generic overload for N arguments, with a `std::enable_if` check, and with perfect forwarding of the arguments to their final location in `Mat`'s representation.

Unfortunately, writing that kind of generic code without it being a giant PITA requires C++17. So the required C++ level was also changed to C++17. C++17 has excellent coverage on all operating systems released since around 6 years ago, if that's acceptable for compatibility?

For context, opensim-core already compiles with C++17. OpenSim Creator compiles with C++20 (good compatibility on Ubuntu20+, MacOS from 3-4 years ago, Windows). A C++20 version of the overload would be even cleaner, because `std::enable_if_t` can be ported to a `requires` clause and `typename... Elements` can be ported to `std::convertible_to<E>... Elements` 😄

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/840)
<!-- Reviewable:end -->
