### PR TITLE
CableSpan: add support for enabling/disabling solver warm starts

### DIFF
--- a/Simbody/include/simbody/internal/CableSpan.h
+++ b/Simbody/include/simbody/internal/CableSpan.h
@@ -138,17 +138,19 @@ straight line. Similarly the cable can touchdown on the obstacle if the surface
 obstructs the straight line segment again. The cable will always slide freely
 through any via points present in the path.
 
-The path is computed as an optimization problem using the previous optimal path
-as the warm start. This is done by computing natural geodesic corrections for
-each curve segment to compute the locally shortest path, as described in the
-following publication:
+The path is computed as an optimization problem by computing natural geodesic
+corrections for each curve segment to compute the locally shortest path,
+as described in the following publication:
 
     Scholz, A., Sherman, M., Stavness, I. et al (2015). A fast multi-obstacle
     muscle wrapping method using natural geodesic variations. Multibody System
     Dynamics 36, 195–219.
 
 The overall path is locally the shortest, allowing winding over an obstacle
-multiple times, without flipping to the other side.
+multiple times, without flipping to the other side. The wrapping solver can
+optionally use the solution from the previous time step as a warm start to
+improve performance during forward dynamics simulations (see method
+`getUseWarmStart()` for more information).
 
 During initialization the path is assumed to be in contact with each obstacle at
 the user defined contact-point-hint. At each contact point a
@@ -490,6 +492,21 @@ public:
 
     /** Set the algorithm used to compute the optimal path. **/
     void setAlgorithm(CableSpanAlgorithm algorithm);
+
+    /** Whether the solver uses the previously computed path as a warm
+    start to compute the next path solution. When true (the default), each path
+    computation is seeded with the previous optimal path, which is typically
+    much faster. When false, the path is always recomputed from each obstacle's
+    initial contact-point hint (see addObstacle and setObstacleContactPointHint)
+    every time the State is realized to Stage::Position. **/
+    bool getUseWarmStart() const;
+
+    /** Set whether the solver uses the previously computed path as a warm
+    start to compute the next path solution.
+    @note Changing this setting invalidates the Stage::Topology cache.
+    Therefore, callers should re-realize the system to Stage::Topology and
+    obtain a new State before any new computations. **/
+    void setUseWarmStart(bool useWarmStart);
 
     ///@}
 

--- a/Simbody/src/CableSpan.cpp
+++ b/Simbody/src/CableSpan.cpp
@@ -481,6 +481,10 @@ struct CableSpanParameters final : IntegratorTolerances {
     Real solverMaxStepSize = 10. / 180. * Pi;
     // The algorithm used to compute the optimal path.
     CableSpanAlgorithm algorithm = CableSpanAlgorithm::MinimumLength;
+    // Whether the solver uses the previously computed path as a warm start to
+    // compute the next path solution. When false, the path is always recomputed
+    // from each obstacle's initial contact-point hint.
+    bool useWarmStart = true;
 };
 
 } // namespace
@@ -669,11 +673,10 @@ public:
     // Realizing and cache access.
     //--------------------------------------------------------------------------
 
