### PR TITLE
Fix OBJ face parsing with mixed whitespace

### DIFF
--- a/SimTKcommon/Geometry/src/PolygonalMesh.cpp
+++ b/SimTKcommon/Geometry/src/PolygonalMesh.cpp
@@ -326,7 +326,6 @@ void PolygonalMesh::loadObjFile(std::istream& file) {
                     nIndex--;
                     normalIndices.push_back(nIndex);
                 }
-                s.ignore(line.size(), ' ');
             }
             if (getNumFaces() == 0) { // First encountered face, set expectations
                 expectNormals = (indices.size() == normalIndices.size());
@@ -1295,4 +1294,3 @@ createCylinderMesh(const UnitVec3& axis, Real radius, Real halfLength,
 
     return cyl; // just a shallow copy
 }
-

--- a/SimTKcommon/tests/TestPolygonalMesh.cpp
+++ b/SimTKcommon/tests/TestPolygonalMesh.cpp
@@ -114,6 +114,39 @@ void testLoadObjFile() {
     ASSERT(!mesh.hasTextureCoordinates())
 }
 
+void testLoadObjFileWithWhitespaceDelimitedFaces() {
+    string file;
+    file += "v 0 0 0\n";
+    file += "v 1 0 0\n";
+    file += "v 1 1 0\n";
+    file += "v 0 1 0\n";
+    file += "vt 0 0\n";
+    file += "vt 1 0\n";
+    file += "vt 1 1\n";
+    file += "vt 0 1\n";
+    file += "vn 0 0 1\n";
+    file += "f\t1/1/1\t2/2/1\v3/3/1\f4/4/1\n";
+    file += "f  1/1/1\t2/2/1 \\\n";
+    file += "  3/3/1\v4/4/1\n";
+
+    PolygonalMesh mesh;
+    stringstream stream(file);
+    mesh.loadObjFile(stream);
+
+    const Vec2 expectedTextureCoordinates[] = {Vec2(0, 0), Vec2(1, 0),
+                                               Vec2(1, 1), Vec2(0, 1)};
+    ASSERT(mesh.getNumFaces() == 2);
+    for (int face = 0; face < mesh.getNumFaces(); ++face) {
+        ASSERT(mesh.getNumVerticesForFace(face) == 4);
+        for (int vertex = 0; vertex < 4; ++vertex) {
+            ASSERT(mesh.getFaceVertex(face, vertex) == vertex);
+            ASSERT(mesh.getVertexNormal(face, vertex) == UnitVec3(0, 0, 1));
+            ASSERT(mesh.getVertexTextureCoordinate(face, vertex) ==
+                   expectedTextureCoordinates[vertex]);
+        }
+    }
+}
+
 void testLoadObjFileWithNormalsTexture() {
     string file;
     file += "# This is a comment\n";
@@ -572,6 +605,7 @@ int main() {
     try {
         testCreateMesh();
         testLoadObjFile();
+        testLoadObjFileWithWhitespaceDelimitedFaces();
         testLoadObjFileWithNormalsTexture();
         testConvertObjFileToVisualizationFormat();
         testLoadVtpFile();


### PR DESCRIPTION
## Summary

- let formatted face-token extraction handle tabs, vertical whitespace, form feeds, and repeated separators
- preserve existing OBJ line continuation and slash-delimited vertex/texture/normal parsing
- add focused regression coverage for mixed whitespace across ordinary and continued face records

## Problem

The face parser already reads each vertex token with `operator>>`, which skips leading whitespace. It then calls `ignore(..., ' ')` after every token. When a face uses a separator other than a literal space, that extra call consumes subsequent vertex tokens while searching for a space.

The regression test fails on the previous implementation because a four-vertex face is parsed with fewer than four vertices.

## Implementation

Remove the redundant literal-space `ignore` call and rely on the formatted extraction that already drives the loop. This keeps token boundaries intact for all stream-recognized whitespace without changing the parsing of `v/vt/vn` triplets or backslash-continued lines.

The new test covers tabs, vertical tabs, form feeds, repeated spaces, a continued face line, and texture/normal indices.

## Validation

- `cmake -S . --preset ci-make-macos-release -DINSTALL_DOCS=OFF`
- `cmake --build --preset ci-make-macos-release --parallel 4`
- `ctest --test-dir out/build/ci-make-macos-release --parallel 4 --output-on-failure` (114/114 passed)
- `clang-format --dry-run --Werror` on the added test
- `git diff --check`
- no-tab check on both changed files

Fixes #747.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/863)
<!-- Reviewable:end -->
