### PR TITLE
Move `DecorativeTorus` implementation to `VisualizerGeometry::implementTorusGeometry`

### DIFF
--- a/SimTKmath/Geometry/src/ContactGeometry_Torus.cpp
+++ b/SimTKmath/Geometry/src/ContactGeometry_Torus.cpp
@@ -80,9 +80,7 @@ ContactGeometry::Torus::Impl& ContactGeometry::Torus::updImpl() {
 }
 
 DecorativeGeometry ContactGeometry::Torus::Impl::createDecorativeGeometry() const {
-    PolygonalMesh mesh;
-    createPolygonalMesh(mesh);
-    return DecorativeMesh(mesh);
+    return DecorativeTorus(torusRadius, tubeRadius);
 }
 
 
@@ -125,47 +123,6 @@ void ContactGeometry::Torus::Impl::getBoundingSphere
     (Vec3& center, Real& radius) const {
     center = Vec3(0);
     radius = tubeRadius + torusRadius;
-}
-
-// Create a polygonal mesh for this torus using parameterization as follows:
-// u = [0, 2*Pi] traces a circle in the x-y plane with radius torusRadius,
-// which is the centroid of the torus. A point P on this circle is
-// given by P = torusRadius*~[cos(u) sin(u) 0].
-// v = [0, 2*Pi] traces a circle arond the cross-section (or tube) of the
-// torus with radius tubeRadius, at a given u. A point Q on this circle
-// is given by Q = (torusRadius + tubeRadius*cos(v))*e1 + tubeRadius*(~[0 0 1]*sin(v))
-// where e1 = ~[sin(u) cos(u) 0]. The tube circle is in a plane spanned
-// by e1 and the z-axis.
-void ContactGeometry::Torus::Impl::createPolygonalMesh(PolygonalMesh& mesh) const {
-    // TODO add resolution argument
-    const int numSides = 12; //*resolution;
-    const int numSlices = 36; //*resolution;   
-
-    // add vertices 
-    for (int i = 0; i < numSlices; ++i) {
-      Real u = Real((i*2*SimTK_PI)/numSlices);
-      UnitVec3 e1(std::sin(u), std::cos(u), 0); // torus circle aligned with z-axis (z-axis through hole)
-      for (int j = 0; j < numSides; ++j) {
-        Real v = Real((j*2*SimTK_PI)/numSides);
-        Vec3 vtx = (torusRadius + tubeRadius*std::cos(v))*e1 + tubeRadius*std::sin(v)*Vec3(0,0,1); // use ZAXIS? 
-        mesh.addVertex(vtx);  
-      }
-    }
-
-    // add faces, be careful to wrap indices for the last slice
-    int numVertices = mesh.getNumVertices();
-//    cout << "num verts = " << numVertices << endl;
-    for (int i = 0; i < numVertices; ++i) {
-//      cout << "v" << i << ": " << mesh.getVertexPosition(i) << endl;
-      // define counter-clockwise quad faces
-      Array_<int> faceIndices;
-      faceIndices.push_back(i); // u_i,v_i
-      faceIndices.push_back((i+1)%numVertices); // u_i, v_i+1
-      faceIndices.push_back((i+1+numSides)%numVertices); // u_i+1, v_i+1
-      faceIndices.push_back((i+numSides)%numVertices); // u_i+1, v_i
-      mesh.addFace(faceIndices);    
-    }
-
 }
 
 //TODO

--- a/Simbody/Visualizer/src/VisualizerGeometry.h
+++ b/Simbody/Visualizer/src/VisualizerGeometry.h
@@ -47,12 +47,12 @@ public:
     void implementCircleGeometry(const DecorativeCircle& geom) override;
     void implementSphereGeometry(const DecorativeSphere& geom) override;
     void implementEllipsoidGeometry(const DecorativeEllipsoid& geom) override;
+    void implementTorusGeometry(const DecorativeTorus& geom) override;
     void implementFrameGeometry(const DecorativeFrame& geom) override;
     void implementTextGeometry(const DecorativeText& geom) override;
     void implementMeshGeometry(const DecorativeMesh& geom) override;
     void implementMeshFileGeometry(const DecorativeMeshFile& geom) override; 
     void implementArrowGeometry(const DecorativeArrow& geom) override {}; // Not handled yet by this Visualizer
-    void implementTorusGeometry(const DecorativeTorus& geom) override {}; // Not handled yet by this Visualizer
     void implementConeGeometry(const DecorativeCone& geom) override {}; // Not handled yet by this Visualizer
     static Vec4 getColor(const DecorativeGeometry& geom,
                          const Vec3& defaultColor = Vec3(-1));


### PR DESCRIPTION
This change moves the creation of a `PolygonalMesh` for a torus from `ContactGeometry::Torus::Impl` to  `VisualizerGeometry::implementTorusGeometry`. This allows creating a `DecorativeTorus` that can be visualized without needing to first create a `ContactGeometry::Torus`. This is beneficial for downstream applications where it is beneficial to create `SimTK::DecorativeGeometry` and `SimTK::ContactGeometry` independently (see https://github.com/opensim-org/opensim-core/pull/4182). 

```c++
#include "Simbody.h"
using namespace SimTK;
int main() {
    // Define the system.
    MultibodySystem system;
    SimbodyMatterSubsystem matter(system);
    GeneralForceSubsystem forces(system);
    Force::Gravity gravity(forces, matter, -YAxis, 9.8);

    // Describe mass and visualization properties for a generic body.
    Body::Rigid bodyInfo(MassProperties(1.0, Vec3(0), UnitInertia(1)));
    bodyInfo.addDecoration(Transform(), DecorativeTorus(0.5, 0.1));

    // Create the moving (mobilized) bodies of the pendulum.
    MobilizedBody::Weld weld(matter.Ground(), Transform(Vec3(0)),
            bodyInfo, Transform(Vec3(0, 0, 0)));
}
```

<img width="800" height="600" alt="ContactTorus_1" src="https://github.com/user-attachments/assets/de7553f2-b2dd-42ab-bc3b-7e3004b2a13d" />

A possibly better alternative would be to add a cached mesh to `simbody-visualizer.cpp` and then add a `drawTorus` method to `VisualizerProtocol`. I would be happy to give that a try, but I would need a little help understanding how `VisualizerPrototcol` communicates with the visualizer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/842)
<!-- Reviewable:end -->