-    // Allocate state variables and cache entries.
-    void realizeTopology(State& state)
+    // Compute the initial instance data based on the contact point hint.
+    CurveSegmentData::Instance computeInitialInstanceData() const
     {
         CurveSegmentData::Instance dataInst;
-        // Initialize the contact point if a hint is available.
         if (isContactPointHintAvailable()) {
             const Vec3 initContactPoint =
                 getContactGeometry().projectDownhillToNearestPoint(
@@ -682,17 +685,30 @@ public:
             dataInst.X_SQ.updP()    = initContactPoint;
             dataInst.wrappingStatus = ObstacleWrappingStatus::InitialGuess;
         } else {
-            // Otherwise assume no contact.
             dataInst.trackingPointOnLine_S = Vec3{0.};
             dataInst.wrappingStatus = ObstacleWrappingStatus::LiftedFromSurface;
         }
-        // Use auto-update discrete variable to retain the previous path as a
-        // warmstart.
-        m_indexDataInst = updSubsystem().allocateAutoUpdateDiscreteVariable(
-            state,
-            Stage::Position,
-            new Value<CurveSegmentData::Instance>(dataInst),
-            Stage::Instance);
+        return dataInst;
+    }
+
+    // Allocate state variables and cache entries.
+    void realizeTopology(State& state)
+    {
+        if (getUseWarmStart()) {
+            m_indexDataInst = updSubsystem().allocateAutoUpdateDiscreteVariable(
+                state,
+                Stage::Position,
+                new Value<CurveSegmentData::Instance>(
+                    computeInitialInstanceData()),
+                Stage::Instance);
+        } else {
+            m_indexDataInstCache = updSubsystem().allocateCacheEntry(
+                state,
+                Stage::Instance,
+                Stage::Infinity,
+                new Value<CurveSegmentData::Instance>(
+                    computeInitialInstanceData()));
+        }
 
         m_indexDataPos = updSubsystem().allocateCacheEntry(
             state,
@@ -706,37 +722,70 @@ public:
         getSubsystem().markCacheValueNotRealized(state, m_indexDataPos);
     }
 
+    void invalidateDataInstCache(const State& state) const
+    {
+        if (!getUseWarmStart()) {
+            SubsystemIndex subsystemIx = getSubsystem().getMySubsystemIndex();
+            CacheEntryKey cacheKey =
+                std::make_pair(subsystemIx, m_indexDataInstCache);
+            SimTK_ASSERT_ALWAYS(state.hasCacheEntry(cacheKey),
+                "CurveSegment: cannot invalidate non-existent instance cache.");
+            getSubsystem().markCacheValueNotRealized(
+                state,
+                m_indexDataInstCache);
+        }
+    }
+
     const CurveSegmentData::Instance& getDataInst(const State& state) const
     {
         const CableSubsystem& subsystem = getSubsystem();
-        if (!subsystem.isDiscreteVarUpdateValueRealized(
-                state,
-                m_indexDataInst)) {
-            updDataInst(state) = getPrevDataInst(state);
-            subsystem.markDiscreteVarUpdateValueRealized(
-                state,
-                m_indexDataInst);
+
+        // Warm start enabled.
+        if (getUseWarmStart()) {
+            if (!subsystem.isDiscreteVarUpdateValueRealized(
+                    state,
+                    m_indexDataInst)) {
+                updDataInst(state) = getPrevDataInst(state);
+                markDataInstRealized(state);
+            }
+            return Value<CurveSegmentData::Instance>::downcast(
+                subsystem.getDiscreteVarUpdateValue(state, m_indexDataInst));
+        }
+
+        // Warm start disabled.
+        if (!subsystem.isCacheValueRealized(state, m_indexDataInstCache)) {
+            updDataInst(state) = computeInitialInstanceData();
+            markDataInstRealized(state);
         }
         return Value<CurveSegmentData::Instance>::downcast(
-            subsystem.getDiscreteVarUpdateValue(state, m_indexDataInst));
+            subsystem.getCacheEntry(state, m_indexDataInstCache));
     }
 
     CurveSegmentData::Instance& updDataInst(const State& state) const
     {
         return Value<CurveSegmentData::Instance>::updDowncast(
-            getSubsystem().updDiscreteVarUpdateValue(state, m_indexDataInst));
+            getUseWarmStart()
+                ? getSubsystem().updDiscreteVarUpdateValue(
+                      state,
+                      m_indexDataInst)
+                : getSubsystem().updCacheEntry(state, m_indexDataInstCache));
+    }
+
+    void markDataInstRealized(const State& state) const
+    {
+        if (getUseWarmStart()) {
+            getSubsystem().markDiscreteVarUpdateValueRealized(
+                state,
+                m_indexDataInst);
+        } else {
+            getSubsystem().markCacheValueRealized(state, m_indexDataInstCache);
+        }
     }
 
     const CurveSegmentData::Instance& getPrevDataInst(const State& state) const
     {
         return Value<CurveSegmentData::Instance>::downcast(
             getSubsystem().getDiscreteVariable(state, m_indexDataInst));
-    }
-
-    CurveSegmentData::Instance& updPrevDataInst(State& state) const
-    {
-        return Value<CurveSegmentData::Instance>::updDowncast(
-            getSubsystem().updDiscreteVariable(state, m_indexDataInst));
     }
 
     const CurveSegmentData::Position& getDataPos(const State& state) const
@@ -850,6 +899,8 @@ public:
     }
 
     const IntegratorTolerances& getIntegratorTolerances() const;
