### PR TITLE
Remove hard-coded Visual Studio version in CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,7 +18,6 @@
                 "lhs": "${hostSystemName}",
                 "rhs": "Windows"
             },
-            "generator": "Visual Studio 17 2022",
             "architecture": {
                 "value": "x64"
             }


### PR DESCRIPTION
Quick fix (won't wait for review): this hard-coded VS needs to be removed because it prevents Simbody from building on CI or developer machines with VS2026 etc.

If there's a desire to change VS version then it should be done via the developer's/CI's environment (e.g. by sourcing vcvars.bat or similar).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/862)
<!-- Reviewable:end -->
