### PR TITLE
Add `CableSpan::Impl::realizePosition()` calls to path unit force calculation methods

### DIFF
--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -4541,6 +4541,7 @@ void CableSpan::calcOriginUnitForce(
     const State& state,
     SpatialVec& unitForce_G) const
 {
+    getImpl().realizePosition(state);
     calcUnitForceAtCableOrigin(getImpl(), state, unitForce_G);
 }
 
@@ -4548,6 +4549,7 @@ void CableSpan::calcTerminationUnitForce(
     const State& state,
     SpatialVec& unitForce_G) const
 {
+    getImpl().realizePosition(state);
     calcUnitForceAtCableTermination(getImpl(), state, unitForce_G);
 }
 
@@ -4793,6 +4795,7 @@ void CableSpan::calcCurveSegmentUnitForce(
     CableSpanObstacleIndex ix,
     SpatialVec& unitForce_G) const
 {
+    getImpl().realizePosition(state);
     const auto& curve = getImpl().getObstacleCurveSegment(ix);
     calcUnitForceExertedByCurve(curve, state, unitForce_G);
 }
@@ -4809,6 +4812,7 @@ void CableSpan::calcViaPointUnitForce(
     CableSpanViaPointIndex ix,
     SpatialVec& unitForce_G) const
 {
+    getImpl().realizePosition(state);
     const auto& viaPoint = getImpl().getViaPoint(ix);
     calcUnitForceExertedByViaPoint(viaPoint, state, unitForce_G);
 }


### PR DESCRIPTION
While debugging an issue related to incorrect forces being computed along muscles paths in OpenSim, I noticed that in `CableSpan`, the recently added methods `calcOriginUnitForce`, `calcTerminationUnitForce`,  `calcCurveSegmentUnitForce` and `calcViaPointUnitForce`, do not ensure that the `CableSpan` position-level cache is validated. This change adds calls to `CableSpan::Impl::realizePosition` to make sure the cache is valid.

While, the true cause to my issue was not related to this change, I think it is generally good to verify that the `CableSpan` cache is valid in these methods.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/846)
<!-- Reviewable:end -->
