### PR TITLE
Add position Jacobian operators w.r.t. mobilizer frames

### DIFF
--- a/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
+++ b/Simbody/include/simbody/internal/SimbodyMatterSubsystem.h
@@ -1224,6 +1224,130 @@ SpatialVec calcBiasForFrameJacobian(const State&         state,
     return JFDotu[0];
 }
 
+/** Calculate the product of the body position Jacobian with respect to
+inboard frame positions, JpF, with a vector of nb position-like quantities,
+dp_PF. If dp_PF is a vector of perturbations in mobilizer inboard frame (F)
+positions, expressed in the parent body P, then the result is the change in
+mobilized body (B) origin positions (Bo) measured and expressed in Ground.
+
+@param[in]      state
+    A State that has already been realized through Position stage.
+@param[in]      dp_PF
+    A vector of nb position-like quantities, one per mobilized body in the order
+    of MobilizedBodyIndex. The 0th entry is ignored since Ground has no inboard
+    frame. This is usually a set of perturbations in mobilizer inboard frame (F)
+    positions, expressed in the parent bodies P.
+@param[out]     dp_GB
+    The product JpF*dp_PF, usually the change in mobilized body (B) origin
+    positions (Bo), measured and expressed in Ground. The 0th entry is set to
+    zero since Ground does not move.
+
+@see multiplyByPositionJacobianWrtInboardFramePositionsTranspose() **/
+void multiplyByPositionJacobianWrtInboardFramePositions(
+        const State&                      state,
+        const Vector_<Vec3>&              dp_PF,
+        Vector_<Vec3>&                    dp_GB) const;
+
+/** Calculate the product of the transposed body position Jacobian with respect
+to inboard frame positions, ~JpF (==JpF^T), with a vector of nb gradient-like
+quantities, g_GB. If g_GB is the gradient of a scalar function with respect to
+the mobilized body (B) origin positions (Bo) in Ground, then the result is the
+gradient of that same function with respect to the mobilizer inboard frame (F)
+positions, expressed in the parent bodies P.
+
+@param[in]      state
+    A State that has already been realized through Position stage.
+@param[in]      g_GB
+    A vector of nb gradient-like quantities, one per mobilized body in the order
+    of MobilizedBodyIndex. The 0th entry is ignored since Ground does not move.
+    Usually, g_GB contains sensitivities like partial(f)/partial(p_GB) for a
+    scalar function f, expressed in Ground.
+@param[out]     g_PF
+    The product ~JpF*g_GB, usually the gradient of f with respect to the
+    mobilizer inboard frame (F) positions, expressed in the parent bodies P.
+    The 0th entry is set to zero since Ground has no inboard frame.
+
+<h3>Usage</h3>
+If you have a scalar function f that depends on the mobilized body positions
+p_GB (e.g., the squared distance between a measured point and a body origin),
+use this method to obtain the gradient of f with respect to the mobilizer
+inboard frame positions p_PF:
+<pre>
+           partial(f)            partial(f)
+  g_PF = -------------- = ~JpF --------------
+          partial(p_PF)         partial(p_GB)
+</pre>
+This operator may be useful when computing gradients with respect to mobilizer
+inboard frame positions when optimizing the geometry of a multibody system.
+
+@see multiplyByPositionJacobianWrtInboardFramePositions() **/
+void multiplyByPositionJacobianWrtInboardFramePositionsTranspose(
+        const State&                      state,
+        const Vector_<Vec3>&              g_GB,
+        Vector_<Vec3>&                    g_PF) const;
+
+/** Calculate the product of the body position Jacobian with respect to
+outboard frame positions, JpM, with a vector of nb position-like quantities,
+dp_BM. If dp_BM is a vector of perturbations in mobilizer outboard frame (M)
+positions, expressed in the child body B, then the result is the change in
+mobilized body (B) origin positions (Bo) measured and expressed in Ground.
+
+@param[in]      state
+    A State that has already been realized through Position stage.
+@param[in]      dp_BM
+    A vector of nb position-like quantities, one per mobilized body in the order
+    of MobilizedBodyIndex. The 0th entry is ignored since Ground has no outboard
+    frame. This is usually a set of perturbations in mobilizer outboard frame
+    (M) positions, expressed in the child bodies B.
+@param[out]     dp_GB
+    The product JpM*dp_BM, usually the change in mobilized body (B) origin
+    positions (Bo), measured and expressed in Ground. The 0th entry is set to
+    zero since Ground does not move.
+
+@see multiplyByPositionJacobianWrtOutboardFramePositionsTranspose() **/
+void multiplyByPositionJacobianWrtOutboardFramePositions(
+        const State&                      state,
+        const Vector_<Vec3>&              dp_BM,
+        Vector_<Vec3>&                    dp_GB) const;
+
+/** Calculate the product of the transposed body position Jacobian with respect
+to outboard frame positions, ~JpM (==JpM^T), with a vector of nb gradient-like
+quantities, g_GB. If g_GB is the gradient of a scalar function with respect to
+the mobilized body (B) origin positions (Bo) in Ground, then the result is the
+gradient of that same function with respect to the mobilizer outboard frame (M)
+positions, expressed in the child bodies B.
+
+@param[in]      state
+    A State that has already been realized through Position stage.
+@param[in]      g_GB
+    A vector of nb gradient-like quantities, one per mobilized body in the order
+    of MobilizedBodyIndex. The 0th entry is ignored since Ground does not move.
+    Usually, g_GB contains sensitivities like partial(f)/partial(p_GB) for a
+    scalar function f, expressed in Ground.
+@param[out]     g_BM
+    The product ~JpM*g_GB, usually the gradient of f with respect to the
+    mobilizer outboard frame (M) positions, expressed in the child bodies B.
+    The 0th entry is set to zero since Ground has no outboard frame.
+
+<h3>Usage</h3>
+If you have a scalar function f that depends on the mobilized body positions
+p_GB (e.g., the squared distance between a measured point and a body origin),
+use this method to obtain the gradient of f with respect to the mobilizer
+outboard frame positions p_BM:
+<pre>
+           partial(f)            partial(f)
+  g_BM = -------------- = ~JpM --------------
+          partial(p_BM)         partial(p_GB)
+</pre>
+This operator may be useful when computing gradients with respect to mobilizer
+outboard frame positions when optimizing the geometry of a multibody system.
+
+@see multiplyByPositionJacobianWrtOutboardFramePositions() **/
+void multiplyByPositionJacobianWrtOutboardFramePositionsTranspose(
+        const State&                      state,
+        const Vector_<Vec3>&              g_GB,
+        Vector_<Vec3>&                    g_BM) const;
+
 /**@}**/
 
 //==============================================================================