+
+    bool getUseWarmStart() const;
 
     //--------------------------------------------------------------------------
     // Utility functions.
@@ -1257,9 +1308,7 @@ public:
             dataInst.integratorInitialStepSize,
             updDataInst(state));
 
-        getSubsystem().markDiscreteVarUpdateValueRealized(
-            state,
-            m_indexDataInst);
+        markDataInstRealized(state);
         invalidatePosEntry(state);
     }
 
@@ -1284,9 +1333,7 @@ public:
             break;
         }
 
-        getSubsystem().markDiscreteVarUpdateValueRealized(
-            state,
-            m_indexDataInst);
+        markDataInstRealized(state);
         return getDataInst(state);
     }
 
@@ -1470,6 +1517,7 @@ private:
     // Topology cache.
     CacheEntryIndex m_indexDataPos        = CacheEntryIndex::Invalid();
     DiscreteVariableIndex m_indexDataInst = DiscreteVariableIndex::Invalid();
+    CacheEntryIndex m_indexDataInstCache  = CacheEntryIndex::Invalid();
 
     // Initial contact point hint used to setup the initial path.
     Vec3 m_contactPointHint_S{NaN, NaN, NaN};
@@ -1843,6 +1891,9 @@ public:
     {
         if (getSubsystem().isCacheValueRealized(state, m_indexDataPos)) {
             return;
+        }
+        for (const CurveSegment& curve : m_curveSegments) {
+            curve.invalidateDataInstCache(state);
         }
         calcDataPos(state);
         getSubsystem().markCacheValueRealized(state, m_indexDataPos);
@@ -2525,6 +2576,11 @@ private:
 const IntegratorTolerances& CurveSegment::getIntegratorTolerances() const
 {
     return getCable().getParameters();
+}
+
+bool CurveSegment::getUseWarmStart() const
+{
+    return getCable().getParameters().useWarmStart;
 }
 
 ObstacleIndex CurveSegment::findPrevObstacleInContactWithCable(
@@ -4774,6 +4830,17 @@ void CableSpan::setSmoothnessTolerance(Real tolerance)
 void CableSpan::setAlgorithm(CableSpanAlgorithm algorithm)
 {
     updImpl().updParameters().algorithm = algorithm;
+}
+
+bool CableSpan::getUseWarmStart() const
+{
+    return getImpl().getParameters().useWarmStart;
+}
+
+void CableSpan::setUseWarmStart(bool useWarmStart)
+{
+    updImpl().invalidateTopology();
+    updImpl().updParameters().useWarmStart = useWarmStart;
 }
 
 Real CableSpan::calcLength(const State& s) const

--- a/Simbody/tests/TestCableSpan.cpp
+++ b/Simbody/tests/TestCableSpan.cpp
@@ -1204,6 +1204,148 @@ void testRobustInitialPath()
         expectedLength);
 }
 
