### PR TITLE
Add `CableSpan` path tangent direction calculation methods

### DIFF
--- a/Simbody/include/simbody/internal/CableSpan.h
+++ b/Simbody/include/simbody/internal/CableSpan.h
@@ -307,6 +307,13 @@ public:
         const State& state,
         SpatialVec& unitForce_G) const;
 
+    /** Calculate the tangent direction of the cable span at the origin. This is
+    the direction along the path away from the origin point, i.e., the direction
+    of cable tension. State must be realized to Stage::Position.
+    @param state State of the system.
+    **/
+    UnitVec3 calcOriginTangentDirection(const State& state) const;
+
     /** Calculate the unit force exerted by the cable at the cable termination
     (in ground frame). The force can be obtained by multiplying the result by
     the cable tension. State must be realized to Stage::Position.
@@ -316,6 +323,13 @@ public:
     void calcTerminationUnitForce(
         const State& state,
         SpatialVec& unitForce_G) const;
+
+    /** Calculate the tangent direction of the cable span at the termination.
+    This is the direction along the path away from the termination point, i.e.,
+    the direction of cable tension. State must be realized to Stage::Position.
+    @param state State of the system.
+    **/
+    UnitVec3 calcTerminationTangentDirection(const State& state) const;
 
     ///@}
 
@@ -639,6 +653,26 @@ public:
         const State& state,
         CableSpanViaPointIndex ix,
         SpatialVec& unitForce_G) const;
+
+    /** Calculate the initial tangent direction of the cable span at the
+    specified via point. This is the direction along the path from the via point
+    towards the origin point, i.e., the direction of cable tension. State must
+    be realized to Stage::Position.
+    @param state State of the system.
+    @param ix The index of the via point in this CableSpan. **/
+    UnitVec3 calcViaPointInitialTangentDirection(
+        const State& state,
+        CableSpanViaPointIndex ix) const;
+
+    /** Calculate the final tangent direction of the cable span at the specified
+    via point. This is the direction along the path from the via point towards
+    the termination point, i.e., the direction of cable tension. State must be
+    realized to Stage::Position.
+    @param state State of the system.
+    @param ix The index of the via point in this CableSpan. **/
+    UnitVec3 calcViaPointFinalTangentDirection(
+        const State& state,
+        CableSpanViaPointIndex ix) const;
 
     ///@}
 

--- a/Simbody/include/simbody/internal/CableSpan.h
+++ b/Simbody/include/simbody/internal/CableSpan.h
@@ -307,9 +307,9 @@ public:
         const State& state,
         SpatialVec& unitForce_G) const;
 
-    /** Calculate the tangent direction of the cable span at the origin. This is
-    the direction along the path away from the origin point, i.e., the direction
-    of cable tension. State must be realized to Stage::Position.
+    /** Calculate the cable span tangent direction at the origin. The direction
+    points along the path from the origin towards the termination.
+    State must be realized to Stage::Position.
     @param state State of the system.
     **/
     UnitVec3 calcOriginTangentDirection(const State& state) const;
@@ -324,9 +324,9 @@ public:
         const State& state,
         SpatialVec& unitForce_G) const;
 
-    /** Calculate the tangent direction of the cable span at the termination.
-    This is the direction along the path away from the termination point, i.e.,
-    the direction of cable tension. State must be realized to Stage::Position.
+    /** Calculate the cable span tangent direction at the termination. The
+    direction points along the path from the origin towards the termination.
+    State must be realized to Stage::Position.
     @param state State of the system.
     **/
     UnitVec3 calcTerminationTangentDirection(const State& state) const;
@@ -654,23 +654,22 @@ public:
         CableSpanViaPointIndex ix,
         SpatialVec& unitForce_G) const;
 
-    /** Calculate the initial tangent direction of the cable span at the
-    specified via point. This is the direction along the path from the via point
-    towards the origin point, i.e., the direction of cable tension. State must
-    be realized to Stage::Position.
+    /** Calculate the incoming tangent direction of the cable span at the
+    specified via point. The direction points along the path from the origin
+    towards the via point. State must be realized to Stage::Position.
     @param state State of the system.
     @param ix The index of the via point in this CableSpan. **/