--- a/Simbody/src/RigidBodyNode.h
+++ b/Simbody/src/RigidBodyNode.h
@@ -510,6 +510,69 @@ virtual void multiplyBySystemJacobianTranspose(
   { SimTK_THROW2(Exception::UnimplementedVirtualMethod, "RigidBodeNode", 
     "multiplyBySystemJacobianTranspose"); }
 
+
+// Calculate the contribution of a perturbation in the inboard frame position
+// of this node to the perturbation of this node's body frame position, in
+// Ground. Call base to tip, skipping the Ground mobilized body, whose position
+// is fixed.
+void multiplyByPositionJacobianWrtInboardFramePosition(
+        const SBTreePositionCache&  pc,
+        const Vec3*                 dp_PF,
+        Vec3*                       dp_GB) const {
+
+    dp_GB[nodeNum] = dp_GB[parent->getNodeNum()] +
+                     getX_GP(pc).R() * dp_PF[nodeNum];
+}
+
+// Calculate this node's contribution to the transpose of the position Jacobian
+// with respect to the inboard frame position. Call tip to base, skipping the
+// Ground mobilized body, whose position is fixed.
+void multiplyByPositionJacobianWrtInboardFramePositionTranspose(
+        const SBTreePositionCache&  pc,
+        Vec3*                       zTmp,
+        const Vec3*                 g_GB,
+        Vec3*                       g_PF) const {
+
+    Vec3& sum = zTmp[nodeNum];
+    sum = g_GB[nodeNum];
+    for (unsigned i = 0; i < children.size(); ++i) {
+        sum += zTmp[children[i]->getNodeNum()];
+    }
+
+    g_PF[nodeNum] = ~getX_GP(pc).R() * sum;
+}
+
+// Calculate the contribution of a perturbation in the outboard frame position
+// of this node to the perturbation of this node's body frame position, in
+// Ground. Call base to tip, skipping the Ground mobilized body, whose position
+// is fixed.
+void multiplyByPositionJacobianWrtOutboardFramePosition(
+        const SBTreePositionCache&  pc,
+        const Vec3*                 dp_BM,
+        Vec3*                       dp_GB) const {
+
+    dp_GB[nodeNum] = dp_GB[parent->getNodeNum()] -
+                     getX_GB(pc).R() * dp_BM[nodeNum];
+}
+
+// Calculate this node's contribution to the transpose of the position Jacobian
+// with respect to the outboard frame position. Call tip to base, skipping the
+// Ground mobilized body, whose position is fixed.
+void multiplyByPositionJacobianWrtOutboardFramePositionTranspose(
+        const SBTreePositionCache&  pc,
+        Vec3*                       zTmp,
+        const Vec3*                 g_GB,
+        Vec3*                       g_BM) const {
+
+    Vec3& sum = zTmp[nodeNum];
+    sum = g_GB[nodeNum];
+    for (unsigned i = 0; i < children.size(); ++i) {
+        sum += zTmp[children[i]->getNodeNum()];
+    }
+
+    g_BM[nodeNum] = -(~getX_GB(pc).R() * sum);
+}
+
 virtual void calcEquivalentJointForces(
     const SBTreePositionCache&  pc,
     const SBTreeVelocityCache&  vc,

--- a/Simbody/src/SimbodyMatterSubsystem.cpp
+++ b/Simbody/src/SimbodyMatterSubsystem.cpp
@@ -2025,6 +2025,71 @@ void SimbodyMatterSubsystem::calcBiasForFrameJacobian
 
 
 //==============================================================================
+//           JACOBIANS WRT INBOARD/OUTBOARD MOBILIZER FRAME POSITIONS
+//==============================================================================
+
+void SimbodyMatterSubsystem::multiplyByPositionJacobianWrtInboardFramePositions(
+        const State&         s,
+        const Vector_<Vec3>& dp_PF,
+        Vector_<Vec3>&       dp_GB) const {
+    SimTK_APIARGCHECK2_ALWAYS(dp_PF.size() == getNumBodies(),
+        "SimbodyMatterSubsystem",
+        "multiplyByPositionJacobianWrtInboardFramePositions",
+        "The number of inboard frame perturbations, dp_PF (%d), and number of "
+        "bodies (%d) must be the same.",
+        dp_PF.size(), getNumBodies());
+    getRep().multiplyByPositionJacobianWrtInboardFramePositions(
+            s, dp_PF, dp_GB);
+}
+
+void SimbodyMatterSubsystem::
+multiplyByPositionJacobianWrtInboardFramePositionsTranspose(
+        const State&         s,
+        const Vector_<Vec3>& g_GB,
+        Vector_<Vec3>&       g_PF) const {
+    SimTK_APIARGCHECK2_ALWAYS(g_GB.size() == getNumBodies(),
+        "SimbodyMatterSubsystem",
+        "multiplyByPositionJacobianWrtInboardFramePositionsTranspose",
+        "The length of g_GB (%d) and the number of bodies (%d) must be the "
+        "same.",
+        g_GB.size(), getNumBodies());
+    getRep().multiplyByPositionJacobianWrtInboardFramePositionsTranspose(
+            s, g_GB, g_PF);
+}
+
+void SimbodyMatterSubsystem::multiplyByPositionJacobianWrtOutboardFramePositions(
+        const State&         s,
+        const Vector_<Vec3>& dp_BM,
+        Vector_<Vec3>&       dp_GB) const {
+    SimTK_APIARGCHECK2_ALWAYS(dp_BM.size() == getNumBodies(),
+        "SimbodyMatterSubsystem",
+        "multiplyByPositionJacobianWrtOutboardFramePositions",
+        "The number of outboard frame perturbations, dp_BM (%d), and number of "
+        "bodies (%d) must be the same.",
+        dp_BM.size(), getNumBodies());
+    getRep().multiplyByPositionJacobianWrtOutboardFramePositions(
+            s, dp_BM, dp_GB);
+}
+
+void SimbodyMatterSubsystem::
+multiplyByPositionJacobianWrtOutboardFramePositionsTranspose(
+        const State&         s,
+        const Vector_<Vec3>& g_GB,
+        Vector_<Vec3>&       g_BM) const {
+    SimTK_APIARGCHECK2_ALWAYS(g_GB.size() == getNumBodies(),
+        "SimbodyMatterSubsystem",
+        "multiplyByPositionJacobianWrtOutboardFramePositionsTranspose",
+        "The length of g_GB (%d) and the number of bodies (%d) must be the "
+        "same.",
+        g_GB.size(), getNumBodies());
+    getRep().multiplyByPositionJacobianWrtOutboardFramePositionsTranspose(
+            s, g_GB, g_BM);
+}
+
+
+
+
+//==============================================================================
 //                              MISC OPERATORS
 //==============================================================================
 

--- a/Simbody/src/SimbodyMatterSubsystemRep.cpp
+++ b/Simbody/src/SimbodyMatterSubsystemRep.cpp
@@ -6352,6 +6352,120 @@ void SimbodyMatterSubsystemRep::multiplyBySystemJacobianTranspose
 //................... MULTIPLY BY SYSTEM JACOBIAN TRANSPOSE ....................
 
 
+// =============================================================================
+//             JACOBIANS WRT MOBILIZER INBOARD AND OUTBOARD FRAMES
+// =============================================================================
+
+void SimbodyMatterSubsystemRep::
+multiplyByPositionJacobianWrtInboardFramePositions(
+        const State&         s,
+        const Vector_<Vec3>& dp_PF,
+        Vector_<Vec3>&       dp_GB) const {
+    const int nb = getNumBodies();
+    assert(dp_PF.size() == nb);
+    dp_GB.resize(nb);
+    assert(dp_PF.hasContiguousData() && dp_GB.hasContiguousData());
+
+    const SBTreePositionCache& pc = getTreePositionCache(s);
+    const Vec3* dp_PFPtr = dp_PF.size() ? &dp_PF[0] : NULL;
+    Vec3*       dp_GBPtr = dp_GB.size() ? &dp_GB[0] : NULL;
+
+    dp_GBPtr[0] = Vec3(0); // Ground is fixed.
+
+    // Skip ground -- it has no inboard frame.
+    for (int i = 1; i < static_cast<int>(rbNodeLevels.size()); i++) {
+        for (int j = 0; j < static_cast<int>(rbNodeLevels[i].size()); j++) {
+            const RigidBodyNode& node = *rbNodeLevels[i][j];
+            node.multiplyByPositionJacobianWrtInboardFramePosition(
+                    pc, dp_PFPtr, dp_GBPtr);
+        }
+    }
+}
+
+void SimbodyMatterSubsystemRep::
+multiplyByPositionJacobianWrtInboardFramePositionsTranspose(
+        const State&         s,
+        const Vector_<Vec3>& g_GB,
+        Vector_<Vec3>&       g_PF) const {
+    const int nb = getNumBodies();
+    assert(g_GB.size() == nb);
+    g_PF.resize(nb);
+    assert(g_GB.hasContiguousData() && g_PF.hasContiguousData());
+
+    const SBTreePositionCache& pc = getTreePositionCache(s);
+
+    Vector_<Vec3> zTemp(nb); zTemp.setToZero();
+    const Vec3* g_GBPtr  = g_GB.size() ? &g_GB[0] : NULL;
+    Vec3*       g_PFPtr  = g_PF.size() ? &g_PF[0] : NULL;
+    Vec3*       zTempPtr = zTemp.size() ? &zTemp[0] : NULL;
+
+    // Skip ground -- it has no inboard frame.
+    for (int i = static_cast<int>(rbNodeLevels.size()) - 1; i > 0; i--) {
+        for (int j=0; j < static_cast<int>(rbNodeLevels[i].size()); j++) {
+            const RigidBodyNode& node = *rbNodeLevels[i][j];
+            node.multiplyByPositionJacobianWrtInboardFramePositionTranspose(
+                    pc, zTempPtr, g_GBPtr, g_PFPtr);
+        }
+    }
+
+    g_PFPtr[0] = Vec3(0); // Ground has no inboard frame.
+}
+
+void SimbodyMatterSubsystemRep::
+multiplyByPositionJacobianWrtOutboardFramePositions(
+        const State&         s,
+        const Vector_<Vec3>& dp_BM,
+        Vector_<Vec3>&       dp_GB) const {
+    const int nb = getNumBodies();
+    assert(dp_BM.size() == nb);
+    dp_GB.resize(nb);
+    assert(dp_BM.hasContiguousData() && dp_GB.hasContiguousData());
+
+    const SBTreePositionCache& pc = getTreePositionCache(s);
+    const Vec3* dp_BMPtr = dp_BM.size() ? &dp_BM[0] : NULL;
+    Vec3*       dp_GBPtr = dp_GB.size() ? &dp_GB[0] : NULL;
+
+    dp_GBPtr[0] = Vec3(0); // Ground is fixed.
+
+    // Skip ground -- it has no outboard frame.
+    for (int i = 1; i < static_cast<int>(rbNodeLevels.size()); i++) {
+        for (int j = 0; j < static_cast<int>(rbNodeLevels[i].size()); j++) {
+            const RigidBodyNode& node = *rbNodeLevels[i][j];
+            node.multiplyByPositionJacobianWrtOutboardFramePosition(
+                    pc, dp_BMPtr, dp_GBPtr);
+        }
+    }
+}
+
+void SimbodyMatterSubsystemRep::
+multiplyByPositionJacobianWrtOutboardFramePositionsTranspose(
+        const State&         s,
+        const Vector_<Vec3>& g_GB,
+        Vector_<Vec3>&       g_BM) const {
+    const int nb = getNumBodies();
+    assert(g_GB.size() == nb);
+    g_BM.resize(nb);
+    assert(g_GB.hasContiguousData() && g_BM.hasContiguousData());
+
+    const SBTreePositionCache& pc = getTreePositionCache(s);
+    Vector_<Vec3> zTemp(nb); zTemp.setToZero();
+    const Vec3* g_GBPtr  = g_GB.size() ? &g_GB[0] : NULL;
+    Vec3*       g_BMPtr  = g_BM.size() ? &g_BM[0] : NULL;
+    Vec3*       zTempPtr = zTemp.size() ? &zTemp[0] : NULL;
+
+    // Skip ground -- it has no outboard frame.
+    for (int i = static_cast<int>(rbNodeLevels.size()) - 1; i > 0; i--) {
+        for (int j = 0; j < static_cast<int>(rbNodeLevels[i].size()); j++) {
+            const RigidBodyNode& node = *rbNodeLevels[i][j];
+            node.multiplyByPositionJacobianWrtOutboardFramePositionTranspose(
+                    pc, zTempPtr, g_GBPtr, g_BMPtr);
+        }
+    }
+
+    g_BMPtr[0] = Vec3(0); // Ground has no outboard frame.
+}
+
+//............. JACOBIANS WRT MOBILIZER INBOARD AND OUTBOARD FRAMES ............
 
 // =============================================================================
 //                     CALC TREE EQUIVALENT MOBILITY FORCES

--- a/Simbody/src/SimbodyMatterSubsystemRep.h
+++ b/Simbody/src/SimbodyMatterSubsystemRep.h
@@ -560,6 +560,51 @@ public:
         const Vector_<SpatialVec>& X, 
         Vector&                    JtX) const;
 
+    // Calculate the product of the body position Jacobian with respect to
+    // inboard frame positions, JpF, with a vector of nb position-like
+    // quantities, dp_PF. If dp_PF is a vector of perturbations in mobilizer
+    // inboard frame (F) positions, expressed in the parent body P, then the
+    // result is the change in mobilized body (B) origin positions (Bo) measured
+    // and expressed in Ground.
+    void multiplyByPositionJacobianWrtInboardFramePositions(const State& s,
+        const Vector_<Vec3>& dp_PF,
+        Vector_<Vec3>&       dp_GB) const;
+
+    // Calculate the product of the transposed body position Jacobian with
+    // respect to inboard frame positions, ~JpF (==JpF^T), with a vector of nb
+    // gradient-like quantities, g_GB. If g_GB is the gradient of a scalar
+    // function with respect to the mobilized body (B) origin positions (Bo) in
+    // Ground, then the result is the gradient of that same function with
+    // respect to the mobilizer inboard frame (F) positions, expressed in the
+    // parent bodies P.
+    void multiplyByPositionJacobianWrtInboardFramePositionsTranspose(
+        const State&         s,
+        const Vector_<Vec3>& g_GB,
+        Vector_<Vec3>&       g_PF) const;
+
+    // Calculate the product of the body position Jacobian with respect to
+    // outboard frame positions, JpM, with a vector of nb position-like
+    // quantities, dp_BM. If dp_BM is a vector of perturbations in mobilizer
+    // outboard frame (M) positions, expressed in the child body B, then the
+    // result is the change in mobilized body (B) origin positions (Bo) measured
+    // and expressed in Ground.
+    void multiplyByPositionJacobianWrtOutboardFramePositions(
+        const State&         s,
+        const Vector_<Vec3>& dp_BM,
+        Vector_<Vec3>&       dp_GB) const;
+
+    // Calculate the product of the transposed body position Jacobian with
+    // respect to outboard frame positions, ~JpM (==JpM^T), with a vector of nb
+    // gradient-like quantities, g_GB. If g_GB is the gradient of a scalar
+    // function with respect to the mobilized body (B) origin positions (Bo) in
+    // Ground, then the result is the gradient of that same function with
+    // respect to the mobilizer outboard frame (M) positions, expressed in the
+    // child bodies B.
+    void multiplyByPositionJacobianWrtOutboardFramePositionsTranspose(
+        const State&         s,
+        const Vector_<Vec3>& g_GB,
+        Vector_<Vec3>&       g_BM) const;
+
     // Given a set of body forces, return the equivalent set of mobilizer torques 
     // IGNORING CONSTRAINTS.
     // Must be in DynamicsStage so that articulated body inertias are available,

--- a/Simbody/tests/TestJacobians.cpp
+++ b/Simbody/tests/TestJacobians.cpp
@@ -1,0 +1,308 @@
+/* -------------------------------------------------------------------------- *
+ *                               Simbody(tm)                                  *
+ * -------------------------------------------------------------------------- *
+ * This is part of the SimTK biosimulation toolkit originating from           *
+ * Simbios, the NIH National Center for Physics-Based Simulation of           *
+ * Biological Structures at Stanford, funded under the NIH Roadmap for        *
+ * Medical Research, grant U54 GM072970. See https://simtk.org/home/simbody.  *
+ *                                                                            *
+ * Portions copyright (c) 2008-26 Stanford University and the Authors.        *
+ * Authors: Nicholas Bianco                                                   *
+ * Contributors:                                                              *
+ *                                                                            *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may    *
+ * not use this file except in compliance with the License. You may obtain a  *
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0.         *
+ *                                                                            *
+ * Unless required by applicable law or agreed to in writing, software        *
+ * distributed under the License is distributed on an "AS IS" BASIS,          *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.   *
+ * See the License for the specific language governing permissions and        *
+ * limitations under the License.                                             *
+ * -------------------------------------------------------------------------- */
+
+#include "SimTKsimbody.h"
+
+using namespace SimTK;
+
+namespace {
+
+    // A branched multibody of bodies containing various mobilizers of different
+    // types including Pin, Ellipsoid, and CantileverFreeBeam mobilizers.
+    class BranchedSystem {
+    public:
+        enum MobilizerType {Ground=0, Pin=1, Ellipsoid=2, CantileverFreeBeam=3,
+                            Gimbal=4, Weld=5, Free=6};
+
+        BranchedSystem() :
+                m_matter(m_system), m_forces(m_system),
+                m_gravity(m_forces, m_matter, -YAxis, 9.8) {
+
+            Body::Rigid body(MassProperties(1.0, Vec3(0), UnitInertia(1)));
+
+            m_pin = MobilizedBody::Pin(
+                    m_matter.Ground(), X_PF[Pin],
+                    body, X_BM[Pin]);
+
+            // Branch 1
+            m_ellipsoid = MobilizedBody::Ellipsoid(
+                    m_pin, X_PF[Ellipsoid],
+                    body, X_BM[Ellipsoid],
+                    m_ellipsoidRadii);
+
+            m_cantileverFreeBeam = MobilizedBody::CantileverFreeBeam(
+                    m_ellipsoid, X_PF[CantileverFreeBeam],
+                    body, X_BM[CantileverFreeBeam],
+                    m_cantileverFreeBeamLength);
+
+            // Branch 2
+            m_gimbal = MobilizedBody::Gimbal(
+                    m_pin, X_PF[Gimbal],
+                    body, X_BM[Gimbal]);
+
+            m_weld = MobilizedBody::Weld(
+                    m_gimbal, X_PF[Weld],
+                    body, X_BM[Weld]);
+
+            m_free = MobilizedBody::Free(
+                    m_weld, X_PF[Free],
+                    body, X_BM[Free]);
+        }
+
+        void loadDefaultState(State& state) {
+            for (int i = 0; i < state.getNQ(); ++i) {
+                state.updQ()[i] = 0.1 * (i+1);
+            }
+            for (int i = 0; i < state.getNU(); ++i) {
+                state.updU()[i] = 1.0 * (i+1);
+            }
+        }
+
+        MultibodySystem        m_system;
+        SimbodyMatterSubsystem m_matter;
+        GeneralForceSubsystem  m_forces;
+        Force::Gravity         m_gravity;
+
+        MobilizedBody::Pin                m_pin;
+        MobilizedBody::Ellipsoid          m_ellipsoid;
+        MobilizedBody::CantileverFreeBeam m_cantileverFreeBeam;
+        MobilizedBody::Gimbal             m_gimbal;
+        MobilizedBody::Weld               m_weld;
+        MobilizedBody::Free               m_free;
+
+        const Real m_cantileverFreeBeamLength = 1.23;
+        const Vec3 m_ellipsoidRadii = Vec3(0.1, 0.2, 0.3);
+
+    private:
+        const Array_<Transform> X_PF = {
+            Transform(),                              // [0] Ground
+            Transform(Rotation(BodyRotationSequence,  // [1] Pin
+                            Pi/8, XAxis,
+                            Pi/7, YAxis),
+                    Vec3(-0.4, 0.5, -0.6)),
+            Transform(Rotation(BodyRotationSequence,  // [2] Ellipsoid
+                            Pi/4, ZAxis,
+                            Pi/5, XAxis),
+                    Vec3(0.1, -0.2, 0.3)),
+            Transform(Rotation(BodyRotationSequence,  // [3] CantileverFreeBeam
+                            -Pi/3, XAxis,
+                            Pi/5, ZAxis),
+                    Vec3(0.6, -0.7, 0.8)),
+            Transform(Rotation(BodyRotationSequence,  // [4] Gimbal
+                            Pi/6, YAxis,
+                            -Pi/7, ZAxis),
+                    Vec3(-0.9, 1.0, -1.1)),
+            Transform(Rotation(BodyRotationSequence,  // [5] Weld
+                            Pi/8, ZAxis,
+                            Pi/9, YAxis),
+                    Vec3(1.2, -1.3, 1.4)),
+            Transform(Rotation(BodyRotationSequence,  // [6] Free
+                            -Pi/10, YAxis,
+                            Pi/11, XAxis),
+                    Vec3(-1.5, 1.6, -1.7))};
+        const Array_<Transform> X_BM = {
+            Transform(),                              // [0] Ground
+            Transform(Rotation(BodyRotationSequence,  // [1] Pin
+                            Pi/5, ZAxis,
+                            Pi/6, YAxis),
+                    Vec3(-0.10, 0.11, -0.12)),
+            Transform(Rotation(BodyRotationSequence,  // [2] Ellipsoid
+                            -Pi/4, XAxis,
+                            Pi/3, YAxis),
+                    Vec3(0.7, -0.8, 0.9)),
+            Transform(Rotation(BodyRotationSequence,  // [3] CantileverFreeBeam
+                            -Pi/6, ZAxis,
+                            Pi/4, XAxis),
+                    Vec3(-0.16, 0.17, -0.18)),
+            Transform(Rotation(BodyRotationSequence,  // [4] Gimbal
+                            Pi/5, YAxis,
+                            -Pi/6, ZAxis),
+                    Vec3(0.19, -0.20, 0.21)),
+            Transform(Rotation(BodyRotationSequence,  // [5] Weld
+                            -Pi/7, XAxis,
+                            Pi/8, ZAxis),
+                    Vec3(-0.22, 0.23, -0.24)),
+            Transform(Rotation(BodyRotationSequence,  // [6] Free
+                            Pi/9, ZAxis,
+                            -Pi/10, YAxis),
+                    Vec3(0.25, -0.26, 0.27))};
+    };
+
+}
+
+void testMultiplyByPositionJacobianWrtInboardFramePositions() {
+    BranchedSystem sys;
+    State state = sys.m_system.realizeTopology();
+    sys.loadDefaultState(state);
+    sys.m_system.realize(state, Stage::Position);
+
+    const int nb = sys.m_matter.getNumBodies();
+    const Real h = 1e-5;
+
+    Vector_<Vec3> dp_PF(nb);
+    for (int b = 0; b < nb; ++b) {
+        dp_PF[b] = Vec3(0.5*(b+1), -0.3*(b+1), 0.7*(b+1));
+    }
+
+    Vector_<Vec3> dp_GB;
+    sys.m_matter.multiplyByPositionJacobianWrtInboardFramePositions(
+            state, dp_PF, dp_GB);
+
+    State pert = state;
+    MobilizedBody mobods[6] = { sys.m_pin,
+                                sys.m_ellipsoid,
+                                sys.m_cantileverFreeBeam,
+                                sys.m_gimbal,
+                                sys.m_weld,
+                                sys.m_free };
+    for (int m = 0; m < 6; ++m) {
+        const MobilizedBodyIndex bIdx = mobods[m].getMobilizedBodyIndex();
+        Transform X_PF = mobods[m].getInboardFrame(pert);
+        X_PF.updP() += h * dp_PF[bIdx];
+        mobods[m].setInboardFrame(pert, X_PF);
+    }
+    sys.m_system.realize(pert, Stage::Position);
+
+    for (int ib = 0; ib < nb; ++ib) {
+        const Vec3 p0 = sys.m_matter.getMobilizedBody(MobilizedBodyIndex(ib))
+                                    .getBodyTransform(state).p();
+        const Vec3 p1 = sys.m_matter.getMobilizedBody(MobilizedBodyIndex(ib))
+                                    .getBodyTransform(pert).p();
+        SimTK_TEST_EQ_TOL(dp_GB[ib], (p1 - p0) / h, 1e-10);
+    }
+}
+
+void testMultiplyByPositionJacobianWrtInboardFramePositionsTranspose() {
+    BranchedSystem sys;
+    State state = sys.m_system.realizeTopology();
+    sys.loadDefaultState(state);
+    sys.m_system.realize(state, Stage::Position);
+
+    const int nb = sys.m_matter.getNumBodies();
+
+    Vector_<Vec3> dp_PF(nb), g_GB(nb);
+    for (int b = 0; b < nb; ++b) {
+        dp_PF[b] = Vec3( 0.1*(b+1), -0.2*(b+1),  0.3*(b+1));
+        g_GB[b]  = Vec3(-0.5*(b+1),  0.7*(b+1), -0.9*(b+1));
+    }
+    dp_PF[0] = Vec3(0);
+    g_GB[0]  = Vec3(0);
+
+    Vector_<Vec3> dp_GB, g_PF;
+    sys.m_matter.multiplyByPositionJacobianWrtInboardFramePositions(
+            state, dp_PF, dp_GB);
+    sys.m_matter.multiplyByPositionJacobianWrtInboardFramePositionsTranspose(
+            state, g_GB, g_PF);
+
+    // <JpF*dp_PF, g_GB> = <dp_PF, ~JpF*g_GB>
+    Real lhs = 0, rhs = 0;
+    for (int b = 0; b < nb; ++b) {
+        lhs += dot(g_GB[b],  dp_GB[b]);
+        rhs += dot(dp_PF[b], g_PF[b]);
+    }
+    SimTK_TEST_EQ_TOL(lhs, rhs, 1e-10);
+}
+
+void testMultiplyByPositionJacobianWrtOutboardFramePositions() {
+    BranchedSystem sys;
+    State state = sys.m_system.realizeTopology();
+    sys.loadDefaultState(state);
+    sys.m_system.realize(state, Stage::Position);
+
+    const int nb = sys.m_matter.getNumBodies();
+    const Real h = 1e-5;
+
+    Vector_<Vec3> dp_BM(nb);
+    for (int b = 0; b < nb; ++b) {
+        dp_BM[b] = Vec3(-0.2*(b+1), 0.9*(b+1), -0.4*(b+1));
+    }
+
+    Vector_<Vec3> dp_GB;
+    sys.m_matter.multiplyByPositionJacobianWrtOutboardFramePositions(
+        state, dp_BM, dp_GB);
+
+    State pert = state;
+    MobilizedBody mobods[6] = { sys.m_pin,
+                                sys.m_ellipsoid,
+                                sys.m_cantileverFreeBeam,
+                                sys.m_gimbal,
+                                sys.m_weld,
+                                sys.m_free };
+    for (int m = 0; m < 6; ++m) {
+        const MobilizedBodyIndex bIdx = mobods[m].getMobilizedBodyIndex();
+        Transform X_BM = mobods[m].getOutboardFrame(pert);
+        X_BM.updP() += h * dp_BM[bIdx];
+        mobods[m].setOutboardFrame(pert, X_BM);
+    }
+    sys.m_system.realize(pert, Stage::Position);
+
+    for (int ib = 0; ib < nb; ++ib) {
+        const Vec3 p0 = sys.m_matter.getMobilizedBody(MobilizedBodyIndex(ib))
+                                    .getBodyTransform(state).p();
+        const Vec3 p1 = sys.m_matter.getMobilizedBody(MobilizedBodyIndex(ib))
+                                    .getBodyTransform(pert).p();
+        SimTK_TEST_EQ_TOL(dp_GB[ib], (p1 - p0) / h, 1e-10);
+    }
+}
+
+void testMultiplyByPositionJacobianWrtOutboardFramePositionsTranspose() {
+    BranchedSystem sys;
+    State state = sys.m_system.realizeTopology();
+    sys.loadDefaultState(state);
+    sys.m_system.realize(state, Stage::Position);
+
+    const int nb = sys.m_matter.getNumBodies();
+
+    Vector_<Vec3> dp_BM(nb), g_GB(nb);
+    for (int b = 0; b < nb; ++b) {
+        dp_BM[b] = Vec3( 0.2*(b+1), -0.4*(b+1),  0.6*(b+1));
+        g_GB[b]  = Vec3(-0.3*(b+1),  0.9*(b+1), -0.5*(b+1));
+    }
+    dp_BM[0] = Vec3(0);
+    g_GB[0]  = Vec3(0);
+
+    Vector_<Vec3> dp_GB, g_BM;
+    sys.m_matter.multiplyByPositionJacobianWrtOutboardFramePositions(
+            state, dp_BM, dp_GB);
+    sys.m_matter.multiplyByPositionJacobianWrtOutboardFramePositionsTranspose(
+            state, g_GB, g_BM);
+
+    // <JpM*dp_BM, g_GB> = <dp_BM, ~JpM*g_GB>
+    Real lhs = 0, rhs = 0;
+    for (int b = 0; b < nb; ++b) {
+        lhs += dot(g_GB[b],  dp_GB[b]);
+        rhs += dot(dp_BM[b], g_BM[b]);
+    }
+    SimTK_TEST_EQ_TOL(lhs, rhs, 1e-10);
+}
+
+int main() {
+    SimTK_START_TEST("TestJacobians");
+        SimTK_SUBTEST(testMultiplyByPositionJacobianWrtInboardFramePositions);
+        SimTK_SUBTEST(
+            testMultiplyByPositionJacobianWrtInboardFramePositionsTranspose);
+        SimTK_SUBTEST(testMultiplyByPositionJacobianWrtOutboardFramePositions);
+        SimTK_SUBTEST(
+            testMultiplyByPositionJacobianWrtOutboardFramePositionsTranspose);
+    SimTK_END_TEST();
+}


### PR DESCRIPTION
Part 2 of addressing #856.

This change builds on #859, adding a new set of Jacobian operators to calculate the change in the position of a mobilized body with respect to changes in inboard and outboard mobilizer frames and their transpose. The following operators are added to `SimbodyMatterSubystem()`:

 - `multiplyByPositionJacobianWrtInboardFramePositions()`
 - `multiplyByPositionJacobianWrtInboardFramePositionsTranspose()`
 - `multiplyByPositionJacobianWrtOutboardFramePositions()`
 - `multiplyByPositionJacobianWrtOutboardFramePositionsTranspose()`

The forward operators take a change or perturbation in mobilizer inboard (F) or outboard (M) frames and calculate the resulting change in mobilizer body (B). The transpose operators are arguably more useful, since they allow taking a gradient-like quantity $`g_{GB}  = \partial{f} / \partial{p_{GB}}`$ and map it to something like $`g_{PF}  = \partial{f} / \partial{p_{PF}}`$. If $`f`$, for example, is a function that computes the distance between a measured point and a body origin, then the transpose operator can be used to assemble a gradient with respect to the mobilizer frame position. This is directly useful if you want to optimize the geometry of a system (e.g., the offsets of inboard/outboard frames) while tracking experimental data.

The underlying math is relatively simple: a shift in an inboard or outboard frame will shift all mobilizer positions down the kinematic chain, and the rotations `R_GB` and `R_GP` re-express the position shifts in ground. The transpose operators accumulate shifts for all children up to the current node, similar to other transpose operators.

The implementation follows a similar pattern to the other Jacobian operators: accessors and argument checking in `SimbodyMatterSubsystem`, an internal representation in `SimbodyMatterSubsystemRep` for creating intermediate data structures (e.g., for handling transpose accumulations), and a per-node implementation in `RigidBodyNode`. Since ground always contributes zero motion and all mobilizers handle inboard and outboard frames the same way, the current implementation is written directly in `RigidBodyNode` with no virtual dispatches.

For testing, I've added `TestJacobians.cpp` that covers all the new operators using a branch multibody system containing a variety of different mobilizers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/simbody/simbody/866)
<!-- Reviewable:end -->