+/** CableSpan warm start test.
+
+This tests that path solutions are dependent on previous path solutions when
+warm starts are enabled, and only dependent on the contact hint when warm starts
+are disabled. **/
+void testUseWarmStart() {
+    class PendulumSystem {
+    public:
+        PendulumSystem(bool useWarmStart, Real defaultAngle) :
+                m_matter(m_system), m_cables(m_system) {
+
+            // Pendulum bodies.
+            Body::Rigid pendulumBody(MassProperties(1., Vec3(0),
+                    Inertia(1)));
+            Body::Rigid headBody(MassProperties(1., Vec3(0), Inertia(1)));
+
+            // Base body is welded to ground.
+            MobilizedBody::Weld base(
+                m_matter.Ground(),
+                Transform(Vec3(0., 1.5, 0.)),
+                pendulumBody,
+                Transform());
+
+            // Pendulum body is mobilized by a pin joint.
+            m_pendulum = MobilizedBody::Pin(
+                base,
+                Transform(Vec3(0.)),
+                headBody,
+                Transform(Vec3(0., 1., 0.)));
+            m_pendulum.setDefaultAngle(defaultAngle);
+
+            // Add a cable from the head origin to the base origin, wrapping
+            // over an ellipsoid obstacle.
+            m_cable = CableSpan(
+                m_cables,
+                m_pendulum,
+                Vec3(0.),
+                base,
+                Vec3(0.));
+            // Add the ellipsoid obstacle with a contact hint biased in the
+            // positive x-direction so that, when finding a path solution from
+            // the contact hint, the cable will wrap over the side of the
+            // ellipsoid in the positive x-direction.
+            m_cable.addObstacle(
+                base,
+                Transform(Rotation(), Vec3(0, -0.5, 0)),
+                std::shared_ptr<ContactGeometry>(
+                    new ContactGeometry::Ellipsoid(Vec3(0.1, 0.1, 0.5))),
+                Vec3(0.01, 0.2, 0.));
+
+            // Configure the solver.
+            m_cable.setUseWarmStart(useWarmStart);
+            m_cable.setCurveSegmentAccuracy(1e-12);
+            m_cable.setSmoothnessTolerance(1e-8);
+            m_cable.setSolverMaxIterations(100);
+            m_cable.setAlgorithm(CableSpanAlgorithm::MinimumLength);
+        }
+
+        State getDefaultState() {
+            m_system.realizeTopology();
+            return m_system.getDefaultState();
+        }
+
+        Real getCableLength(const State& s) {
+            return m_cable.calcLength(s);
+        }
+
+        Vec3 getInitialCurvePoint(const State& s) {
+            CableSpanObstacleIndex obsIx(0);
+            return m_cable.calcCurveSegmentInitialFrenetFrame(s, obsIx).p();
+        }
+
+        void setPendulumAngle(State& s, Real angle) {
+            m_pendulum.setAngle(s, angle);
+        }
+
+        void realizePosition(State& s) {
+            m_system.realize(s, Stage::Position);
+        }
+
+    private:
+        MultibodySystem m_system;
+        SimbodyMatterSubsystem m_matter;
+        CableSubsystem m_cables;
+        CableSpan m_cable;
+        MobilizedBody::Pin m_pendulum;
+    };
+
+
+    // Given option to use warm start and a default pendulum angle, construct a
+    // pendulum system with a wrap ellipsoid and calculate the initial curve
+    // point. We first realize the system to the position stage using the
+    // default angle, and then set the angle so that pendulum body to lies
+    // directly benath the ellipsoid obstacle. The initial curve point is then
+    // calculated. If warm start is enabled, the initial curve point should
+    // depend on the choice of the default angle we dictates the initial path
+    // solution. If warm start is disabled, the initial curve point should be
+    // the same regardless of the default angle since the path solver should
+    // always compute the path from the same initial point (i.e., the contact
+    // hint).
+    auto calcInitialCurvePoint = [](bool useWarmStart, Real defaultAngle)
+            -> Vec3 {
+        PendulumSystem pendulumSystem(useWarmStart, defaultAngle);
+        State s = pendulumSystem.getDefaultState();
+        pendulumSystem.realizePosition(s);
+        pendulumSystem.setPendulumAngle(s, 2.0*SimTK::Pi);
+        pendulumSystem.realizePosition(s);
+        return pendulumSystem.getInitialCurvePoint(s);
+    };
+
+
+    // Warm start enabled. The path should have converged to similar solutions,
+    // but on opposite sides of the ellipsoid obstacle, so the initial wrap
+    // points should have equal magnitude but opposite sign in the x-direction
+    // and have equal y-components. The z-components should be zero.
+    const Real tol = 1e-5;
+    {
+        auto firstPoint = calcInitialCurvePoint(true, 0.05*SimTK::Pi);
+        auto secondPoint = calcInitialCurvePoint(true, 1.95*SimTK::Pi);
+        SimTK_ASSERT_ALWAYS(std::abs(firstPoint[0] + secondPoint[0]) < tol,
+            "Warm start enabled: x-components of the initial wrap points "
+            "should have equal magnitude but opposite sign, but they do not.");
+        SimTK_ASSERT_ALWAYS(std::abs(firstPoint[1] - secondPoint[1]) < tol,
+             "Warm start enabled: y-components of the initial wrap points "
+             "should be equal, but they are not.");
+        SimTK_ASSERT_ALWAYS(std::abs(firstPoint[2]) < tol &&
+                            std::abs(secondPoint[2]) < tol,
+            "Warm start enabled: z-components of the initial wrap points "
+            "should be zero, but they are not.");
+    }
+
+    // Warm start disabled. The curve points should be equal since the path
+    // solver should be computing the path from the same initial point (i.e.,
+    // the contact hint) in both case.
+    {
+        auto firstPoint = calcInitialCurvePoint(false, 0.05*SimTK::Pi);
+        auto secondPoint = calcInitialCurvePoint(false, 1.95*SimTK::Pi);
+        SimTK_ASSERT_ALWAYS((firstPoint - secondPoint).norm() < tol,
+            "Warm start disabled: initial wrap points do not match.");
+    }
+}
+
 int main()
 {
     testSimpleCable();
@@ -1213,4 +1355,5 @@ int main()
     testAllSurfaceKinds(true);  // Test length derivative.
     testSolverOptimum();
     testRobustInitialPath();
+    testUseWarmStart();
 }


