### PR TITLE
Add SimTK_NODISCARD to non-mutating Simmatrix operators

### DIFF
--- a/SimTKcommon/BigMatrix/include/SimTKcommon/internal/MatrixBase.h
+++ b/SimTKcommon/BigMatrix/include/SimTKcommon/internal/MatrixBase.h
@@ -449,7 +449,7 @@ public:
 
     void elementwiseInvert(MatrixBase<typename CNT<E>::TInvert>& out) const;
 
-    MatrixBase<typename CNT<E>::TInvert> elementwiseInvert() const {
+    SimTK_NODISCARD MatrixBase<typename CNT<E>::TInvert> elementwiseInvert() const {
         MatrixBase<typename CNT<E>::TInvert> out(nrow(), ncol());
         elementwiseInvert(out);
         return out;
@@ -604,7 +604,7 @@ public:
       { return updBlock(i,j,m,n); }
  
     // Hermitian transpose.
-    inline MatrixView_<EHerm> transpose() const;
+    SimTK_NODISCARD inline MatrixView_<EHerm> transpose() const;
     inline MatrixView_<EHerm> updTranspose();
 
     MatrixView_<EHerm> operator~() const {return transpose();}
@@ -631,7 +631,7 @@ public:
     //MatrixView_<EReal> imag() {return updImag();}
 
     // TODO: this routine seems ill-advised but I need it for the IVM port at the moment
-    TInvert invert() const {  // return a newly-allocated inverse; dump negator 
+    SimTK_NODISCARD TInvert invert() const {  // return a newly-allocated inverse; dump negator 
         TInvert m(*this);
         m.helper.invertInPlace();
         return m;   // TODO - bad: makes an extra copy
@@ -695,7 +695,7 @@ public:
     /// abs() with the result as a function return. More convenient than the 
     /// other abs() member function, but may involve an additional copy of the 
     /// matrix.
-    TAbs abs() const { TAbs mabs; abs(mabs); return mabs; }
+    SimTK_NODISCARD TAbs abs() const { TAbs mabs; abs(mabs); return mabs; }
 
     /// Return a Matrix of the same shape and contents as this one but
     /// with the element type converted to one based on the standard
@@ -758,7 +758,7 @@ public:
 
     //TODO: make unary +/- return a self-view so they won't reallocate?
     const MatrixBase& operator+() const {return *this; }
-    const TNeg&       negate()    const {return *reinterpret_cast<const TNeg*>(this); }
+    SimTK_NODISCARD const TNeg&       negate()    const {return *reinterpret_cast<const TNeg*>(this); }
     TNeg&             updNegate()       {return *reinterpret_cast<TNeg*>(this); }
 
     const TNeg&       operator-() const {return negate();}

--- a/SimTKcommon/BigMatrix/include/SimTKcommon/internal/Matrix_.h
+++ b/SimTKcommon/BigMatrix/include/SimTKcommon/internal/Matrix_.h
@@ -124,7 +124,7 @@ public:
     Matrix_& operator+=(const ELT& r)       { this->updDiag() += r; return *this; }
     Matrix_& operator-=(const ELT& r)       { this->updDiag() -= r; return *this; }  
 
-    const TNeg& negate()    const {return *reinterpret_cast<const TNeg*>(this); }
+    SimTK_NODISCARD const TNeg& negate()    const {return *reinterpret_cast<const TNeg*>(this); }
     TNeg&       updNegate()       {return *reinterpret_cast<TNeg*>(this); }
 
     const TNeg& operator-() const {return negate();}

--- a/SimTKcommon/BigMatrix/include/SimTKcommon/internal/RowVectorBase.h
+++ b/SimTKcommon/BigMatrix/include/SimTKcommon/internal/RowVectorBase.h
@@ -244,7 +244,7 @@ public:
     ptrdiff_t nelt() const {assert(Base::nrow()==1); return Base::nelt();}
 
     // Override MatrixBase operators to return the right shape
-    TAbs abs() const {
+    SimTK_NODISCARD TAbs abs() const {
         TAbs result; Base::abs(result); return result;
     }
 
@@ -272,7 +272,7 @@ public:
     RowVectorView_<ELT> operator()(const Array_<int>& indices)       {return updIndex(indices);}
  
     // Hermitian transpose.
-    THerm transpose() const {return Base::transpose().getAsVectorView();}
+    SimTK_NODISCARD THerm transpose() const {return Base::transpose().getAsVectorView();}
     THerm updTranspose()    {return Base::updTranspose().updAsVectorView();}
 
     THerm operator~() const {return transpose();}
@@ -282,7 +282,7 @@ public:
 
     // Negation
 
-    const TNeg& negate()    const {return *reinterpret_cast<const TNeg*>(this); }
+    SimTK_NODISCARD const TNeg& negate()    const {return *reinterpret_cast<const TNeg*>(this); }
     TNeg&       updNegate()       {return *reinterpret_cast<TNeg*>(this); }
 
     const TNeg& operator-() const {return negate();}

--- a/SimTKcommon/BigMatrix/include/SimTKcommon/internal/VectorBase.h
+++ b/SimTKcommon/BigMatrix/include/SimTKcommon/internal/VectorBase.h
@@ -169,7 +169,7 @@ public:
     { Base::template rowScaleInPlace<EE>(v); return *this; }
     template <class EE> inline void rowScale(const VectorBase<EE>& v, typename EltResult<EE>::Mul& out) const
     { Base::rowScale(v,out); }
-    template <class EE> inline typename EltResult<EE>::Mul rowScale(const VectorBase<EE>& v) const
+    template <class EE> SimTK_NODISCARD inline typename EltResult<EE>::Mul rowScale(const VectorBase<EE>& v) const
     { typename EltResult<EE>::Mul out(nrow()); Base::rowScale(v,out); return out; }
 
     /** Return the root-mean-square (RMS) norm of a Vector of scalars, with 
@@ -322,7 +322,7 @@ public:
     }
 
     /// Return out[i]=this[i]^-1 as function return.
-    VectorBase<typename CNT<ELT>::TInvert> elementwiseInvert() const {
+    SimTK_NODISCARD VectorBase<typename CNT<ELT>::TInvert> elementwiseInvert() const {
         VectorBase<typename CNT<ELT>::TInvert> out(nrow());
         Base::elementwiseInvert(out);
         return out;
@@ -403,7 +403,7 @@ public:
     ptrdiff_t nelt() const {assert(Base::ncol()==1); return Base::nelt();}
 
     // Override MatrixBase operators to return the right shape
-    TAbs abs() const {TAbs result; Base::abs(result); return result;}
+    SimTK_NODISCARD TAbs abs() const {TAbs result; Base::abs(result); return result;}
     
     // Override MatrixBase indexing operators          
     const ELT& operator[](int i) const {return *reinterpret_cast<const ELT*>(Base::getHelper().getElt(i));}
@@ -432,7 +432,7 @@ public:
     VectorView_<ELT> operator()(const Array_<int>& indices)       {return updIndex(indices);}
  
     // Hermitian transpose.
-    THerm transpose() const {return Base::transpose().getAsRowVectorView();}
+    SimTK_NODISCARD THerm transpose() const {return Base::transpose().getAsRowVectorView();}
     THerm updTranspose()    {return Base::updTranspose().updAsRowVectorView();}
 
     THerm operator~() const {return transpose();}
@@ -442,7 +442,7 @@ public:
 
     // Negation
 
-    const TNeg& negate()    const {return *reinterpret_cast<const TNeg*>(this); }
+    SimTK_NODISCARD const TNeg& negate()    const {return *reinterpret_cast<const TNeg*>(this); }
     TNeg&       updNegate()       {return *reinterpret_cast<TNeg*>(this); }
 
     const TNeg& operator-() const {return negate();}

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Mat.h
@@ -228,7 +228,7 @@ public:
     /** Elementwise absolute value; that is, the return value has the same
     dimensions as this Mat but with each element replaced by whatever it thinks
     its absolute value is. **/
-    TAbs abs() const { 
+    SimTK_NODISCARD TAbs abs() const { 
         TAbs mabs;
         for(int j=0;j<N;++j) mabs(j) = (*this)(j).abs();
         return mabs;
@@ -657,7 +657,7 @@ public:
     // Mat<> does, because we can eliminate the negation here almost for free.
     // But we can't standardize (change conjugate to complex) for free, so we'll retain
     // conjugates if there are any.
-    TNormalize normalize() const {
+    SimTK_NODISCARD TNormalize normalize() const {
         if (CNT<E>::IsScalar) {
             return castAwayNegatorIfAny() / (int(SignInterpretation)*norm());
         } else {
@@ -671,7 +671,7 @@ public:
 
     // Default inversion. Assume full rank if square, otherwise return
     // pseudoinverse. (Mostly TODO)
-    TInvert invert() const;
+    SimTK_NODISCARD TInvert invert() const;
 
     const Mat&   operator+() const { return *this; }
     const TNeg&  operator-() const { return negate(); }
@@ -679,10 +679,10 @@ public:
     const THerm& operator~() const { return transpose(); }
     THerm&       operator~()       { return updTranspose(); }
 
-    const TNeg&  negate() const { return *reinterpret_cast<const TNeg*>(this); }
+    SimTK_NODISCARD const TNeg&  negate() const { return *reinterpret_cast<const TNeg*>(this); }
     TNeg&        updNegate()    { return *reinterpret_cast<TNeg*>(this); }
 
-    const THerm& transpose()    const { return *reinterpret_cast<const THerm*>(this); }
+    SimTK_NODISCARD const THerm& transpose()    const { return *reinterpret_cast<const THerm*>(this); }
     THerm&       updTranspose()       { return *reinterpret_cast<THerm*>(this); }
 
     const TPosTrans& positionalTranspose() const

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Row.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Row.h
@@ -237,7 +237,7 @@ public:
     // abs() is elementwise absolute value; that is, the return value has the same
     // dimension as this Row but with each element replaced by whatever it thinks
     // its absolute value is.
-    TAbs abs() const {
+    SimTK_NODISCARD TAbs abs() const {
         TAbs rabs;
         for(int i=0;i<N;++i) rabs[i] = CNT<E>::abs(d[i*STRIDE]);
         return rabs;
@@ -466,7 +466,7 @@ public:
     // Row<> does, because we can eliminate the negation here almost for free.
     // But we can't standardize (change conjugate to complex) for free, so we'll retain
     // conjugates if there are any.
-    TNormalize normalize() const {
+    SimTK_NODISCARD TNormalize normalize() const {
         if (CNT<E>::IsScalar) {
             return castAwayNegatorIfAny() / (int(SignInterpretation)*norm());
         } else {
@@ -477,7 +477,7 @@ public:
         }
     }
 
-    TInvert invert() const {assert(false); return TInvert();} // TODO default inversion
+    SimTK_NODISCARD TInvert invert() const {assert(false); return TInvert();} // TODO default inversion
 
     const Row&   operator+() const { return *this; }
     const TNeg&  operator-() const { return negate(); }
@@ -485,10 +485,10 @@ public:
     const THerm& operator~() const { return transpose(); }
     THerm&       operator~()       { return updTranspose(); }
 
-    const TNeg&  negate() const { return *reinterpret_cast<const TNeg*>(this); }
+    SimTK_NODISCARD const TNeg&  negate() const { return *reinterpret_cast<const TNeg*>(this); }
     TNeg&        updNegate()    { return *reinterpret_cast<TNeg*>(this); }
 
-    const THerm& transpose()    const { return *reinterpret_cast<const THerm*>(this); }
+    SimTK_NODISCARD const THerm& transpose()    const { return *reinterpret_cast<const THerm*>(this); }
     THerm&       updTranspose()       { return *reinterpret_cast<THerm*>(this); }
 
     const TPosTrans& positionalTranspose() const

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/SymMat.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/SymMat.h
@@ -192,7 +192,7 @@ public:
     // abs() is elementwise absolute value; that is, the return value has the same
     // dimension as this SymMat but with each element replaced by whatever it thinks
     // its absolute value is.
-    TAbs abs() const { 
+    SimTK_NODISCARD TAbs abs() const { 
         return TAbs(getAsVec().abs());
     }
 
@@ -580,7 +580,7 @@ public:
     /// SymMat<> does, because we can eliminate the negation here almost for free.
     /// But we can't standardize (change conjugate to complex) for free, so we'll retain
     /// conjugates if there are any.
-    TNormalize normalize() const {
+    SimTK_NODISCARD TNormalize normalize() const {
         if (CNT<E>::IsScalar) {
             return castAwayNegatorIfAny() / (int(SignInterpretation)*norm());
         } else {
@@ -591,7 +591,7 @@ public:
         }
     }
 
-    TInvert invert() const {assert(false); return TInvert();} // TODO default inversion
+    SimTK_NODISCARD TInvert invert() const {assert(false); return TInvert();} // TODO default inversion
 
     const SymMat& operator+() const { return *this; }
     const TNeg&   operator-() const { return negate(); }
@@ -599,10 +599,10 @@ public:
     const THerm&  operator~() const { return transpose(); }
     THerm&        operator~()       { return updTranspose(); }
 
-    const TNeg&  negate() const { return *reinterpret_cast<const TNeg*>(this); }
+    SimTK_NODISCARD const TNeg&  negate() const { return *reinterpret_cast<const TNeg*>(this); }
     TNeg&        updNegate()    { return *reinterpret_cast<TNeg*>(this); }
 
-    const THerm& transpose()    const { return *reinterpret_cast<const THerm*>(this); }
+    SimTK_NODISCARD const THerm& transpose()    const { return *reinterpret_cast<const THerm*>(this); }
     THerm&       updTranspose()       { return *reinterpret_cast<THerm*>(this); }
 
     const TPosTrans& positionalTranspose() const

--- a/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
+++ b/SimTKcommon/SmallMatrix/include/SimTKcommon/internal/Vec.h
@@ -346,7 +346,7 @@ public:
     dimension as this Vec but with each element replaced by whatever it thinks
     its absolute value is. The element type may have changed and the stride
     of the return Vec is always 1. **/
-    TAbs abs() const {
+    SimTK_NODISCARD TAbs abs() const {
         TAbs vabs;
         for(int i=0;i<M;++i) vabs[i] = CNT<E>::abs(d[i*STRIDE]);
         return vabs;
@@ -670,7 +670,7 @@ public:
     Vec<> does, because we can eliminate the negation here almost for free.
     But we can't standardize (change conjugate to complex) for free, so we'll retain
     conjugates if there are any. **/
-    TNormalize normalize() const {
+    SimTK_NODISCARD TNormalize normalize() const {
         if (CNT<E>::IsScalar) {
             return castAwayNegatorIfAny() / (int(SignInterpretation)*norm());
         } else {
@@ -682,7 +682,7 @@ public:
     }
 
     /** This method is not supported for %Vec objects. **/
-    TInvert invert() const {assert(false); return TInvert();} // TODO default inversion
+    SimTK_NODISCARD TInvert invert() const {assert(false); return TInvert();} // TODO default inversion
 
     /** Unary plus does nothing. **/
     const Vec&   operator+() const { return *this; }
@@ -703,13 +703,13 @@ public:
     THerm&       operator~()       { return updTranspose(); }
 
     /** Non-operator version of unary negation; just a recast. **/
-    const TNeg&  negate() const { return *reinterpret_cast<const TNeg*>(this); }
+    SimTK_NODISCARD const TNeg&  negate() const { return *reinterpret_cast<const TNeg*>(this); }
     /** Non-operator version of unary negation; recasts and returns a 
     writable reference. **/
     TNeg&        updNegate()    { return *reinterpret_cast<      TNeg*>(this); }
 
     /** Non-operator version of Hermitian transpose; just a recast. **/
-    const THerm& transpose()    const { return *reinterpret_cast<const THerm*>(this); }
+    SimTK_NODISCARD const THerm& transpose()    const { return *reinterpret_cast<const THerm*>(this); }
     /** Non-operator version of Hermitian transpose; recasts and returns a 
     writable reference. **/
     THerm&       updTranspose()       { return *reinterpret_cast<      THerm*>(this); }

--- a/SimTKcommon/include/SimTKcommon/internal/common.h
+++ b/SimTKcommon/include/SimTKcommon/internal/common.h
@@ -2,6 +2,23 @@
 #define SimTK_SimTKCOMMON_COMMON_H_
 
 /* -------------------------------------------------------------------------- *
+ *                           SimTK_NODISCARD                                  *
+ * -------------------------------------------------------------------------- */
+/** Warn if a caller fails to capture or use the return value of a method.
+    Primarily used on pure evaluation methods whose names resemble in-place
+    action verbs (e.g., normalize(), invert(), transpose()). **/
+#if defined(SWIG) || defined(DOXYGEN)
+    #define SimTK_NODISCARD
+#elif defined(__cplusplus) && (__cplusplus >= 201703L)
+    #define SimTK_NODISCARD [[nodiscard]]
+#elif defined(__clang__) || defined(__GNUC__)
+    #define SimTK_NODISCARD __attribute__((warn_unused_result))
+#else
+    #define SimTK_NODISCARD
+#endif
+
+
+/* -------------------------------------------------------------------------- *
  *                       Simbody(tm): SimTKcommon                             *
  * -------------------------------------------------------------------------- *
  * This is part of the SimTK biosimulation toolkit originating from           *

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1981,6 +1981,7 @@ INCLUDE_FILE_PATTERNS  =
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             = SimTK_SIMBODY_EXPORT= \
+                         SimTK_NODISCARD= \
                          SimTK_SimTKCOMMON_EXPORT= \
                          SimTK_SIMMATH_EXPORT= \
                          SimTK_FORCE_INLINE= \


### PR DESCRIPTION
### Description
As per issue #864 this PR adds the `SimTK_NODISCARD` attribute to non-mutating `Simmatrix` methods.

### Changes
- `SimTKcommon/internal/common.h`: Introduced `SimTK_NODISCARD` macro (resolves to standard C++17 `[[nodiscard]]`, falls back to `__attribute__((warn_unused_result))` on GCC/Clang, and is disabled under `SWIG` and `DOXYGEN` to prevent build errors).
- `SmallMatrix/BigMatrix` headers`: Annotated pure evaluation methods in `Vec`, `Mat`, `Row`, `SymMat`, `VectorBase`, `MatrixBase`, `RowVectorBase`, and `Matrix_`.
- `doc/Doxyfile.in`: Added `SimTK_NODISCARD=` to `PREDEFINED` to keep generated API reference documentation clean.

### Testing Done
- Full regression suite passed (114) via ctest.
-  Expected `[-Wunused-result]` warning when return values are discarded. Compiles with zero warnings when return values are assigned, chained (`v.normalize().abs()`), or passed to stream/function sinks.
- Verified that unevaluated contexts (`decltype`, `sizeof`), explicit `(void)` casts, and `-DSWIG` mode compile with zero issues.

### Looking for feedback on
1. If the macro definition and placement in `common.h` align with Simbody's preferred conventions.
2. If there are any other specific non-mutating method that should be annotated in this pass.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/865)
<!-- Reviewable:end -->
