### PR TITLE
Fix SimTK::Factor implementations memory leak on copy assign

### DIFF
--- a/SimTKmath/LinearAlgebra/src/Eigen.cpp
+++ b/SimTKmath/LinearAlgebra/src/Eigen.cpp
@@ -60,31 +60,30 @@ EigenRepBase* EigenDefault::clone() const {
    ///////////
    // Eigen //
    ///////////
-Eigen::~Eigen() {
-    delete rep;
-}
-Eigen::Eigen() {
-   rep = new EigenDefault();
-}
+Eigen::~Eigen() = default;
+
+Eigen::Eigen() : rep{new EigenDefault()} {}
 
 template < class ELT >
-Eigen::Eigen( const Matrix_<ELT>& m ) {
-    rep = new EigenRep<typename CNT<ELT>::StdNumber>(m); 
-}
+Eigen::Eigen(const Matrix_<ELT>& m) :
+    rep{new EigenRep<typename CNT<ELT>::StdNumber>(m)}
+{}
+
 // copy constructor
-Eigen::Eigen( const Eigen& c ) {
-    rep = c.rep->clone();
-}
+Eigen::Eigen(const Eigen&) = default;
+
+// move constructor
+Eigen::Eigen( Eigen&& c ) noexcept = default;
+
 // copy assignment operator
-Eigen& Eigen::operator=(const Eigen& rhs) {
-    rep = rhs.rep->clone();
-    return *this;
-}
+Eigen& Eigen::operator=(const Eigen& rhs) = default;
+
+// move assignment operator
+Eigen& Eigen::operator=(Eigen&& rhs) noexcept = default;
 
 template < class ELT >
 void Eigen::factor( const Matrix_<ELT>& m ) {
-    delete rep;
-    rep = new EigenRep<typename CNT<ELT>::StdNumber>(m); 
+    rep.reset(new EigenRep<typename CNT<ELT>::StdNumber>(m));
 }
 
 template <class VAL, class VEC> 
@@ -156,7 +155,7 @@ EigenRep<T>::EigenRep( const Matrix_<ELT>& mat):
 }
 template <typename T >
 EigenRepBase* EigenRep<T>::clone() const {
-   return( new EigenRep<T>(*this) );
+   return new EigenRep<T>(*this);
 }
 
 

