### PR TITLE
Add `CableSpan::calcResampledDecorativePathPoints()`

### DIFF
--- a/Simbody/include/simbody/internal/CableSpan.h
+++ b/Simbody/include/simbody/internal/CableSpan.h
@@ -515,9 +515,10 @@ public:
         const State& state,
         const std::function<void(Vec3 point_G)>& sink) const;
 
-    /** Compute points on the path spanned by this cable suitable for
-    visualization purposes where the points along each obstacle's curve segment
-    are computed at equal length intervals.
+    /** Compute `numCurveSegmentSamples` equally-spaced points for each curve
+    segment along the path spanned by this cable and emit them to `sink`.
+    This can be useful for visualization purposes, where it can be important to
+    limit the amount of visualized path points for performance reasons.
     State must be realized to Stage::Position.
     @param state System State.
     @param numCurveSegmentSamples The number of samples to take per curve

--- a/Simbody/include/simbody/internal/CableSpan.h
+++ b/Simbody/include/simbody/internal/CableSpan.h
@@ -515,6 +515,19 @@ public:
         const State& state,
         const std::function<void(Vec3 point_G)>& sink) const;
 
+    /** Compute points on the path spanned by this cable suitable for
+    visualization purposes where the points along each obstacle's curve segment
+    are computed at equal length intervals.
+    State must be realized to Stage::Position.
+    @param state System State.
+    @param numCurveSegmentSamples The number of samples to take per curve
+                                  segment.
+    @param sink Where the path points (in ground frame) will be written to. **/
+    void calcResampledDecorativePathPoints(
+        const State& state,
+        int numCurveSegmentSamples,
+        const std::function<void(Vec3 point_G)>& sink) const;
+
     ///@}
 
     /** @name Curve segment computations */

--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -2182,6 +2182,38 @@ public:
         int numSamples,
         const std::function<void(Vec3 point_G)>& sink) const;
 
+    void calcResampledDecorativePathPoints(
+        const State& state,
+        int numCurveSegmentSamples,
+        const std::function<void(Vec3 point_G)>& sink) const
+    {
+        // Write the initial path point.
+        const CableSpanData::Position& dataPos = getDataPos(state);
+        sink(dataPos.originPoint_G);
+
+        // Write the path points for each cable segment.
+        for (CableSegmentIndex ix(0); ix < getNumCableSegments(); ++ix) {
+            const CableSegment& cableSegment = getCableSegment(ix);
+
+            // Write the path points for each obstacle in the cable segment.
+            for (ObstacleIndex ix : cableSegment.getObstacleIndexes()) {
+                const CurveSegment& curve = getObstacleCurveSegment(ix);
+                curve.calcResampledPoints(state, numCurveSegmentSamples, sink);
+            }
+
+            // Write the path points for the final via point in the cable
+            // segment.
+            if (cableSegment.getFinalViaPointIndex().isValid()) {
+                const ViaPoint& viaPoint = getViaPoint(
+                    cableSegment.getFinalViaPointIndex());
+                viaPoint.calcDecorativePathPoints(state, sink);
+            }
+        }
+
+        // Write the path's termination point.
+        sink(dataPos.terminationPoint_G);
+    }
+
     void calcDecorativeGeometryAndAppend(
         const State& state,
         Array_<DecorativeGeometry>& decorations) const
@@ -4764,6 +4796,15 @@ void CableSpan::calcDecorativePathPoints(
     const std::function<void(Vec3 point_G)>& sink) const
 {
     getImpl().calcDecorativePathPoints(state, sink);
+}
+
+void CableSpan::calcResampledDecorativePathPoints(
+    const State& state,
+    int numCurveSegmentSamples,
+    const std::function<void(Vec3 point_G)>& sink) const
+{
+    getImpl().calcResampledDecorativePathPoints(state, numCurveSegmentSamples,
+        sink);
 }
 
 Real CableSpan::calcCablePower(const State& state, Real tension) const

--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -1615,17 +1615,6 @@ public:
         return station_G;
     }
 
-    //--------------------------------------------------------------------------
-    // Helper function: via point visualization
-    //--------------------------------------------------------------------------
-
-    void calcDecorativePathPoints(
-        const State& state,
-        const std::function<void(Vec3 point_G)>& sink) const
-    {
-        sink(getStation_G(state));
-    }
-
 private:
     //--------------------------------------------------------------------------
     // Data
@@ -2163,12 +2152,12 @@ public:
                 curve.calcDecorativePathPoints(state, sink);
             }
 
-            // Write the path points for the final via point in the cable
+            // Write the path point for the final via point in the cable
             // segment.
             if (cableSegment.getFinalViaPointIndex().isValid()) {
                 const ViaPoint& viaPoint = getViaPoint(
                     cableSegment.getFinalViaPointIndex());
-                viaPoint.calcDecorativePathPoints(state, sink);
+                sink(viaPoint.getStation_G(state));
             }
         }
 
@@ -2201,12 +2190,12 @@ public:
                 curve.calcResampledPoints(state, numCurveSegmentSamples, sink);
             }
 
-            // Write the path points for the final via point in the cable
+            // Write the path point for the final via point in the cable
             // segment.
             if (cableSegment.getFinalViaPointIndex().isValid()) {
                 const ViaPoint& viaPoint = getViaPoint(
                     cableSegment.getFinalViaPointIndex());
-                viaPoint.calcDecorativePathPoints(state, sink);
+                sink(viaPoint.getStation_G(state));
             }
         }
 
@@ -4803,8 +4792,8 @@ void CableSpan::calcResampledDecorativePathPoints(
     int numCurveSegmentSamples,
     const std::function<void(Vec3 point_G)>& sink) const
 {
-    getImpl().calcResampledDecorativePathPoints(state, numCurveSegmentSamples,
-        sink);
+    getImpl().calcResampledDecorativePathPoints(
+        state, numCurveSegmentSamples, sink);
 }
 
 Real CableSpan::calcCablePower(const State& state, Real tension) const


### PR DESCRIPTION
`CableSpan::calcResampleDecorativePathPoints()` is a method for generating decorative path points across an entire `CableSpan`. Unlike `CableSpan::calcDecorativePathPoints()`, points along a curve segment are resampled to desired equal length intervals in the same way as `CableSpan::calcCurveSegmentResampledPoints()`.

This change will serve to address the following OpenSim issue: https://github.com/opensim-org/opensim-core/issues/4279.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/855)
<!-- Reviewable:end -->