### PR DESCRIPTION
### Motivation
This change is motivated by [a recently discovered bug in OpenSim](https://github.com/opensim-org/opensim-core/issues/4330), where we found that moment arm calculations could change based on different default values for a coordinate. A path would first compute an initial solution at the default coordinate values. Then, when computing moment arms at coordinate values far from the default, the moment arm calculation would differ from when the default coordinate value is near the coordinate value used to calculate the moment arm. (In OpenSim Creator, this would manifest as moment arm values "flipping signs" when moving the coordinate slider, since moment arms would be recalculated treating the value on the slider as the coordinate's default.)

### Summary of changes
This change adds the accessors `getUseWarmStart()` and `setUseWarmStart()` to `CableSpan`, which internally controls a flag on `CableSpanParameters` to dictate when path warm starts are used (or not). If enabled, the auto-update discrete variable containing a curve's wrapping state is populated from the previous path solution (i.e., the current behavior). If disabled, it instead uses a plain cache entry at `Stage::Instance` to store intermediate path solutions which get (manually, see below) wiped on `realizePosition()` to force the path to always start from the contact hint. 
 
### Looking for feedback
When warm starts are disabled, the current approach must manually wipe the instance cache data on every `realizePosition()` call to get the desired behavior (always solve from the contact hints). Ideally, the cache entry would get wiped automatically, but setting the "earliest" stage to `SimTK::Position` makes the cache value via `getCacheEntry()` inaccessible since the position stage hasn't yet been reached during while the path solver is computing the optimal path. The alternative to the current approach is to instead call `updCacheEntry()` within `getDataInst` which will allow access to the cache value before hitting `Stage::Position`. I'm happy to switch if desired, but since call a `upd` method within `get` feels wrong, I've opted for the current approach which manually clears the instance cache data.

### Drive-by CI change

I've updated the generator in the Windows CMake preset to `Visual Studio 18 2026`, since the GitHub Actions `windows-latest` runner no longer supports `Visual Studio 17 2022`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/858)
<!-- Reviewable:end -->