--- a/SimTKmath/LinearAlgebra/src/Factor.cpp
+++ b/SimTKmath/LinearAlgebra/src/Factor.cpp
@@ -59,23 +59,21 @@ FactorLURepBase* FactorLUDefault::clone() const {
    ///////////////
    // FactorLU //
    ///////////////
-FactorLU::~FactorLU() {
-    delete rep;
-}
+FactorLU::~FactorLU() = default;
 // default constructor
-FactorLU::FactorLU() {
-    rep = new FactorLUDefault();
-}
+FactorLU::FactorLU() : rep(new FactorLUDefault()) {}
 
 // copy constructor
-FactorLU::FactorLU( const FactorLU& c ) {
-    rep = c.rep->clone();
-}
+FactorLU::FactorLU( const FactorLU& c ) = default;
+
+// move constructor
+FactorLU::FactorLU( FactorLU&& ) noexcept = default;
+
 // copy assignment operator
-FactorLU& FactorLU::operator=(const FactorLU& rhs) {
-    rep = rhs.rep->clone();
-    return *this;
-}
+FactorLU& FactorLU::operator=(const FactorLU& rhs) = default;
+
+// move assignment operator
+FactorLU& FactorLU::operator=(FactorLU&& rhs) noexcept = default;
 
 template <typename ELT>
 void FactorLU::inverse( Matrix_<ELT>& inverse ) const {
@@ -84,14 +82,13 @@ void FactorLU::inverse( Matrix_<ELT>& inverse ) const {
 
 
 template < class ELT >
-FactorLU::FactorLU( const Matrix_<ELT>& m ) {
-    rep = new FactorLURep<typename CNT<ELT>::StdNumber>(m);
-}
+FactorLU::FactorLU( const Matrix_<ELT>& m ) :
+    rep{new FactorLURep<typename CNT<ELT>::StdNumber>(m)}
+{}
 
 template < class ELT >
 void FactorLU::factor( const Matrix_<ELT>& m ) {
-    delete rep;
-    rep = new FactorLURep<typename CNT<ELT>::StdNumber>(m);
+    rep.reset(new FactorLURep<typename CNT<ELT>::StdNumber>(m));
 }
 
 template < typename ELT >

--- a/SimTKmath/LinearAlgebra/src/FactorLLT.cpp
+++ b/SimTKmath/LinearAlgebra/src/FactorLLT.cpp
@@ -46,23 +46,22 @@ FactorLLTRepBase* FactorLLTDefault::clone() const {
 }
 
 // FactorLLT
-FactorLLT::~FactorLLT() {
-    delete rep;
-}
+FactorLLT::~FactorLLT() = default;
+
 // default constructor
-FactorLLT::FactorLLT() {
-    rep = new FactorLLTDefault();
-}
+FactorLLT::FactorLLT() : rep{new FactorLLTDefault()} {}
 
 // copy constructor
-FactorLLT::FactorLLT(const FactorLLT& c) {
-    rep = c.rep->clone();
-}
+FactorLLT::FactorLLT(const FactorLLT& c) = default;
+
+// move constructor
+FactorLLT::FactorLLT(FactorLLT&& c) noexcept = default;
+
 // copy assignment operator
-FactorLLT& FactorLLT::operator=(const FactorLLT& rhs) {
-    rep = rhs.rep->clone();
-    return *this;
-}
+FactorLLT& FactorLLT::operator=(const FactorLLT& rhs) = default;
+
+// move assignment operator
+FactorLLT& FactorLLT::operator=(FactorLLT&& rhs) noexcept = default;
 
 template <typename ELT>
 void FactorLLT::inverse(Matrix_<ELT>& inverse) const {
@@ -70,14 +69,13 @@ void FactorLLT::inverse(Matrix_<ELT>& inverse) const {
 }
 
 template <class ELT>
-FactorLLT::FactorLLT(const Matrix_<ELT>& m) {
-    rep = new FactorLLTRep<typename CNT<ELT>::StdNumber>(m);
-}
+FactorLLT::FactorLLT(const Matrix_<ELT>& m) :
+    rep{new FactorLLTRep<typename CNT<ELT>::StdNumber>(m)}
+{}
 
 template <class ELT>
 void FactorLLT::factor(const Matrix_<ELT>& m) {
-    delete rep;
-    rep = new FactorLLTRep<typename CNT<ELT>::StdNumber>(m);
+    rep.reset(new FactorLLTRep<typename CNT<ELT>::StdNumber>(m));
 }
 
 template <typename ELT>

--- a/SimTKmath/LinearAlgebra/src/FactorQTZ.cpp
+++ b/SimTKmath/LinearAlgebra/src/FactorQTZ.cpp
@@ -58,60 +58,58 @@ FactorQTZRepBase* FactorQTZDefault::clone() const {
    ///////////////
    // FactorQTZ //
    ///////////////
-FactorQTZ::~FactorQTZ() {
-    delete rep;
-}
+FactorQTZ::~FactorQTZ() = default;
+
 // default constructor
-FactorQTZ::FactorQTZ() {
-    rep = new FactorQTZDefault();
-}
+FactorQTZ::FactorQTZ() :
+    rep{new FactorQTZDefault()}
+{}
+
 // copy constructor
-FactorQTZ::FactorQTZ( const FactorQTZ& c ) {
-    rep = c.rep->clone();
-}
+FactorQTZ::FactorQTZ( const FactorQTZ& c ) = default;
+
+// move constructor
+FactorQTZ::FactorQTZ( FactorQTZ&& c ) noexcept = default;
+
 // copy assignment operator
-FactorQTZ& FactorQTZ::operator=(const FactorQTZ& rhs) {
-    rep = rhs.rep->clone();
-    return *this;
-}
+FactorQTZ& FactorQTZ::operator=(const FactorQTZ& rhs) = default;
+
+// move assignment operator
+FactorQTZ& FactorQTZ::operator=(FactorQTZ&& rhs) noexcept = default;
 
 template <typename ELT>
 void FactorQTZ::inverse( Matrix_<ELT>& inverse ) const {
     rep->inverse( inverse );
 }
 template < class ELT >
-void FactorQTZ::factor( const Matrix_<ELT>& m ){
-    delete rep;
-  
+void FactorQTZ::factor( const Matrix_<ELT>& m ){  
     // if user does not supply rcond set it to max(nRow,nCol)*(eps)^7/8 (similar to matlab)
     int mnmax = (m.nrow() > m.ncol()) ? m.nrow() : m.ncol();
-    rep = new FactorQTZRep<typename CNT<ELT>::StdNumber>(m, mnmax*NTraits<typename CNT<ELT>::Precision>::getSignificant());
+    rep.reset(new FactorQTZRep<typename CNT<ELT>::StdNumber>(m, mnmax*NTraits<typename CNT<ELT>::Precision>::getSignificant()));
 }
 template < class ELT >
 void FactorQTZ::factor( const Matrix_<ELT>& m, double rcond ){
-    delete rep;
-    rep = new FactorQTZRep<typename CNT<ELT>::StdNumber>(m, rcond );
+    rep.reset(new FactorQTZRep<typename CNT<ELT>::StdNumber>(m, rcond ));
 }
 template < class ELT >
 void FactorQTZ::factor( const Matrix_<ELT>& m, float rcond ){
-    delete rep;
-    rep = new FactorQTZRep<typename CNT<ELT>::StdNumber>(m, rcond );
+    rep.reset(new FactorQTZRep<typename CNT<ELT>::StdNumber>(m, rcond ));
 }
 template < class ELT >
 FactorQTZ::FactorQTZ( const Matrix_<ELT>& m ) {
 
     // if user does not supply rcond set it to max(nRow,nCol)*(eps)^7/8 (similar to matlab)
     int mnmax = (m.nrow() > m.ncol()) ? m.nrow() : m.ncol();
-    rep = new FactorQTZRep<typename CNT<ELT>::StdNumber>(m, mnmax*NTraits<typename CNT<ELT>::Precision>::getSignificant()); 
+    rep.reset(new FactorQTZRep<typename CNT<ELT>::StdNumber>(m, mnmax*NTraits<typename CNT<ELT>::Precision>::getSignificant()));
 }
 template < class ELT >
-FactorQTZ::FactorQTZ( const Matrix_<ELT>& m, double rcond ) {
-    rep = new FactorQTZRep<typename CNT<ELT>::StdNumber>(m, rcond); 
-}
+FactorQTZ::FactorQTZ( const Matrix_<ELT>& m, double rcond ) :
+    rep{new FactorQTZRep<typename CNT<ELT>::StdNumber>(m, rcond)}
+{}
 template < class ELT >
-FactorQTZ::FactorQTZ( const Matrix_<ELT>& m, float rcond ) {
-    rep = new FactorQTZRep<typename CNT<ELT>::StdNumber>(m, rcond); 
-}
+FactorQTZ::FactorQTZ( const Matrix_<ELT>& m, float rcond ) :
+    rep{new FactorQTZRep<typename CNT<ELT>::StdNumber>(m, rcond)}
+{}
 
 int FactorQTZ::getRank() const {
     return(rep->rank);

--- a/SimTKmath/LinearAlgebra/src/FactorSVD.cpp
+++ b/SimTKmath/LinearAlgebra/src/FactorSVD.cpp
@@ -60,21 +60,22 @@ FactorSVDRepBase* FactorSVDDefault::clone() const {
    ///////////
    // FactorSVD //
    ///////////
-FactorSVD::~FactorSVD() {
-    delete rep;
-}
-FactorSVD::FactorSVD() {
-   rep = new FactorSVDDefault();
-}
+FactorSVD::~FactorSVD() = default;
+
+FactorSVD::FactorSVD() : rep{new FactorSVDDefault()} {}
+
 // copy constructor
-FactorSVD::FactorSVD( const FactorSVD& c ) {
-    rep = c.rep->clone();
-}
+FactorSVD::FactorSVD(const FactorSVD&) = default;
+
+// move constructor
+FactorSVD::FactorSVD( FactorSVD&& ) noexcept = default;
+
 // copy assignment operator
-FactorSVD& FactorSVD::operator=(const FactorSVD& rhs) {
-    rep = rhs.rep->clone();
-    return *this;
-}
+FactorSVD& FactorSVD::operator=(const FactorSVD&) = default;
+
+// move assignment operator
+FactorSVD& FactorSVD::operator=(FactorSVD&&) noexcept = default;
+
 int FactorSVD::getRank() {
      return(rep->getRank() );
 }
@@ -95,38 +96,34 @@ void FactorSVD::inverse( Matrix_<ELT>& inverse ) {
 }
 template < class ELT >
 FactorSVD::FactorSVD( const Matrix_<ELT>& m ) {
-
     // if user does not supply rcond set it to max(nRow,nCol)*(eps)^7/8 (similar to matlab)
     int mnmax = (m.nrow() > m.ncol()) ? m.nrow() : m.ncol();
-    rep = new FactorSVDRep<typename CNT<ELT>::StdNumber>(m, mnmax*NTraits<typename CNT<ELT>::Precision>::getSignificant()); 
+    rep.reset(new FactorSVDRep<typename CNT<ELT>::StdNumber>(m, mnmax*NTraits<typename CNT<ELT>::Precision>::getSignificant()));
 }
 template < class ELT >
-FactorSVD::FactorSVD( const Matrix_<ELT>& m, double rcond ) {
-    rep = new FactorSVDRep<typename CNT<ELT>::StdNumber>(m, rcond);
-}
+FactorSVD::FactorSVD( const Matrix_<ELT>& m, double rcond ) :
+    rep{new FactorSVDRep<typename CNT<ELT>::StdNumber>(m, rcond)}
+{}
 template < class ELT >
-FactorSVD::FactorSVD( const Matrix_<ELT>& m, float rcond ) {
-    rep = new FactorSVDRep<typename CNT<ELT>::StdNumber>(m, rcond);
-}
+FactorSVD::FactorSVD( const Matrix_<ELT>& m, float rcond ) :
+    rep{new FactorSVDRep<typename CNT<ELT>::StdNumber>(m, rcond)}
+{}
 
 template < class ELT >
 void FactorSVD::factor( const Matrix_<ELT>& m ) {
-    delete rep;
 
     // if user does not supply rcond set it to max(nRow,nCol)*(eps)^7/8 (similar to matlab)
     int mnmax = (m.nrow() > m.ncol()) ? m.nrow() : m.ncol();
-    rep = new FactorSVDRep<typename CNT<ELT>::StdNumber>(m, mnmax*NTraits<typename CNT<ELT>::Precision>::getSignificant()); 
+    rep.reset(new FactorSVDRep<typename CNT<ELT>::StdNumber>(m, mnmax*NTraits<typename CNT<ELT>::Precision>::getSignificant()));
 }
 
 template < class ELT >
 void FactorSVD::factor( const Matrix_<ELT>& m, double rcond ){
-    delete rep;
-    rep = new FactorSVDRep<typename CNT<ELT>::StdNumber>(m, rcond );
+    rep.reset(new FactorSVDRep<typename CNT<ELT>::StdNumber>(m, rcond ));
 }
 template < class ELT >
 void FactorSVD::factor( const Matrix_<ELT>& m, float rcond ){
-    delete rep;
-    rep = new FactorSVDRep<typename CNT<ELT>::StdNumber>(m, rcond );
+    rep.reset(new FactorSVDRep<typename CNT<ELT>::StdNumber>(m, rcond ));
 }
 
 template <class T> 

--- a/SimTKmath/include/simmath/LinearAlgebra.h
+++ b/SimTKmath/include/simmath/LinearAlgebra.h
@@ -60,7 +60,6 @@ public:
 }; // class Factor
 
 class FactorLURepBase;
-
 /**
  * Class for performing LU matrix factorizations 
  */
@@ -71,7 +70,9 @@ class SimTK_SIMMATH_EXPORT FactorLU: public Factor {
 
     FactorLU();
     FactorLU( const FactorLU& c );
+    FactorLU( FactorLU&& ) noexcept;
     FactorLU& operator=(const FactorLU& rhs);
+    FactorLU& operator=(FactorLU&& rhs) noexcept;
 
     template <class ELT> FactorLU( const Matrix_<ELT>& m );
     /// factors a matrix
@@ -95,10 +96,11 @@ class SimTK_SIMMATH_EXPORT FactorLU: public Factor {
 
 
     protected:
-    class FactorLURepBase *rep;
+    ClonePtr<FactorLURepBase> rep;
 
 }; // class FactorLU
 
+class FactorLLTRepBase;
 /**
  * Class for performing LLT (Cholesky) matrix factorizations
  */
@@ -108,7 +110,9 @@ class SimTK_SIMMATH_EXPORT FactorLLT : public Factor {
 
     FactorLLT();
     FactorLLT(const FactorLLT& c);
+    FactorLLT(FactorLLT&& c) noexcept;
     FactorLLT& operator=(const FactorLLT& rhs);
+    FactorLLT& operator=(FactorLLT&& rhs) noexcept;
 
     template <class ELT>
     FactorLLT(const Matrix_<ELT>& m);
@@ -130,8 +134,8 @@ class SimTK_SIMMATH_EXPORT FactorLLT : public Factor {
     template <class ELT>
     void getL(Matrix_<ELT>& l) const;
 
-   protected:
-    class FactorLLTRepBase* rep;
+    protected:
+    ClonePtr<FactorLLTRepBase> rep;
 
 };  // class FactorLLT
 
@@ -146,7 +150,10 @@ class SimTK_SIMMATH_EXPORT FactorQTZ: public Factor {
 
     FactorQTZ();
     FactorQTZ( const FactorQTZ& c );
+    FactorQTZ( FactorQTZ&& c ) noexcept;
     FactorQTZ& operator=(const FactorQTZ& rhs);
+    FactorQTZ& operator=(FactorQTZ&& rhs) noexcept;
+
     /// do QTZ factorization of a matrix
     template <typename ELT> FactorQTZ( const Matrix_<ELT>& m);
     /// do QTZ factorization of a matrix for a given reciprocal condition number
@@ -173,8 +180,10 @@ class SimTK_SIMMATH_EXPORT FactorQTZ: public Factor {
 //    void setRank(int rank); TBD
 
     protected:
-    class FactorQTZRepBase *rep;
+    ClonePtr<FactorQTZRepBase> rep;
 }; // class FactorQTZ
+
+class EigenRepBase;
 /**
  * Class to compute Eigen values and Eigen vectors of a matrix
  */
@@ -185,7 +194,9 @@ class SimTK_SIMMATH_EXPORT Eigen {
 
     Eigen();
     Eigen( const Eigen& c );
+    Eigen( Eigen&& c ) noexcept;
     Eigen& operator=(const Eigen& rhs);
+    Eigen& operator=(Eigen&& rhs) noexcept;
 
     /// create a default eigen class
     template <class ELT> Eigen( const Matrix_<ELT>& m );
@@ -212,9 +223,11 @@ class SimTK_SIMMATH_EXPORT Eigen {
 
      
     protected:
-    class EigenRepBase *rep;
+    ClonePtr<EigenRepBase> rep;
 
 }; // class Eigen
+
+class FactorSVDRepBase;
 /**
  * Class to compute a singular value decomposition of a matrix
  */
@@ -226,8 +239,12 @@ class SimTK_SIMMATH_EXPORT FactorSVD: public Factor {
     FactorSVD();
     /// copy  constructor  
     FactorSVD( const FactorSVD& c );
+    /// move constructor
+    FactorSVD( FactorSVD&& ) noexcept;
     /// copy  assign  
     FactorSVD& operator=(const FactorSVD& rhs);
+    /// move assign
+    FactorSVD& operator=(FactorSVD&&) noexcept;
 
     /// constructor 
     template < class ELT > FactorSVD( const Matrix_<ELT>& m );
@@ -263,7 +280,7 @@ class SimTK_SIMMATH_EXPORT FactorSVD: public Factor {
     template <class ELT> void solve( const Matrix_<ELT>& b, Matrix_<ELT>& x );
 
     protected:
-    class FactorSVDRepBase *rep;
+    ClonePtr<FactorSVDRepBase> rep;
 
 }; // class FactorSVD
 


### PR DESCRIPTION
Fixes a memory leak found downstream during libASAN screening in [OpenSim Creator](https://www.opensimcreator.com/). The source of the leak was via an `OpenSim::Model`, which allocates a `CableSubsystem`, which allocates an internal datastructure that includes `FactorQTZ` and friends.

At some point, a copy assignment happens somewhere with a struct containing a `FactorQTZ`, but the current implementation does not handle copy assignment correctly - it overwrites with a `clone` but doesn't account for deleting the left-hand side of the expression.

I decided the best solution is to just convert all `Factor`s to use a `ClonePtr`, which is effectively what all of the code is doing: this reduces the boilerplate and brings move construction/assignment along for the ride.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/841)
<!-- Reviewable:end -->
