### PR TITLE
Fix visualizer drive letter issue on Windows

### DIFF
--- a/SimTKcommon/src/Pathname.cpp
+++ b/SimTKcommon/src/Pathname.cpp
@@ -198,7 +198,8 @@ void Pathname::deconstructPathname( const string&   pathname,
     if (processed.substr(0, 1) == "/") {
         dontApplySearchPath = true;
         processed.erase(0, 1);
-        if (drive.empty()) drive = getCurrentDriveLetter();
+        // if (drive.empty()) drive = getCurrentDriveLetter();
+        if (drive.empty()) drive = getThisExecutableDirectory()[0];
     }
     else if (processed.substr(0, 2) == "./") {
         dontApplySearchPath = true;


### PR DESCRIPTION
Closes #765

Hello all,

The simbody-visualizer didn't work on Windows when the drive letters for [current working directory] and [executable directory] didn't match. Therefore, both executable and working directories must have been in one drive. The issue was in the concatenation during path search: 

```
d:\Programs\Python314\Lib\site-packages\opensim
d:\Programs\Python314\Lib\site-packages\opensim\bin
d:\WINDOWS\system32
d:\WINDOWS
```

This is a temporary fix. Now, both directories could have different drive letters, and it works very well in my local machine:


<img width="942" height="337" alt="image" src="https://github.com/user-attachments/assets/6e9cdd46-f687-4e00-a3b8-2a7dfe4b9a7a" />


This probably doesn't affect Linux and Mac users since there is no drive letter there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/854)
<!-- Reviewable:end -->