-    UnitVec3 calcViaPointInitialTangentDirection(
+    UnitVec3 calcViaPointIncomingTangentDirection(
         const State& state,
         CableSpanViaPointIndex ix) const;
 
-    /** Calculate the final tangent direction of the cable span at the specified
-    via point. This is the direction along the path from the via point towards
-    the termination point, i.e., the direction of cable tension. State must be
+    /** Calculate the outgoing tangent direction of the cable span at the
+    specified via point. The direction points along the path from the via point
+    towards the termination point. State must be
     realized to Stage::Position.
     @param state State of the system.
     @param ix The index of the via point in this CableSpan. **/
-    UnitVec3 calcViaPointFinalTangentDirection(
+    UnitVec3 calcViaPointOutgoingTangentDirection(
         const State& state,
         CableSpanViaPointIndex ix) const;
 

--- a/Simbody/include/simbody/internal/CableSpan.h
+++ b/Simbody/include/simbody/internal/CableSpan.h
@@ -297,16 +297,6 @@ public:
     /** @name End point computations */
     ///@{
 
-    /** Calculate the unit force exerted by the cable at the cable origin (in
-    ground frame). The force can be obtained by multiplying the result by the
-    cable tension. State must be realized to Stage::Position.
-    @param state State of the system.
-    @param[out] unitForce_G The resulting unit spatial force in ground frame.
-    **/
-    void calcOriginUnitForce(
-        const State& state,
-        SpatialVec& unitForce_G) const;
-
     /** Calculate the cable span tangent direction at the origin. The direction
     points along the path from the origin towards the termination.
     State must be realized to Stage::Position.
@@ -314,13 +304,16 @@ public:
     **/
     UnitVec3 calcOriginTangentDirection(const State& state) const;
 
-    /** Calculate the unit force exerted by the cable at the cable termination
-    (in ground frame). The force can be obtained by multiplying the result by
-    the cable tension. State must be realized to Stage::Position.
+    /** Calculate the unit force exerted by the cable at the cable origin (in
+    ground frame). The force is applied tangent to the cable span pointing
+    towards the termination, i.e., the same direction as returned by
+    calcOriginTangentDirection(). The effect of a tensile force applied to the
+    cable can be obtained by multiplying the returned unit force by the cable
+    tension. State must be realized to Stage::Position.
     @param state State of the system.
     @param[out] unitForce_G The resulting unit spatial force in ground frame.
     **/
-    void calcTerminationUnitForce(
+    void calcOriginUnitForce(
         const State& state,
         SpatialVec& unitForce_G) const;
 
@@ -330,6 +323,19 @@ public:
     @param state State of the system.
     **/
     UnitVec3 calcTerminationTangentDirection(const State& state) const;
+
+    /** Calculate the unit force exerted by the cable at the cable termination
+    (in ground frame). The force is applied tangent to the cable span pointing
+    towards the origin, i.e., the opposite of the direction returned by
+    calcTerminationTangentDirection(). The effect of a tensile force applied to
+    the cable can be obtained by multiplying the returned unit force by the
+    cable tension. State must be realized to Stage::Position.
+    @param state State of the system.
+    @param[out] unitForce_G The resulting unit spatial force in ground frame.
+    **/
+    void calcTerminationUnitForce(
+        const State& state,
+        SpatialVec& unitForce_G) const;
 
     ///@}
 
@@ -619,8 +625,9 @@ public:
         const std::function<void(Vec3 point_G)>& sink) const;
 
     /** Calculate the unit force exerted by the cable at the specified obstacle
-    (in ground frame). The force can be obtained by multiplying the result by
-    the cable tension. State must be realized to Stage::Position.
+    (in ground frame). The effect of a tensile force applied to the cable can be
+    obtained by multiplying the returned unit force by the cable tension. State
+    must be realized to Stage::Position.
     @param state State of the system.
     @param ix The index of the obstacle in this CableSpan.
     @param[out] unitForce_G The resulting unit spatial force in ground frame. **/
@@ -644,8 +651,9 @@ public:
         CableSpanViaPointIndex ix) const;
 
     /** Calculate the unit force exerted by the cable at the specified via point
-    (in ground frame). The force can be obtained by multiplying the result by
-    the cable tension. State must be realized to Stage::Position.
+    (in ground frame). The effect of a tensile force applied to the cable can be
+    obtained by multiplying the returned unit force by the cable tension. State
+    must be realized to Stage::Position.
     @param state State of the system.
     @param ix The index of the via point in this CableSpan.
     @param[out] unitForce_G The resulting unit spatial force in ground frame. **/

--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -4566,12 +4566,28 @@ void CableSpan::calcOriginUnitForce(
     calcUnitForceAtCableOrigin(getImpl(), state, unitForce_G);
 }
 
+UnitVec3 CableSpan::calcOriginTangentDirection(const State& state) const
+{
+    getImpl().realizePosition(state);
+    const CableSpanData::Position& dataPos = getImpl().getDataPos(state);
+    return dataPos.originTangent_G;
+}
+
 void CableSpan::calcTerminationUnitForce(
     const State& state,
     SpatialVec& unitForce_G) const
 {
     getImpl().realizePosition(state);
     calcUnitForceAtCableTermination(getImpl(), state, unitForce_G);
+}
+
+UnitVec3 CableSpan::calcTerminationTangentDirection(const State& state) const
+{
+    getImpl().realizePosition(state);
+    const CableSpanData::Position& dataPos = getImpl().getDataPos(state);
+    // Negative sign to point in the direction away from the termination point,
+    // i.e., the direction of cable tension force at the termination point.
+    return -dataPos.terminationTangent_G;
 }
 
 ObstacleIndex CableSpan::addObstacle(
@@ -4845,4 +4861,28 @@ void CableSpan::calcViaPointUnitForce(
     getImpl().realizePosition(state);
     const auto& viaPoint = getImpl().getViaPoint(ix);
     calcUnitForceExertedByViaPoint(viaPoint, state, unitForce_G);
+}
+
+UnitVec3 CableSpan::calcViaPointInitialTangentDirection(
+    const State& state,
+    CableSpanViaPointIndex ix) const
+{
+    SimTK_INDEXCHECK_ALWAYS(ix,getNumViaPoints(),
+        "CableSpan::calcViaPointInitialTangentDirection()");
+    getImpl().realizePosition(state);
+    const CableSpanData::Position& dataPos = getImpl().getDataPos(state);
+    // Negative sign to point in the direction away from the via point, i.e.,
+    // the direction of cable tension force at the via point.
+    return -dataPos.viaPointInTangents_G[ix];
+}
+
+UnitVec3 CableSpan::calcViaPointFinalTangentDirection(
+    const State& state,
+    CableSpanViaPointIndex ix) const
+{
+    SimTK_INDEXCHECK_ALWAYS(ix,getNumViaPoints(),
+        "CableSpan::calcViaPointFinalTangentDirection()");
+    getImpl().realizePosition(state);
+    const CableSpanData::Position& dataPos = getImpl().getDataPos(state);
+    return dataPos.viaPointOutTangents_G[ix];
 }

--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -4585,9 +4585,7 @@ UnitVec3 CableSpan::calcTerminationTangentDirection(const State& state) const
 {
     getImpl().realizePosition(state);
     const CableSpanData::Position& dataPos = getImpl().getDataPos(state);
-    // Negative sign to point in the direction away from the termination point,
-    // i.e., the direction of cable tension force at the termination point.
-    return -dataPos.terminationTangent_G;
+    return dataPos.terminationTangent_G;
 }
 
 ObstacleIndex CableSpan::addObstacle(
@@ -4863,25 +4861,23 @@ void CableSpan::calcViaPointUnitForce(
     calcUnitForceExertedByViaPoint(viaPoint, state, unitForce_G);
 }
 
-UnitVec3 CableSpan::calcViaPointInitialTangentDirection(
+UnitVec3 CableSpan::calcViaPointIncomingTangentDirection(
     const State& state,
     CableSpanViaPointIndex ix) const
 {
     SimTK_INDEXCHECK_ALWAYS(ix,getNumViaPoints(),
-        "CableSpan::calcViaPointInitialTangentDirection()");
+        "CableSpan::calcViaPointIncomingTangentDirection()");
     getImpl().realizePosition(state);
     const CableSpanData::Position& dataPos = getImpl().getDataPos(state);
-    // Negative sign to point in the direction away from the via point, i.e.,
-    // the direction of cable tension force at the via point.
-    return -dataPos.viaPointInTangents_G[ix];
+    return dataPos.viaPointInTangents_G[ix];
 }
 
-UnitVec3 CableSpan::calcViaPointFinalTangentDirection(
+UnitVec3 CableSpan::calcViaPointOutgoingTangentDirection(
     const State& state,
     CableSpanViaPointIndex ix) const
 {
     SimTK_INDEXCHECK_ALWAYS(ix,getNumViaPoints(),
-        "CableSpan::calcViaPointFinalTangentDirection()");
+        "CableSpan::calcViaPointOutgoingTangentDirection()");
     getImpl().realizePosition(state);
     const CableSpanData::Position& dataPos = getImpl().getDataPos(state);
     return dataPos.viaPointOutTangents_G[ix];

--- a/Simbody/tests/TestCableSpan.cpp
+++ b/Simbody/tests/TestCableSpan.cpp
@@ -545,6 +545,44 @@ void testViaPoints()
             "Unexpected force applied to body %i",
             i);
     }
+
+    // Check tangent directions.
+    // Origin.
+    UnitVec3 originTangent = cable.calcOriginTangentDirection(s);
+    SimTK_TEST_EQ(originTangent, UnitVec3(0., 1., 0.));
+
+    // First via point.
+    CableSpanViaPointIndex viaPoint1Index(0);
+    UnitVec3 viaPoint1InTangent =
+        cable.calcViaPointIncomingTangentDirection(s, viaPoint1Index);
+    SimTK_TEST_EQ(viaPoint1InTangent, UnitVec3(0., 1., 0.));
+    UnitVec3 viaPoint1OutTangent =
+        cable.calcViaPointOutgoingTangentDirection(s, viaPoint1Index);
+    SimTK_TEST_EQ(viaPoint1OutTangent, UnitVec3(0., 0., 1.));
+
+    // Second via point.
+    CableSpanViaPointIndex viaPoint2Index(1);
+    UnitVec3 viaPoint2InTangent =
+        cable.calcViaPointIncomingTangentDirection(s, viaPoint2Index);
+    SimTK_TEST_EQ(viaPoint2InTangent, UnitVec3(0., 0., 1.));
+    UnitVec3 viaPoint2OutTangent =
+        cable.calcViaPointOutgoingTangentDirection(s, viaPoint2Index);
+    SimTK_TEST_EQ(viaPoint2OutTangent, UnitVec3(-1., 0., 0.));
+
+    // Third via point.
+    CableSpanViaPointIndex viaPoint3Index(2);
+    UnitVec3 viaPoint3InTangent =
+        cable.calcViaPointIncomingTangentDirection(s, viaPoint3Index);
+    SimTK_TEST_EQ(viaPoint3InTangent, UnitVec3(-1., 0., 0.));
+    UnitVec3 viaPoint3OutTangent =
+        cable.calcViaPointOutgoingTangentDirection(s, viaPoint3Index);
+    SimTK_TEST_EQ(viaPoint3OutTangent,
+                  UnitVec3(0., -1./std::sqrt(5.), -2./std::sqrt(5.)));
+
+    // Termination.
+    UnitVec3 terminationTangent = cable.calcTerminationTangentDirection(s);
+    SimTK_TEST_EQ(terminationTangent,
+                  UnitVec3(0., -1./std::sqrt(5.), -2./std::sqrt(5.)));
 }
 
 /** Test computed cable path over all supported surfaces and a via point,


### PR DESCRIPTION
This change adds methods to `CableSpan` for calculating path tangent directions at origin, termination, and via points. This will make it easier for downstream applications to calculate force contributions from a `CableSpan` as a series of point forces (see https://github.com/opensim-org/opensim-core/pull/4331).

The methods implemented return point forces in the direction of cable tension, e.g., along the path away from origin, termination, and via points. This is most intuitive to me, but it is different from the way `CableSpan::calcCurveSegmentInitialFrenetFrame()` and `CableSpan::calcCurveSegmentFinalFrenetFrame()` return Frenet frames, where the tangent axis (x-axis) of each frame both point going from the origin to the termination. I'm happy to switch the convention for the tangent direction calculations if we think that is better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/857)
<!-- Reviewable:end -->
